### PR TITLE
Fix feature flags tests with missing distinct ID

### DIFF
--- a/posthog/src/main/java/com/posthog/android/PostHogFeatureFlags.java
+++ b/posthog/src/main/java/com/posthog/android/PostHogFeatureFlags.java
@@ -152,14 +152,15 @@ public class PostHogFeatureFlags {
             connection = client.decide();
             HttpURLConnection con = connection.connection;
 
-            if (properties.distinctId() == null) {
-                throw new IllegalArgumentException("Calling decide endpoint requires user to be identified before.");
-            }
 
             // Construct payload
             JSONObject payload = new JSONObject();
             payload.put("token", this.posthog.apiKey);
             payload.put("distinct_id", properties.distinctId());
+            if (properties.distinctId() == null) {
+                // Use anon id if distinct id doesn't exist since decide requires a distinct id
+                payload.put("distinct_id", properties.anonymousId());
+            }
             payload.put("groups", properties.groups());
             payload.put("$anon_distinct_id", properties.anonymousId());
             String stringifiedPayload = payload.toString();

--- a/posthog/src/test/java/com/posthog/android/PostHogFeatureFlagsTest.java
+++ b/posthog/src/test/java/com/posthog/android/PostHogFeatureFlagsTest.java
@@ -61,7 +61,6 @@ public class PostHogFeatureFlagsTest {
                 .executor(posthogExecutor)
                 .build();
         // Wait for flags to reload on initializing PostHog
-        posthog.identify("distinct_id");
         Thread.sleep(1000);
     }
 

--- a/posthog/src/test/java/com/posthog/android/PostHogFeatureFlagsTest.java
+++ b/posthog/src/test/java/com/posthog/android/PostHogFeatureFlagsTest.java
@@ -60,8 +60,8 @@ public class PostHogFeatureFlagsTest {
                 .integration(integration)
                 .executor(posthogExecutor)
                 .build();
-
         // Wait for flags to reload on initializing PostHog
+        posthog.identify("distinct_id");
         Thread.sleep(1000);
     }
 


### PR DESCRIPTION
Feature flag tests were failing because there was no distinct ID being set