### PR TITLE
Make sure defaultOptions are configured on capture calls

### DIFF
--- a/posthog/src/main/java/com/posthog/android/PostHog.java
+++ b/posthog/src/main/java/com/posthog/android/PostHog.java
@@ -399,7 +399,7 @@ public class PostHog {
               finalOptions = options;
             }
 
-            final Properties finalUserProperties = this.prepareEventProperties(userProperties, finalOptions)
+            final Properties finalUserProperties = prepareEventProperties(userProperties, finalOptions);
 
             IdentifyPayload.Builder builder =
                 new IdentifyPayload.Builder().userProperties(finalUserProperties);
@@ -455,46 +455,13 @@ public class PostHog {
               finalOptions = options;
             }
 
-            final Properties finalProperties = this.prepareEventProperties(properties, finalOptions)
+            final Properties finalProperties = prepareEventProperties(properties, finalOptions);
 
             CapturePayload.Builder builder =
                 new CapturePayload.Builder().event(event).properties(finalProperties);
             fillAndEnqueue(builder, finalOptions);
           }
         });
-  }
-
-  private Properties prepareEventProperties(final @Nullable Properties properties, final @NonNull Options options) {
-    final Properties finalProperties;
-    if (properties == null) {
-      finalProperties = EMPTY_PROPERTIES;
-    } else {
-      finalProperties = properties;
-    }
-
-    // Send feature flags with capture call
-    boolean shouldSendFeatureFlags = false;
-    if (
-      !options.context().isEmpty() &&
-      options.context().get(SEND_FEATURE_FLAGS_KEY) instanceof Boolean &&
-      (Boolean) options.context().get(SEND_FEATURE_FLAGS_KEY)
-    ) {
-      shouldSendFeatureFlags = true;
-    }
-    if (shouldSendFeatureFlags) {
-      ValueMap flags = featureFlags.getFlagVariants();
-      List<String> activeFlags = featureFlags.getFlags();
-
-      // Add all feature variants to event
-      for (Map.Entry<String, Object> entry : flags.entrySet()) {
-        finalProperties.putFeatureFlag(entry.getKey(), entry.getValue());
-      }
-
-      // Add all feature flag keys to $active_feature_flags key
-      finalProperties.putActiveFeatureFlags(activeFlags);
-    }
-
-    return finalProperties
   }
 
   /** @see #screen(String, Properties, Options) */
@@ -535,7 +502,7 @@ public class PostHog {
               finalOptions = options;
             }
 
-            final Properties finalProperties = this.prepareEventProperties(properties, finalOptions)
+            final Properties finalProperties = prepareEventProperties(properties, finalOptions);
 
             //noinspection deprecation
             ScreenPayload.Builder builder =
@@ -643,7 +610,7 @@ public class PostHog {
               finalOptions = options;
             }
 
-            final Properties finalGroupProperties = this.prepareEventProperties(groupProperties, finalOptions)
+            final Properties finalGroupProperties = prepareEventProperties(groupProperties, finalOptions);
 
             GroupPayload.Builder builder =
                 new GroupPayload.Builder().groupType(groupType).groupKey(groupKey).groupProperties(finalGroupProperties);
