### PR TITLE
isFeatureEnabled now returns true if multivariant flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- isFeatureEnabled now returns true if multivariant flag ([#38](https://github.com/PostHog/posthog-android/pull/38))
+- isFeatureEnabled now returns true if multivariant flag ([#42](https://github.com/PostHog/posthog-android/pull/42))
 
 ## 3.0.0-alpha.6 - 2023-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- isFeatureEnabled now returns true if multivariant flag ([#38](https://github.com/PostHog/posthog-android/pull/38))
+
 ## 3.0.0-alpha.6 - 2023-10-06
 
 - Upsert flags when loading feature flags with computed errors ([#38](https://github.com/PostHog/posthog-android/pull/38))

--- a/posthog/build.gradle.kts
+++ b/posthog/build.gradle.kts
@@ -25,7 +25,7 @@ configure<JavaPluginExtension> {
 
 buildConfig {
     useKotlinOutput()
-    packageName("com.posthog.internal")
+    packageName("com.posthog")
     buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
 }
 

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -1,6 +1,5 @@
 package com.posthog
 
-import com.posthog.internal.BuildConfig
 import com.posthog.internal.PostHogContext
 import com.posthog.internal.PostHogLogger
 import com.posthog.internal.PostHogNetworkStatus

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -51,8 +51,10 @@ internal class PostHogFeatureFlags(
                     synchronized(featureFlagsLock) {
                         if (response.errorsWhileComputingFlags) {
                             // if not all flags were computed, we upsert flags instead of replacing them
-                            this.featureFlags = (this.featureFlags ?: mapOf()) + (response.featureFlags ?: mapOf())
-                            this.featureFlagPayloads = (this.featureFlagPayloads ?: mapOf()) + (response.featureFlagPayloads ?: mapOf())
+                            this.featureFlags =
+                                (this.featureFlags ?: mapOf()) + (response.featureFlags ?: mapOf())
+                            this.featureFlagPayloads = (this.featureFlagPayloads
+                                ?: mapOf()) + (response.featureFlagPayloads ?: mapOf())
                         } else {
                             this.featureFlags = response.featureFlags
                             this.featureFlagPayloads = response.featureFlagPayloads
@@ -87,8 +89,13 @@ internal class PostHogFeatureFlags(
             value = featureFlags?.get(key)
         }
 
-        return if (value is Boolean) {
-            value
+        return if (value != null) {
+            if (value is Boolean) {
+                value
+            } else {
+                // if its multivariant flag, its enabled by default
+                true
+            }
         } else {
             defaultValue
         }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -53,8 +53,10 @@ internal class PostHogFeatureFlags(
                             // if not all flags were computed, we upsert flags instead of replacing them
                             this.featureFlags =
                                 (this.featureFlags ?: mapOf()) + (response.featureFlags ?: mapOf())
-                            this.featureFlagPayloads = (this.featureFlagPayloads
-                                ?: mapOf()) + (response.featureFlagPayloads ?: mapOf())
+                            this.featureFlagPayloads = (
+                                this.featureFlagPayloads
+                                    ?: mapOf()
+                                ) + (response.featureFlagPayloads ?: mapOf())
                         } else {
                             this.featureFlags = response.featureFlags
                             this.featureFlagPayloads = response.featureFlagPayloads

--- a/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
@@ -1,6 +1,5 @@
 package com.posthog
 
-import com.posthog.internal.BuildConfig
 import com.posthog.internal.PostHogPrintLogger
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.BuildConfig
 import com.posthog.PostHogConfig
 import com.posthog.apiKey
 import com.posthog.generateEvent


### PR DESCRIPTION
## :bulb: Motivation and Context
By doing https://github.com/PostHog/posthog-android/pull/41 I noticed that `isFeatureEnabled` is also wrong.

I also noticed that the iOS SDK never returns `false` if a flag has a `false` value.
https://github.com/PostHog/posthog-ios/blob/9298825fe26899a58b976d400254e0b050daa578/PostHog/Classes/PHGPostHog.m#L317
Is it a bug on the iOS SDK I believe, right?


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
