### PR TITLE
Pick up consumer proguard rules correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - Expose and allow to enable and disable the debug mode at runtime ([#60](https://github.com/PostHog/posthog-android/pull/60))
+- Pick up consumer proguard rules correctly ([#62](https://github.com/PostHog/posthog-android/pull/62))
 
 ## 3.0.0-beta.4 - 2023-11-08
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,15 +17,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
-android.nonTransitiveRClass=true
 
 android.defaults.buildfeatures.buildconfig=true
-android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.shaders=false
-android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -21,7 +21,6 @@ android {
         minSdk = PosthogBuildConfig.Android.MIN_SDK
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
 
         buildFeatures {
             buildConfig = true
@@ -32,7 +31,7 @@ android {
 
     buildTypes {
         release {
-            consumerProguardFiles("proguard-rules.pro")
+            consumerProguardFiles("consumer-rules.pro")
         }
     }
     compileOptions {

--- a/posthog-android/consumer-rules.pro
+++ b/posthog-android/consumer-rules.pro
@@ -12,9 +12,16 @@
 
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.posthog.PostHogEvent { *; }
+-keep class com.posthog.PostHogEvent { <init>(); }
+
 -keep class com.posthog.internal.PostHogBatchEvent { *; }
+-keep class com.posthog.internal.PostHogBatchEvent { <init>(); }
+
 -keep class com.posthog.internal.PostHogDecideRequest { *; }
+-keep class com.posthog.internal.PostHogDecideRequest { <init>(); }
+
 -keep class com.posthog.internal.PostHogDecideResponse { *; }
+-keep class com.posthog.internal.PostHogDecideResponse { <init>(); }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)

--- a/posthog-android/consumer-rules.pro
+++ b/posthog-android/consumer-rules.pro
@@ -11,10 +11,10 @@
 #-keep class com.google.gson.stream.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
--keep class com.posthog.PostHogEvent { <fields>; }
--keep class com.posthog.internal.PostHogBatchEvent { <fields>; }
--keep class com.posthog.internal.PostHogDecideRequest { <fields>; }
--keep class com.posthog.internal.PostHogDecideResponse { <fields>; }
+-keep class com.posthog.PostHogEvent { *; }
+-keep class com.posthog.internal.PostHogBatchEvent { *; }
+-keep class com.posthog.internal.PostHogDecideRequest { *; }
+-keep class com.posthog.internal.PostHogDecideResponse { *; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)

--- a/posthog-samples/posthog-android-sample/build.gradle.kts
+++ b/posthog-samples/posthog-android-sample/build.gradle.kts
@@ -21,11 +21,13 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {


### PR DESCRIPTION
## :bulb: Motivation and Context

> java.lang.RuntimeException: Failed to invoke constructor 'com.posthog.PostHogEvent()' with no args.

If Proguard/R8 removed the classes/methods/ctor not referenced directly.
https://github.com/google/gson/blob/2658aca66a1d0f097794a5ad5eb33c095a8f8d5d/gson/src/main/java/com/google/gson/internal/ConstructorConstructor.java#L273C39-L273C67

* Consumer file was not picked up correctly since it was set twice/and a typo.
* Issue reported by a user.


## :green_heart: How did you test it?
Running the sample with R8 enabled.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
