### PR TITLE
ci: run tests on master as well

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,9 @@ name: Android CI
 
 on:
   - pull_request
+  - push:
+      branches:
+        - master
 
 jobs:
   tests:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,7 +1,7 @@
 name: Android CI
 
 on:
-  - pull_request
+  - pull_request:
   - push:
       branches:
         - master

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,10 +1,10 @@
 name: Android CI
 
 on:
-  - pull_request:
-  - push:
-      branches:
-        - master
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   tests:
@@ -17,8 +17,8 @@ jobs:
       - name: Setup JDK 1.8
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: "8"
+          distribution: "adopt"
 
       - name: Grant Permissions to gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
Previously we were only running on pull requests, but this means that we
don't get test results for the master branch. This is a problem because
we want to know if the master branch is broken before we perform a
release of the App. We could enforce that all PRs must be up to date
with master, but this is a bit of a pain and doesn't really solve the
problem of knowing for sure that master is broken.