### PR TITLE
Groups are cached in the disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - SDK only sends the `$feature_flag_called` event once per flag ([#47](https://github.com/PostHog/posthog-android/pull/47))
+- Groups are cached in the disk ([#48](https://github.com/PostHog/posthog-android/pull/48))
 
 ## 3.0.0-alpha.7 - 2023-10-10
 

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAppInstallIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAppInstallIntegration.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.posthog.PostHog
 import com.posthog.PostHogIntegration
 import com.posthog.android.PostHogAndroidConfig
+import com.posthog.internal.PostHogPreferences.Companion.BUILD
+import com.posthog.internal.PostHogPreferences.Companion.VERSION
 
 /**
  * Captures app installed and updated events
@@ -20,8 +22,8 @@ internal class PostHogAppInstallIntegration(
                 val versionName = packageInfo.versionName
                 val versionCode = packageInfo.versionCodeCompat()
 
-                val previousVersion = preferences.getValue("version") as? String
-                var previousBuild = preferences.getValue("build")
+                val previousVersion = preferences.getValue(VERSION) as? String
+                var previousBuild = preferences.getValue(BUILD)
 
                 val event: String
                 val props = mutableMapOf<String, Any>()
@@ -47,8 +49,8 @@ internal class PostHogAppInstallIntegration(
                 props["version"] = versionName
                 props["build"] = versionCode
 
-                preferences.setValue("version", versionName)
-                preferences.setValue("build", versionCode)
+                preferences.setValue(VERSION, versionName)
+                preferences.setValue(BUILD, versionCode)
 
                 PostHog.capture(event, properties = props)
             }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -73,7 +73,7 @@ internal class PostHogSharedPreferences(
                     (value.toSet() as? Set<String>)?.let {
                         edit.putStringSet(key, it)
                     } ?: run {
-                        stringifyObject(key, value, edit)
+                        serializeObject(key, value, edit)
                     }
                 }
                 is Array<*> -> {
@@ -81,10 +81,10 @@ internal class PostHogSharedPreferences(
                     (value.toSet() as? Set<String>)?.let {
                         edit.putStringSet(key, it)
                     } ?: run {
-                        stringifyObject(key, value, edit)
+                        serializeObject(key, value, edit)
                     }
                 } else -> {
-                    stringifyObject(key, value, edit)
+                    serializeObject(key, value, edit)
                 }
             }
 
@@ -108,7 +108,7 @@ internal class PostHogSharedPreferences(
         }
     }
 
-    private fun stringifyObject(key: String, value: Any, editor: SharedPreferences.Editor) {
+    private fun serializeObject(key: String, value: Any, editor: SharedPreferences.Editor) {
         try {
             config.serializer.serializeObject(value)?.let {
                 editor.putString(key, it)

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -121,7 +121,8 @@ internal class PostHogSharedPreferences(
     private fun deserializeObject(value: String): Any {
         try {
             config.serializer.deserializeString(value)?.let {
-                // only return the deserialized object if it's not null otherwise fallback to the original value
+                // only return the deserialized object if it's not null otherwise fallback
+                // to the original (and stringified) value
                 return it
             }
         } catch (ignored: Throwable) { }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -94,12 +94,12 @@ internal class PostHogSharedPreferencesTests {
     }
 
     @Test
-    fun `preferences does not set a non valid type`() {
+    fun `preferences stringify a non valid type`() {
         val sut = getSut()
 
         sut.setValue("key", Any())
 
-        assertNull(sut.getValue("key"))
+        assertEquals("{}", sut.getValue("key"))
     }
 
     @Test

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.posthog.android.FakeSharedPreferences
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.apiKey
+import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import kotlin.test.Test
@@ -100,6 +101,27 @@ internal class PostHogSharedPreferencesTests {
         sut.setValue("key", Any())
 
         assertEquals("{}", sut.getValue("key"))
+    }
+
+    @Test
+    fun `preferences deserialize groups`() {
+        val sut = getSut()
+
+        val props = mapOf("key" to "value")
+        sut.setValue(GROUPS, props)
+
+        assertEquals(props, sut.getValue(GROUPS))
+    }
+
+    @Test
+    fun `preferences fallback to stringified version if not special key`() {
+        val sut = getSut()
+
+        val props = mapOf("key" to "value")
+        sut.setValue("key", props)
+
+        val json = """{"key":"value"}"""
+        assertEquals(json, sut.getValue("key"))
     }
 
     @Test

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MainActivity.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MainActivity.kt
@@ -38,9 +38,6 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
         text = AnnotatedString("Hello $name!"),
         modifier = modifier,
         onClick = {
-            val props = mutableMapOf<String, Any>()
-            props["test_key"] = "test_value"
-            PostHog.group("theType", "theKey", groupProperties = props)
 //            PostHog.optOut()
 //            PostHog.optIn()
 //            PostHog.identify("my_distinct_id", properties = mapOf("my_property" to 1), userProperties = mapOf("name" to "hello"))

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MainActivity.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MainActivity.kt
@@ -38,6 +38,9 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
         text = AnnotatedString("Hello $name!"),
         modifier = modifier,
         onClick = {
+            val props = mutableMapOf<String, Any>()
+            props["test_key"] = "test_value"
+            PostHog.group("theType", "theKey", groupProperties = props)
 //            PostHog.optOut()
 //            PostHog.optIn()
 //            PostHog.identify("my_distinct_id", properties = mapOf("my_property" to 1), userProperties = mapOf("name" to "hello"))

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -73,6 +73,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getSdkName ()Ljava/lang/String;
 	public final fun getSdkVersion ()Ljava/lang/String;
 	public final fun getSendFeatureFlagEvent ()Z
+	public final fun getSerializer ()Lcom/posthog/internal/PostHogSerializer;
 	public final fun getStoragePrefix ()Ljava/lang/String;
 	public final fun removeIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun setCachePreferences (Lcom/posthog/internal/PostHogPreferences;)V
@@ -92,6 +93,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setSdkName (Ljava/lang/String;)V
 	public final fun setSdkVersion (Ljava/lang/String;)V
 	public final fun setSendFeatureFlagEvent (Z)V
+	public final fun setSerializer (Lcom/posthog/internal/PostHogSerializer;)V
 	public final fun setStoragePrefix (Ljava/lang/String;)V
 }
 
@@ -206,11 +208,21 @@ public abstract interface class com/posthog/internal/PostHogNetworkStatus {
 }
 
 public abstract interface class com/posthog/internal/PostHogPreferences {
+	public static final field BUILD Ljava/lang/String;
+	public static final field Companion Lcom/posthog/internal/PostHogPreferences$Companion;
+	public static final field GROUPS Ljava/lang/String;
+	public static final field VERSION Ljava/lang/String;
 	public abstract fun clear (Ljava/util/List;)V
 	public abstract fun getAll ()Ljava/util/Map;
 	public abstract fun getValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun remove (Ljava/lang/String;)V
 	public abstract fun setValue (Ljava/lang/String;Ljava/lang/Object;)V
+}
+
+public final class com/posthog/internal/PostHogPreferences$Companion {
+	public static final field BUILD Ljava/lang/String;
+	public static final field GROUPS Ljava/lang/String;
+	public static final field VERSION Ljava/lang/String;
 }
 
 public final class com/posthog/internal/PostHogPreferences$DefaultImpls {
@@ -222,5 +234,12 @@ public final class com/posthog/internal/PostHogPrintLogger : com/posthog/interna
 	public fun <init> (Lcom/posthog/PostHogConfig;)V
 	public fun isEnabled ()Z
 	public fun log (Ljava/lang/String;)V
+}
+
+public final class com/posthog/internal/PostHogSerializer {
+	public fun <init> (Lcom/posthog/PostHogConfig;)V
+	public final fun deserializeString (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun getGson ()Lcom/google/gson/Gson;
+	public final fun serializeObject (Ljava/lang/Object;)Ljava/lang/String;
 }
 

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -93,7 +93,6 @@ public class com/posthog/PostHogConfig {
 	public final fun setSdkName (Ljava/lang/String;)V
 	public final fun setSdkVersion (Ljava/lang/String;)V
 	public final fun setSendFeatureFlagEvent (Z)V
-	public final fun setSerializer (Lcom/posthog/internal/PostHogSerializer;)V
 	public final fun setStoragePrefix (Ljava/lang/String;)V
 }
 

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -5,6 +5,7 @@ import com.posthog.internal.PostHogLogger
 import com.posthog.internal.PostHogNetworkStatus
 import com.posthog.internal.PostHogPreferences
 import com.posthog.internal.PostHogPrintLogger
+import com.posthog.internal.PostHogSerializer
 
 /**
  * The SDK Config
@@ -92,6 +93,9 @@ public open class PostHogConfig(
     // fix me: https://stackoverflow.com/questions/53866865/leaking-this-in-constructor-warning-should-apply-to-final-classes-as-well-as
     @PostHogInternal
     public var logger: PostHogLogger = PostHogPrintLogger(this)
+
+    @PostHogInternal
+    public var serializer: PostHogSerializer = PostHogSerializer(this)
 
     @PostHogInternal
     public var context: PostHogContext? = null

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -95,7 +95,9 @@ public open class PostHogConfig(
     public var logger: PostHogLogger = PostHogPrintLogger(this)
 
     @PostHogInternal
-    public var serializer: PostHogSerializer = PostHogSerializer(this)
+    public val serializer: PostHogSerializer by lazy {
+        PostHogSerializer(this)
+    }
 
     @PostHogInternal
     public var context: PostHogContext? = null

--- a/posthog/src/main/java/com/posthog/PostHogInternal.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInternal.kt
@@ -14,5 +14,6 @@ package com.posthog
     AnnotationTarget.CONSTRUCTOR,
     AnnotationTarget.FIELD,
     AnnotationTarget.FILE,
+    AnnotationTarget.PROPERTY,
 )
 public annotation class PostHogInternal

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -13,7 +13,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 internal class PostHogFeatureFlags(
     private val config: PostHogConfig,
-    private val serializer: PostHogSerializer,
     private val api: PostHogApi,
     private val executor: ExecutorService,
 ) {
@@ -94,7 +93,7 @@ internal class PostHogFeatureFlags(
                 // only try to parse if its a String, since the JSON values are stringified
                 if (value is String) {
                     // try to deserialize as Any?
-                    serializer.deserializeString(value)?.let {
+                    config.serializer.deserializeString(value)?.let {
                         parsedPayloads[item.key] = it
                     }
                 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -19,7 +19,7 @@ public interface PostHogPreferences {
     public fun getAll(): Map<String, Any>
 
     public companion object {
-        public const val GROUPS: String = "\$groups"
+        public const val GROUPS: String = "groups"
         internal const val ANONYMOUS_ID = "anonymousId"
         internal const val DISTINCT_ID = "distinctId"
         internal const val OPT_OUT = "opt-out"

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -17,4 +17,13 @@ public interface PostHogPreferences {
     public fun remove(key: String)
 
     public fun getAll(): Map<String, Any>
+
+    public companion object {
+        public const val GROUPS: String = "\$groups"
+        internal const val ANONYMOUS_ID = "anonymousId"
+        internal const val DISTINCT_ID = "distinctId"
+        internal const val OPT_OUT = "opt-out"
+        public const val VERSION: String = "version"
+        public const val BUILD: String = "build"
+    }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -18,14 +18,12 @@ import kotlin.math.min
  * The class that manages the events Queue
  * @property config the Config
  * @property api the API
- * @property serializer the Serializer
  * @property dateProvider the Date provider
  * @property executor the Executor
  */
 internal class PostHogQueue(
     private val config: PostHogConfig,
     private val api: PostHogApi,
-    private val serializer: PostHogSerializer,
     private val dateProvider: PostHogDateProvider,
     private val executor: ExecutorService,
 ) {
@@ -83,7 +81,7 @@ internal class PostHogQueue(
 
                 try {
                     val os = config.encryption?.encrypt(file.outputStream()) ?: file.outputStream()
-                    serializer.serialize(event, os.writer().buffered())
+                    config.serializer.serialize(event, os.writer().buffered())
                     config.logger.log("Queued event ${file.name}.")
 
                     flushIfOverThreshold(true)
@@ -167,7 +165,7 @@ internal class PostHogQueue(
             try {
                 val inputStream = config.encryption?.decrypt(file.inputStream()) ?: file.inputStream()
 
-                val event = serializer.deserialize<PostHogEvent?>(inputStream.reader().buffered())
+                val event = config.serializer.deserialize<PostHogEvent?>(inputStream.reader().buffered())
                 event?.let {
                     events.add(it)
                 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogSendCachedEventsIntegration.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogSendCachedEventsIntegration.kt
@@ -13,14 +13,12 @@ import java.util.concurrent.ExecutorService
  * The integration that send all the cached events, triggered once the SDK is setup
  * @property config the Config
  * @property api the API class
- * @property serializer the Serializer
  * @property startDate the startDate cut off so we don't race with the Queue
  * @property executor the Executor
  */
 internal class PostHogSendCachedEventsIntegration(
     private val config: PostHogConfig,
     private val api: PostHogApi,
-    private val serializer: PostHogSerializer,
     private val startDate: Date,
     private val executor: ExecutorService,
 ) : PostHogIntegration {
@@ -62,7 +60,7 @@ internal class PostHogSendCachedEventsIntegration(
 
                         try {
                             val inputStream = config.encryption?.decrypt(eventBytes.inputStream()) ?: eventBytes.inputStream()
-                            val event = serializer.deserialize<PostHogEvent?>(inputStream.reader().buffered())
+                            val event = config.serializer.deserialize<PostHogEvent?>(inputStream.reader().buffered())
                             event?.let {
                                 events.add(event)
                                 eventsCount++
@@ -151,7 +149,7 @@ internal class PostHogSendCachedEventsIntegration(
                         try {
                             val inputStream =
                                 config.encryption?.decrypt(file.inputStream()) ?: file.inputStream()
-                            val event = serializer.deserialize<PostHogEvent?>(inputStream.reader().buffered())
+                            val event = config.serializer.deserialize<PostHogEvent?>(inputStream.reader().buffered())
                             event?.let {
                                 events.add(event)
                                 eventsCount++

--- a/posthog/src/main/java/com/posthog/internal/PostHogSerializer.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogSerializer.kt
@@ -1,10 +1,12 @@
 package com.posthog.internal
 
+import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonIOException
 import com.google.gson.JsonSyntaxException
 import com.google.gson.reflect.TypeToken
 import com.posthog.PostHogConfig
+import com.posthog.PostHogInternal
 import java.io.IOException
 import java.io.Reader
 import java.io.Writer
@@ -14,25 +16,30 @@ import java.util.Date
  * The JSON serializer using Gson
  * @property config the Config
  */
-internal class PostHogSerializer(private val config: PostHogConfig) {
-    private val gson = GsonBuilder().apply {
+@PostHogInternal
+public class PostHogSerializer(private val config: PostHogConfig) {
+    public val gson: Gson = GsonBuilder().apply {
         setObjectToNumberStrategy(GsonNumberPolicy())
         registerTypeAdapter(Date::class.java, GsonDateTypeAdapter(config))
             .setLenient()
     }.create()
 
     @Throws(JsonIOException::class, IOException::class)
-    inline fun <reified T> serialize(value: T, writer: Writer) {
+    public inline fun <reified T> serialize(value: T, writer: Writer) {
         gson.toJson(value, object : TypeToken<T>() {}.type, writer)
         writer.flush()
     }
 
     @Throws(JsonIOException::class, JsonSyntaxException::class)
-    inline fun <reified T> deserialize(reader: Reader): T {
+    public inline fun <reified T> deserialize(reader: Reader): T {
         return gson.fromJson(reader, object : TypeToken<T>() {}.type)
     }
 
-    fun deserializeString(json: String): Any? {
+    public fun deserializeString(json: String): Any? {
         return gson.fromJson(json, Any::class.java)
+    }
+
+    public fun serializeObject(value: Any): String? {
+        return gson.toJson(value, Any::class.java)
     }
 }

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -18,9 +18,8 @@ internal class PostHogApiTest {
         host: String,
     ): PostHogApi {
         val config = PostHogConfig(apiKey, host)
-        val serializer = PostHogSerializer(config)
         val dateProvider = PostHogCalendarDateProvider()
-        return PostHogApi(config, serializer, dateProvider)
+        return PostHogApi(config, dateProvider)
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
@@ -27,10 +27,9 @@ internal class PostHogFeatureFlagsTest {
         val config = PostHogConfig(apiKey, host).apply {
             this.networkStatus = networkStatus
         }
-        val serializer = PostHogSerializer(config)
         val dateProvider = PostHogCalendarDateProvider()
-        val api = PostHogApi(config, serializer, dateProvider)
-        return PostHogFeatureFlags(config, serializer, api, executor = executor)
+        val api = PostHogApi(config, dateProvider)
+        return PostHogFeatureFlags(config, api, executor = executor)
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
@@ -42,9 +42,8 @@ internal class PostHogQueueTest {
             this.networkStatus = networkStatus
             this.maxBatchSize = maxBatchSize
         }
-        val serializer = PostHogSerializer(config)
-        val api = PostHogApi(config, serializer, dateProvider)
-        return PostHogQueue(config, api, serializer, executor = executor, dateProvider = dateProvider)
+        val api = PostHogApi(config, dateProvider)
+        return PostHogQueue(config, api, executor = executor, dateProvider = dateProvider)
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogSendCachedEventsIntegrationTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogSendCachedEventsIntegrationTest.kt
@@ -42,10 +42,9 @@ internal class PostHogSendCachedEventsIntegrationTest {
             this.networkStatus = networkStatus
             this.maxBatchSize = maxBatchSize
         }
-        val serializer = PostHogSerializer(config)
         val dateProvider = PostHogCalendarDateProvider()
-        val api = PostHogApi(config, serializer, dateProvider)
-        return PostHogSendCachedEventsIntegration(config, api, serializer, date, executor = executor)
+        val api = PostHogApi(config, dateProvider)
+        return PostHogSendCachedEventsIntegration(config, api, date, executor = executor)
     }
 
     @AfterTest

--- a/posthog/src/test/java/com/posthog/internal/PostHogSendCachedLegacyEventsIntegrationTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogSendCachedLegacyEventsIntegrationTest.kt
@@ -38,10 +38,9 @@ internal class PostHogSendCachedLegacyEventsIntegrationTest {
             this.networkStatus = networkStatus
             this.maxBatchSize = maxBatchSize
         }
-        val serializer = PostHogSerializer(config)
         val dateProvider = PostHogCalendarDateProvider()
-        val api = PostHogApi(config, serializer, dateProvider)
-        return PostHogSendCachedEventsIntegration(config, api, serializer, date, executor = executor)
+        val api = PostHogApi(config, dateProvider)
+        return PostHogSendCachedEventsIntegration(config, api, date, executor = executor)
     }
 
     @AfterTest


### PR DESCRIPTION
## :bulb: Motivation and Context
After talking to @neilkakkar, we confirmed that groups should be cached in the disk otherwise customers would have to register the groups every time the SDK is set up.
The Android SDK v2 didn't do groups at all.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
