### PR TITLE
Change screen key to $screen_name to match ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0 - 2020-07-08
+
+- Use `$screen_name` instead of `$screen` as key for what screen you are on when sending a .screen event
+
 ## 1.0.2 - 2020-05-20
 
 - Use `.defaultOptions(new Options().putContext("$lib", "custom-lib"))` to pass a default context

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.posthog.android
 
 VERSION_CODE=3
-VERSION_NAME=1.0.3-SNAPSHOT
+VERSION_NAME=1.1.0-SNAPSHOT
 
 POM_NAME=PostHog for Android
 POM_DESCRIPTION=The hassle-free way to add posthog to your Android app.

--- a/posthog/src/main/java/com/posthog/android/payloads/ScreenPayload.java
+++ b/posthog/src/main/java/com/posthog/android/payloads/ScreenPayload.java
@@ -49,7 +49,7 @@ public class ScreenPayload extends BasePayload {
       @Nullable String distinctId,
       @Nullable String name) {
 
-    super(Type.screen, "$screen", messageId, timestamp, properties, distinctId);
+    super(Type.screen, "$screen_name", messageId, timestamp, properties, distinctId);
 
     if (!isNullOrEmpty(name)) {
       properties.put(NAME_KEY, name);

--- a/posthog/src/test/java/com/posthog/android/payloads/ScreenPayloadTest.java
+++ b/posthog/src/test/java/com/posthog/android/payloads/ScreenPayloadTest.java
@@ -73,7 +73,7 @@ public class ScreenPayloadTest {
   @Test
   public void properties() {
     ScreenPayload payload = builder.name("name").properties(ImmutableMap.of("foo", "bar")).build();
-    assertThat(payload.properties()).isEqualTo(ImmutableMap.of("foo", "bar", "$screen", "name"));
+    assertThat(payload.properties()).isEqualTo(ImmutableMap.of("foo", "bar", "$screen_name", "name"));
   }
 
   @Test


### PR DESCRIPTION
In iOS we push `$screen_name` key with the screen that the event occurred on. Let's change this to match that for consistent reporting in Posthog.