### PR TITLE
Add distinct id cache getter

### DIFF
--- a/posthog/src/main/java/com/posthog/android/PostHog.java
+++ b/posthog/src/main/java/com/posthog/android/PostHog.java
@@ -850,6 +850,11 @@ public class PostHog {
     return properties.anonymousId();
   }
 
+  public String getDistinctId() {
+    Properties properties = propertiesCache.get();
+    return properties.distinctId();
+  }
+
   /** Creates a {@link StatsSnapshot} of the current stats for this instance. */
   public StatsSnapshot getSnapshot() {
     return stats.createSnapshot();

--- a/posthog/src/main/java/com/posthog/android/PostHogActivityLifecycleCallbacks.java
+++ b/posthog/src/main/java/com/posthog/android/PostHogActivityLifecycleCallbacks.java
@@ -82,7 +82,7 @@ class PostHogActivityLifecycleCallbacks implements Application.ActivityLifecycle
       }
 
       Intent intent = activity.getIntent();
-      if (intent == null || intent.getData() == null) {
+      if (intent == null || intent.getData() == null || !intent.getData().isHierarchical()) {
         return;
       }
 


### PR DESCRIPTION
Sometimes you need to have getter for this field.
We want to identify user only once, to not overload our remote DB, so would be nice to know it is already set in cache.