### PR TITLE
Remove properties from `identify` and `alias`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - Ship proguard rules for proguard/r8 full mode ([#52](https://github.com/PostHog/posthog-android/pull/52))
-- Remove properties ties from `identify` and `alias ([#55](https://github.com/PostHog/posthog-android/pull/55))
+- Remove properties ties from `identify` and `alias` ([#55](https://github.com/PostHog/posthog-android/pull/55))
 
 ## 3.0.0-beta.2 - 2023-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - Ship proguard rules for proguard/r8 full mode ([#52](https://github.com/PostHog/posthog-android/pull/52))
+- Remove properties ties from `identify` and `alias ([#55](https://github.com/PostHog/posthog-android/pull/55))
 
 ## 3.0.0-beta.2 - 2023-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - Ship proguard rules for proguard/r8 full mode ([#52](https://github.com/PostHog/posthog-android/pull/52))
-- Remove properties ties from `identify` and `alias` ([#55](https://github.com/PostHog/posthog-android/pull/55))
+- Remove properties from `identify` and `alias` ([#55](https://github.com/PostHog/posthog-android/pull/55))
 
 ## 3.0.0-beta.2 - 2023-10-20
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -89,8 +89,7 @@ Identify the user
 
 ```kotlin
 PostHog.identify(
-    "user123", 
-    properties = mapOf("is_free_trial" to true), 
+    "user123",
     userProperties = mapOf("email" to "user@posthog.com")
 )
 ```
@@ -98,7 +97,7 @@ PostHog.identify(
 Create an alias for the current user
 
 ```kotlin
-PostHog.alias("theAlias", properties = mapOf("is_free_trial" to true))
+PostHog.alias("theAlias")
 ```
 
 Identify a group

--- a/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
@@ -31,7 +31,6 @@ public class PostHogFake : PostHogInterface {
 
     override fun identify(
         distinctId: String,
-        properties: Map<String, Any>?,
         userProperties: Map<String, Any>?,
         userPropertiesSetOnce: Map<String, Any>?,
     ) {
@@ -71,7 +70,7 @@ public class PostHogFake : PostHogInterface {
         this.screenTitle = screenTitle
     }
 
-    override fun alias(alias: String, properties: Map<String, Any>?) {
+    override fun alias(alias: String) {
     }
 
     override fun isOptOut(): Boolean {

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -1,7 +1,7 @@
 public final class com/posthog/PostHog : com/posthog/PostHogInterface {
 	public static final field Companion Lcom/posthog/PostHog$Companion;
 	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun alias (Ljava/lang/String;Ljava/util/Map;)V
+	public fun alias (Ljava/lang/String;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public fun close ()V
 	public fun distinctId ()Ljava/lang/String;
@@ -9,7 +9,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogInterface {
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public fun isOptOut ()Z
 	public fun optIn ()V
@@ -23,7 +23,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogInterface {
 }
 
 public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface {
-	public fun alias (Ljava/lang/String;Ljava/util/Map;)V
+	public fun alias (Ljava/lang/String;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public fun close ()V
 	public fun distinctId ()Ljava/lang/String;
@@ -31,7 +31,7 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public fun isOptOut ()Z
 	public fun optIn ()V
@@ -140,7 +140,7 @@ public final class com/posthog/PostHogIntegration$DefaultImpls {
 }
 
 public abstract interface class com/posthog/PostHogInterface {
-	public abstract fun alias (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun alias (Ljava/lang/String;)V
 	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public abstract fun close ()V
 	public abstract fun distinctId ()Ljava/lang/String;
@@ -148,7 +148,7 @@ public abstract interface class com/posthog/PostHogInterface {
 	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public abstract fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public abstract fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public abstract fun isOptOut ()Z
 	public abstract fun optIn ()V
@@ -162,12 +162,11 @@ public abstract interface class com/posthog/PostHogInterface {
 }
 
 public final class com/posthog/PostHogInterface$DefaultImpls {
-	public static synthetic fun alias$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun capture$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun getFeatureFlag$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getFeatureFlagPayload$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun group$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun identify$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun identify$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun isFeatureEnabled$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;ZILjava/lang/Object;)Z
 	public static synthetic fun reloadFeatureFlags$default (Lcom/posthog/PostHogInterface;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
 	public static synthetic fun screen$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -333,7 +333,7 @@ public class PostHog private constructor(
         capture("\$screen", properties = props)
     }
 
-    public override fun alias(alias: String, properties: Map<String, Any>?) {
+    public override fun alias(alias: String) {
         if (!isEnabled()) {
             return
         }
@@ -341,16 +341,11 @@ public class PostHog private constructor(
         val props = mutableMapOf<String, Any>()
         props["alias"] = alias
 
-        properties?.let {
-            props.putAll(it)
-        }
-
         capture("\$create_alias", properties = props)
     }
 
     public override fun identify(
         distinctId: String,
-        properties: Map<String, Any>?,
         userProperties: Map<String, Any>?,
         userPropertiesSetOnce: Map<String, Any>?,
     ) {
@@ -362,10 +357,6 @@ public class PostHog private constructor(
 
         val props = mutableMapOf<String, Any>()
         props["\$anon_distinct_id"] = anonymousId
-
-        properties?.let {
-            props.putAll(it)
-        }
 
         capture(
             "\$identify",
@@ -609,13 +600,11 @@ public class PostHog private constructor(
 
         public override fun identify(
             distinctId: String,
-            properties: Map<String, Any>?,
             userProperties: Map<String, Any>?,
             userPropertiesSetOnce: Map<String, Any>?,
         ) {
             shared.identify(
                 distinctId,
-                properties = properties,
                 userProperties = userProperties,
                 userPropertiesSetOnce = userPropertiesSetOnce,
             )
@@ -658,8 +647,8 @@ public class PostHog private constructor(
             shared.screen(screenTitle, properties = properties)
         }
 
-        public override fun alias(alias: String, properties: Map<String, Any>?) {
-            shared.alias(alias, properties = properties)
+        public override fun alias(alias: String) {
+            shared.alias(alias)
         }
 
         public override fun isOptOut(): Boolean = shared.isOptOut()

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -37,13 +37,11 @@ public interface PostHogInterface {
      * Identifies the user
      * Docs https://posthog.com/docs/product-analytics/identify
      * @param distinctId the distinctId
-     * @param properties the custom properties
      * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
      * @param userPropertiesSetOnce the user properties to set only once, set as a "$set_once" property, Docs https://posthog.com/docs/product-analytics/user-properties
      */
     public fun identify(
         distinctId: String,
-        properties: Map<String, Any>? = null,
         userProperties: Map<String, Any>? = null,
         userPropertiesSetOnce: Map<String, Any>? = null,
     )
@@ -119,9 +117,8 @@ public interface PostHogInterface {
      * Creates an alias for the user
      * Docs https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user
      * @param alias the alias
-     * @param properties the custom properties
      */
-    public fun alias(alias: String, properties: Map<String, Any>? = null)
+    public fun alias(alias: String)
 
     /**
      * Checks if the [optOut] mode is enabled or disabled

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -446,7 +446,6 @@ internal class PostHogTest {
 
         sut.identify(
             distinctId,
-            props,
             userProperties = userProps,
             userPropertiesSetOnce = userPropsOnce,
         )
@@ -462,7 +461,6 @@ internal class PostHogTest {
         val theEvent = batch.batch.first()
         assertEquals("\$identify", theEvent.event)
         assertEquals(distinctId, theEvent.distinctId)
-        assertEquals("value", theEvent.properties!!["prop"] as String)
         assertNotNull(theEvent.properties!!["\$anon_distinct_id"])
         assertEquals(userProps, theEvent.properties!!["\$set"])
         assertEquals(userPropsOnce, theEvent.properties!!["\$set_once"])
@@ -479,7 +477,6 @@ internal class PostHogTest {
 
         sut.alias(
             "theAlias",
-            props,
         )
 
         queueExecutor.shutdownAndAwaitTermination()
@@ -493,7 +490,6 @@ internal class PostHogTest {
         assertEquals("\$create_alias", theEvent.event)
         assertNotNull(theEvent.distinctId)
         assertEquals("theAlias", theEvent.properties!!["alias"] as String)
-        assertEquals("value", theEvent.properties!!["prop"] as String)
 
         sut.close()
     }


### PR DESCRIPTION
## :bulb: Motivation and Context
Discussed on https://github.com/PostHog/posthog-ios/pull/78


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
