### PR TITLE
Properties sanitizer

### DIFF
--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -3,6 +3,7 @@ package com.posthog.android.sample
 import android.app.Application
 import android.os.StrictMode
 import com.posthog.PostHogOnFeatureFlags
+import com.posthog.PostHogPropertiesSanitizer
 import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 
@@ -17,6 +18,11 @@ class MyApp : Application() {
             flushAt = 5
             maxBatchSize = 5
             onFeatureFlags = PostHogOnFeatureFlags { print("feature flags loaded") }
+            propertiesSanitizer = PostHogPropertiesSanitizer { properties ->
+                properties.apply {
+                    remove("\$device_name")
+                }
+            }
         }
         PostHogAndroid.setup(this, config)
     }

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -52,8 +52,8 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 public class com/posthog/PostHogConfig {
 	public static final field Companion Lcom/posthog/PostHogConfig$Companion;
 	public static final field defaultHost Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogPropertiesSanitizer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogPropertiesSanitizer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun getApiKey ()Ljava/lang/String;
 	public final fun getCachePreferences ()Lcom/posthog/internal/PostHogPreferences;
@@ -72,6 +72,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getOnFeatureFlags ()Lcom/posthog/PostHogOnFeatureFlags;
 	public final fun getOptOut ()Z
 	public final fun getPreloadFeatureFlags ()Z
+	public final fun getPropertiesSanitizer ()Lcom/posthog/PostHogPropertiesSanitizer;
 	public final fun getSdkName ()Ljava/lang/String;
 	public final fun getSdkVersion ()Ljava/lang/String;
 	public final fun getSendFeatureFlagEvent ()Z
@@ -92,6 +93,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setOnFeatureFlags (Lcom/posthog/PostHogOnFeatureFlags;)V
 	public final fun setOptOut (Z)V
 	public final fun setPreloadFeatureFlags (Z)V
+	public final fun setPropertiesSanitizer (Lcom/posthog/PostHogPropertiesSanitizer;)V
 	public final fun setSdkName (Ljava/lang/String;)V
 	public final fun setSdkVersion (Ljava/lang/String;)V
 	public final fun setSendFeatureFlagEvent (Z)V
@@ -181,6 +183,10 @@ public abstract interface annotation class com/posthog/PostHogInternal : java/la
 
 public abstract interface class com/posthog/PostHogOnFeatureFlags {
 	public abstract fun loaded ()V
+}
+
+public abstract interface class com/posthog/PostHogPropertiesSanitizer {
+	public abstract fun sanitize (Ljava/util/Map;)Ljava/util/Map;
 }
 
 public abstract interface annotation class com/posthog/PostHogVisibleForTesting : java/lang/annotation/Annotation {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -273,15 +273,20 @@ public class PostHog private constructor(
 
         val newDistinctId = distinctId ?: this.distinctId
 
+        val mergedProperties = buildProperties(
+            properties = properties,
+            userProperties = userProperties,
+            userPropertiesSetOnce = userPropertiesSetOnce,
+            groupProperties = groupProperties,
+        )
+
+        // sanitize the properties or fallback to the original properties
+        val sanitizedProperties = config?.propertiesSanitizer?.sanitize(mergedProperties.toMutableMap()) ?: mergedProperties
+
         val postHogEvent = PostHogEvent(
             event,
             newDistinctId,
-            properties = buildProperties(
-                properties = properties,
-                userProperties = userProperties,
-                userPropertiesSetOnce = userPropertiesSetOnce,
-                groupProperties = groupProperties,
-            ),
+            properties = sanitizedProperties,
         )
         queue?.add(postHogEvent)
     }

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -89,6 +89,12 @@ public open class PostHogConfig(
      * Defaults to no callback
      */
     public var onFeatureFlags: PostHogOnFeatureFlags? = null,
+
+    /**
+     * Hook that allows to sanitize the event properties
+     * The hook is called before the event is cached or sent over the wire
+     */
+    public var propertiesSanitizer: PostHogPropertiesSanitizer? = null,
 ) {
     // fix me: https://stackoverflow.com/questions/53866865/leaking-this-in-constructor-warning-should-apply-to-final-classes-as-well-as
     @PostHogInternal

--- a/posthog/src/main/java/com/posthog/PostHogPropertiesSanitizer.kt
+++ b/posthog/src/main/java/com/posthog/PostHogPropertiesSanitizer.kt
@@ -1,0 +1,13 @@
+package com.posthog
+
+/**
+ * Hook to sanitize the event properties
+ */
+public fun interface PostHogPropertiesSanitizer {
+    /**
+     * Sanitizes the event properties
+     * @param properties the event properties to sanitize
+     * @return the sanitized properties
+     */
+    public fun sanitize(properties: MutableMap<String, Any>): Map<String, Any>
+}


### PR DESCRIPTION
## :bulb: Motivation and Context
Some SDKs have a `sanitize_properties` method, others `property_denylist`.
This is similar to `sanitize_properties` but as a callback that is run before the event is cached or sent over the wire. 
The user can redact, remove, or add any properties.
The downside is that the user can mess up with properties that may cause a bug on the backend or something.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
