### PR TITLE
`distinct_id` is always a top level property only

### DIFF
--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -188,7 +188,6 @@ public class PostHog private constructor(
         }
 
     private fun buildProperties(
-        distinctId: String,
         properties: Map<String, Any>?,
         userProperties: Map<String, Any>?,
         userPropertiesSetOnce: Map<String, Any>?,
@@ -247,11 +246,6 @@ public class PostHog private constructor(
             props["\$groups"] = it
         }
 
-        // only set if not there.
-        props["distinct_id"]?.let {
-            props["distinct_id"] = distinctId
-        }
-
         return props
     }
 
@@ -277,11 +271,10 @@ public class PostHog private constructor(
             event,
             newDistinctId,
             properties = buildProperties(
-                newDistinctId,
-                properties,
-                userProperties,
-                userPropertiesSetOnce,
-                groupProperties,
+                properties = properties,
+                userProperties = userProperties,
+                userPropertiesSetOnce = userPropertiesSetOnce,
+                groupProperties = groupProperties,
             ),
         )
         queue?.add(postHogEvent)
@@ -363,7 +356,6 @@ public class PostHog private constructor(
 
         val props = mutableMapOf<String, Any>()
         props["\$anon_distinct_id"] = anonymousId
-        props["distinct_id"] = distinctId
 
         properties?.let {
             props.putAll(it)
@@ -437,10 +429,6 @@ public class PostHog private constructor(
     }
 
     private fun loadFeatureFlagsRequest(onFeatureFlags: PostHogOnFeatureFlags?) {
-        val props = mutableMapOf<String, Any>()
-        props["\$anon_distinct_id"] = anonymousId
-        props["distinct_id"] = distinctId
-
         // just defensive, if there's no config.cachePreferences, we fallback to in memory
         val preferences = config?.cachePreferences ?: memoryPreferences
 

--- a/posthog/src/test/resources/json/alias.json
+++ b/posthog/src/test/resources/json/alias.json
@@ -21,7 +21,6 @@
     "$lib_version": "version",
     "$app_namespace": "com.posthog.myapplication",
     "$app_build": "1",
-    "distinct_id": "my_identify",
     "$feature/4535-funnel-bar-viz": true,
     "$active_feature_flags": [
       "4535-funnel-bar-viz"

--- a/posthog/src/test/resources/json/basic-event.json
+++ b/posthog/src/test/resources/json/basic-event.json
@@ -1,9 +1,9 @@
 {
   "uuid": "8837f4d8-01e3-4bb8-b3f3-16b8fa8173e5",
   "event": "testEvent",
+  "distinct_id": "9740f814-0b10-42e2-b3d4-8f35af1b11f6",
   "properties": {
-    "testProperty": "testValue",
-    "distinct_id": "9740f814-0b10-42e2-b3d4-8f35af1b11f6"
+    "testProperty": "testValue"
   },
   "timestamp": "2023-09-19T07:23:00.165Z"
 }

--- a/posthog/src/test/resources/json/batch-request.json
+++ b/posthog/src/test/resources/json/batch-request.json
@@ -4,9 +4,9 @@
     {
       "uuid": "8837f4d8-01e3-4bb8-b3f3-16b8fa8173e5",
       "event": "testEvent",
+      "distinct_id": "9740f814-0b10-42e2-b3d4-8f35af1b11f6",
       "properties": {
-        "testProperty": "testValue",
-        "distinct_id": "9740f814-0b10-42e2-b3d4-8f35af1b11f6"
+        "testProperty": "testValue"
       },
       "timestamp": "2023-09-19T07:23:00.165Z"
     }

--- a/posthog/src/test/resources/json/capture.json
+++ b/posthog/src/test/resources/json/capture.json
@@ -26,7 +26,6 @@
     "$active_feature_flags": [
       "4535-funnel-bar-viz"
     ],
-    "distinct_id": "my_identify",
     "$groups": {
       "company": "company_id_in_your_db"
     }

--- a/posthog/src/test/resources/json/identify.json
+++ b/posthog/src/test/resources/json/identify.json
@@ -30,5 +30,5 @@
       "myProperty": "myValue"
     }
   },
-  "distinct_id": "my_identif$sety"
+  "distinct_id": "my_identify"
 }

--- a/posthog/src/test/resources/json/other-event.json
+++ b/posthog/src/test/resources/json/other-event.json
@@ -1,9 +1,9 @@
 {
   "uuid": "8837f4d8-01e3-4bb8-b3f3-16b8fa8173e5",
   "event": "testNewEvent",
+  "distinct_id": "9740f814-0b10-42e2-b3d4-8f35af1b11f6",
   "properties": {
-    "testProperty": "testValue",
-    "distinct_id": "9740f814-0b10-42e2-b3d4-8f35af1b11f6"
+    "testProperty": "testValue"
   },
   "timestamp": "2023-09-19T07:23:00.165Z"
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
No need to duplicate the `distinct_id` in the properties as well.
the Backend already checks for this field as top level or within the properties, but the top level is preferred.
_#skip-changelog_ since its just internal


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