@@ -742,6 +709,39 @@ public class PostHog {
    */
   public void reloadFeatureFlags() {
     this.featureFlags.reloadFeatureFlags();
+  }
+
+  private Properties prepareEventProperties(final @Nullable Properties properties, final @NonNull Options options) {
+    final Properties finalProperties;
+    if (properties == null) {
+      finalProperties = EMPTY_PROPERTIES;
+    } else {
+      finalProperties = properties;
+    }
+
+    // Send feature flags with capture call
+    boolean shouldSendFeatureFlags = false;
+    if (
+            !options.context().isEmpty() &&
+                    options.context().get(SEND_FEATURE_FLAGS_KEY) instanceof Boolean &&
+                    (Boolean) options.context().get(SEND_FEATURE_FLAGS_KEY)
+    ) {
+      shouldSendFeatureFlags = true;
+    }
+    if (shouldSendFeatureFlags) {
+      ValueMap flags = featureFlags.getFlagVariants();
+      List<String> activeFlags = featureFlags.getFlags();
+
+      // Add all feature variants to event
+      for (Map.Entry<String, Object> entry : flags.entrySet()) {
+        finalProperties.putFeatureFlag(entry.getKey(), entry.getValue());
+      }
+
+      // Add all feature flag keys to $active_feature_flags key
+      finalProperties.putActiveFeatureFlags(activeFlags);
+    }
+
+    return finalProperties;
   }
 
   private void waitForAdvertisingId() {

--- a/posthog/src/main/java/com/posthog/android/PostHog.java
+++ b/posthog/src/main/java/com/posthog/android/PostHog.java
@@ -467,15 +467,14 @@ public class PostHog {
               finalProperties = properties;
             }
 
-            // Send feature flags with capture call
-            boolean shouldSendFeatureFlags = false;
+            // Send feature flags with capture call by default
+            boolean shouldSendFeatureFlags = true;
             if (
-                    options != null &&
-                            !options.context().isEmpty() &&
-                            options.context().get(SEND_FEATURE_FLAGS_KEY) instanceof Boolean &&
-                            (Boolean) options.context().get(SEND_FEATURE_FLAGS_KEY)
+                    finalOptions != null &&
+                            !finalOptions.context().isEmpty() &&
+                            finalOptions.context().get(SEND_FEATURE_FLAGS_KEY) instanceof Boolean
             ) {
-              shouldSendFeatureFlags = true;
+              shouldSendFeatureFlags = (Boolean) finalOptions.context().get(SEND_FEATURE_FLAGS_KEY);
             }
             if (shouldSendFeatureFlags) {
               ValueMap flags = featureFlags.getFlagVariants();

--- a/posthog/src/main/java/com/posthog/android/PostHog.java
+++ b/posthog/src/main/java/com/posthog/android/PostHog.java
@@ -720,13 +720,13 @@ public class PostHog {
     }
 
     // Send feature flags with capture call
-    boolean shouldSendFeatureFlags = false;
+    boolean shouldSendFeatureFlags = true;
     if (
             !options.context().isEmpty() &&
                     options.context().get(SEND_FEATURE_FLAGS_KEY) instanceof Boolean &&
                     (Boolean) options.context().get(SEND_FEATURE_FLAGS_KEY)
     ) {
-      shouldSendFeatureFlags = true;
+      shouldSendFeatureFlags = (Boolean) options.context().get(SEND_FEATURE_FLAGS_KEY);
     }
     if (shouldSendFeatureFlags) {
       ValueMap flags = featureFlags.getFlagVariants();

--- a/posthog/src/test/java/com/posthog/android/PostHogTest.java
+++ b/posthog/src/test/java/com/posthog/android/PostHogTest.java
@@ -277,6 +277,32 @@ public class PostHogTest {
   }
 
   @Test
+  public void captureWithSendFeatureFlagsByDefault() {
+    posthog.capture("capture with flags", new Properties().putValue("url", "github.com"));
+    verify(integration)
+            .capture(
+                    argThat(
+                            new NoDescriptionMatcher<CapturePayload>() {
+                              @Override
+                              protected boolean matchesSafely(CapturePayload payload) {
+                                return payload.event().equals("capture with flags")
+                                        && //
+                                        payload.properties().get("url").equals("github.com")
+                                        &&
+                                        payload.properties().get("$lib").equals("posthog-android-custom-lib")
+                                        &&
+                                        payload.properties().get("$feature/enabled-flag").equals(true)
+                                        &&
+                                        payload.properties().get("$feature/multivariate-flag").equals("blah")
+                                        &&
+                                        payload.properties().get("$active_feature_flags").equals(Arrays.asList("enabled-flag", "multivariate-flag"));
+                              }
+                            }));
+  }
+
+
+
+  @Test
   public void invalidScreen() throws Exception {
     try {
       posthog.screen(null);


### PR DESCRIPTION
- Capture calls were incorrectly handling defaultOptions object
- This PR ensures that sending feature flag option will be handled correctly