### PR TITLE
Updated deprecated buildDir Gradle

### DIFF
--- a/buildSrc/src/main/java/PostHogPublishConfig.kt
+++ b/buildSrc/src/main/java/PostHogPublishConfig.kt
@@ -55,7 +55,7 @@ fun Project.publishingAndroidConfig() {
 
 fun Project.javadocConfig() {
     tasks.withType(DokkaTask::class.java).configureEach {
-        val toOutputDirectory = file("${buildDir.canonicalPath}/reports/javadoc")
+        val toOutputDirectory = file("${layout.buildDirectory.asFile.get()}/reports/javadoc")
         outputDirectory.set(toOutputDirectory)
         doFirst {
             if (!toOutputDirectory.exists()) {


### PR DESCRIPTION
## :bulb: Motivation and Context
Relates to https://github.com/gradle/gradle/issues/20210 and causes:

> posthog-android/posthog-android/buildSrc/src/main/java/PostHogPublishConfig.kt:58:41 'getter for buildDir: File' is deprecated. Deprecated in Java

_#skip-changelog_


## :green_heart: How did you test it?
`buildDir` already fallback to `layout.buildDirectory.asFile.get()` so there's nothing to be done, just warning elimitation.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
