### PR TITLE
Add compatibility to Java 8 bytecode (previously Java 11+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Does not report screen events if there's no title ([#32](https://github.com/PostHog/posthog-android/pull/32))
 - Add `distinctId()` getter to the Public API ([#33](https://github.com/PostHog/posthog-android/pull/33))
+- Add compatibility to Java 8 bytecode (previously Java 11+) ([#34](https://github.com/PostHog/posthog-android/pull/34))
 
 ## 3.0.0-alpha.4 - 2023-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Does not report screen events if there's no title ([#32](https://github.com/PostHog/posthog-android/pull/32))
 - Add `distinctId()` getter to the Public API ([#33](https://github.com/PostHog/posthog-android/pull/33))
-- Add compatibility to Java 8 bytecode (previously Java 11+) ([#34](https://github.com/PostHog/posthog-android/pull/34))
+- Add compatibility to Java 8 bytecode (previously Java 11+) ([#37](https://github.com/PostHog/posthog-android/pull/37))
 
 ## 3.0.0-alpha.4 - 2023-10-03
 

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -6,8 +6,7 @@ object PosthogBuildConfig {
     }
 
     object Build {
-        // should it be 1.8 still?
-        val JAVA_VERSION = JavaVersion.VERSION_11
+        val JAVA_VERSION = JavaVersion.VERSION_1_8
     }
 
     object Android {
@@ -44,8 +43,8 @@ object PosthogBuildConfig {
         val ANDROIDX_JUNIT = "1.1.5"
         val ANDROIDX_RUNNER = "1.5.2"
         val ANDROIDX_CORE = "1.5.0"
-        val MOCKITO = "5.1.0"
-        val MOCKITO_INLINE = "5.2.0"
+        val MOCKITO = "4.1.0" // mockito 5x requires Java 11 bytecode
+        val MOCKITO_INLINE = "4.11.0" // mockito-inline 5x requires Java 11 bytecode
         val ROBOLECTRIC = "4.10.3"
     }
 }

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -58,6 +58,8 @@ android {
 
         // lint runs only for debug build
         checkReleaseBuilds = false
+
+        baseline = File("lint-baseline.xml")
     }
 
     androidComponents.beforeVariants {

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.1" type="baseline" client="gradle" dependencies="true" name="AGP (8.1.1)" variant="all" version="8.1.1">
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.mockito.kotlin:mockito-kotlin than 4.1.0 is available: 5.1.0"
+        errorLine1="    testImplementation(&quot;org.mockito.kotlin:mockito-kotlin:${PosthogBuildConfig.Dependencies.MOCKITO}&quot;)"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="86"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.mockito:mockito-inline than 4.11.0 is available: 5.2.0"
+        errorLine1="    testImplementation(&quot;org.mockito:mockito-inline:${PosthogBuildConfig.Dependencies.MOCKITO_INLINE}&quot;)"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="87"
+            column="24"/>
+    </issue>
+
+</issues>


### PR DESCRIPTION
## :bulb: Motivation and Context
Apps using Java 8 won't be able to use the SDK
AGP 7.x already requires Java 11 but not everyone is able to migrate older projects.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
