### PR TITLE
Keep trying to flush events till the device is connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Keep trying to flush events till the device is connected ([#52](https://github.com/PostHog/posthog-android/pull/52))
+
 ## 3.0.0-beta.1 - 2023-10-18
 
 - Registered keys are cached in the disk preferences ([#51](https://github.com/PostHog/posthog-android/pull/51))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Keep trying to flush events till the device is connected ([#52](https://github.com/PostHog/posthog-android/pull/52))
+- Keep trying to flush events till the device is connected ([#54](https://github.com/PostHog/posthog-android/pull/54))
 
 ## 3.0.0-beta.1 - 2023-10-18
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -138,6 +138,7 @@ internal class PostHogQueue(
 
     private fun executeBatch() {
         if (!isConnected()) {
+            isFlushing.set(false)
             return
         }
 
@@ -220,6 +221,7 @@ internal class PostHogQueue(
 
         executor.executeSafely {
             if (!isConnected()) {
+                isFlushing.set(false)
                 return@executeSafely
             }
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
@@ -168,6 +168,29 @@ internal class PostHogQueueTest {
     }
 
     @Test
+    fun `does not flush if not connected but try to flush again`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        var connected = false
+        val sut = getSut(host = url.toString(), flushAt = 1, networkStatus = {
+            connected
+        })
+
+        sut.add(generateEvent())
+
+        executor.awaitExecution()
+
+        connected = true
+
+        sut.add(generateEvent())
+
+        executor.shutdownAndAwaitTermination()
+
+        assertEquals(1, http.requestCount)
+    }
+
+    @Test
     fun `does not delete file if API is 3xx`() {
         val http = mockHttp(response = MockResponse().setResponseCode(300).setBody("error"))
         val url = http.url("/")


### PR DESCRIPTION
## :bulb: Motivation and Context
If device was disconnected, the flushing boolean would never be flipped

Found by https://github.com/PostHog/posthog-android/pull/53/files#r1365940959


## :green_heart: How did you test it?
Real device and unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
