### PR TITLE
Bump Kotlin to min. 1.6 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Bump Kotlin to min. 1.6 compatibility ([#67](https://github.com/PostHog/posthog-android/pull/67))
+- Bump Kotlin to min. 1.6 compatibility ([#68](https://github.com/PostHog/posthog-android/pull/68))
 
 ## 3.0.0-RC.1 - 2023-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Bump Kotlin to min. 1.6 compatibility ([#67](https://github.com/PostHog/posthog-android/pull/67))
+
 ## 3.0.0-RC.1 - 2023-11-20
 
 - Do not set `$network_carrier` property if empty ([#66](https://github.com/PostHog/posthog-android/pull/66))

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     `kotlin-dsl`
 }
@@ -11,23 +9,22 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 dependencies {
     // also update PosthogBuildConfig.Kotlin.KOTLIN
-    val kotlinVersion = "1.8.10"
+    val kotlinVersion = "1.8.22"
+    // there's no 1.8.22 for dokka yet
+    val dokkaVersion = "1.8.20"
     implementation("com.android.tools.build:gradle:8.1.3")
     // kotlin version has to match kotlinCompilerExtensionVersion
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 
     // publish
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:$kotlinVersion")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
     implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
 
     // tests

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,10 +8,8 @@ repositories {
     gradlePluginPortal()
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -20,12 +20,12 @@ object PosthogBuildConfig {
     object Kotlin {
         // compiler has to match kotlin version
         // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-        val COMPILER_EXTENSION_VERSION = "1.4.3" // kotlin 1.8.10
+        val COMPILER_EXTENSION_VERSION = "1.4.8" // kotlin 1.8.22
 
-        val KOTLIN_COMPATIBILITY = "1.5"
+        val KOTLIN_COMPATIBILITY = "1.6"
 
         // also update buildSrc/gradle.kts - kotlinVersion
-        val KOTLIN = "1.8.10"
+        val KOTLIN = "1.8.22"
     }
 
     object Plugins {

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -71,6 +71,11 @@ android {
     kotlinOptions.postHogConfig()
 }
 
+kotlin {
+    val javaVersion = JavaLanguageVersion.of(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion).asInt()
+    jvmToolchain(javaVersion)
+}
+
 dependencies {
     // runtime
     api(project(mapOf("path" to ":posthog")))

--- a/posthog-samples/posthog-android-sample/build.gradle.kts
+++ b/posthog-samples/posthog-android-sample/build.gradle.kts
@@ -54,6 +54,11 @@ android {
     }
 }
 
+kotlin {
+    val javaVersion = JavaLanguageVersion.of(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion).asInt()
+    jvmToolchain(javaVersion)
+}
+
 dependencies {
     implementation(project(mapOf("path" to ":posthog-android")))
 

--- a/posthog/build.gradle.kts
+++ b/posthog/build.gradle.kts
@@ -29,9 +29,6 @@ buildConfig {
 
 java {
     withSourcesJar()
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion)
-    }
 }
 
 val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
@@ -67,6 +64,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 kotlin {
     explicitApi()
+    jvmToolchain(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion.toInt())
 }
 
 configure<SourceSetContainer> {

--- a/posthog/build.gradle.kts
+++ b/posthog/build.gradle.kts
@@ -21,11 +21,6 @@ plugins {
     id("ru.vyarus.animalsniffer")
 }
 
-configure<JavaPluginExtension> {
-    sourceCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
-    targetCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
-}
-
 buildConfig {
     useKotlinOutput()
     packageName("com.posthog")
@@ -34,6 +29,9 @@ buildConfig {
 
 java {
     withSourcesJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion)
+    }
 }
 
 val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
@@ -75,10 +73,6 @@ configure<SourceSetContainer> {
     test {
         java.srcDir("src/test/java")
     }
-}
-
-tasks.compileJava {
-    options.release.set(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion.toInt())
 }
 
 animalsniffer {


### PR DESCRIPTION
## :bulb: Motivation and Context
* Kotlin 1.5 is deprecated.
* Ref. for the latest toolchain tooling https://blog.blundellapps.co.uk/setting-jdk-level-in-android-gradle-builds/


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
