### PR TITLE
Fix `device_type` typo

### DIFF
--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -41,7 +41,7 @@ internal class PostHogAndroidContext(
         staticContext["\$device_model"] = Build.MODEL
         staticContext["\$device_name"] = Build.DEVICE
         // Check https://github.com/PostHog/posthog-flutter/issues/49 and change if needed
-        staticContext["\$device_type"] = "mobile"
+        staticContext["\$device_type"] = "Mobile"
         staticContext["\$os_name"] = "Android"
         staticContext["\$os_version"] = Build.VERSION.RELEASE
 

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
@@ -60,7 +60,7 @@ internal class PostHogAndroidContextTest {
         assertNotNull(staticContext["\$device_manufacturer"])
         assertNotNull(staticContext["\$device_model"])
         assertNotNull(staticContext["\$device_name"])
-        assertEquals("mobile", staticContext["\$device_type"])
+        assertEquals("Mobile", staticContext["\$device_type"])
 
         assertEquals("Android", staticContext["\$os_name"])
         // its dynamic


### PR DESCRIPTION
## :bulb: Motivation and Context
Just a typo
https://github.com/PostHog/posthog/blob/94405b0532013045c3ea9a39e6234b8152eca2d2/frontend/src/lib/taxonomy.tsx#L220

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
