### PR TITLE
flush forcefully sends events regardless the delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- `flush` forcefully sends events regardless the delay ([#66](https://github.com/PostHog/posthog-android/pull/66))
+- `flush` forcefully sends events regardless the delay ([#73](https://github.com/PostHog/posthog-android/pull/73))
 
 ## 3.0.0 - 2023-12-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- `flush` forcefully sends events regardless the delay ([#66](https://github.com/PostHog/posthog-android/pull/66))
+
 ## 3.0.0 - 2023-12-06
 
 Check out the updated [docs](https://posthog.com/docs/libraries/android).

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -86,7 +86,7 @@ internal class PostHogQueue(
                     }
                     config.logger.log("Queued event ${file.name}.")
 
-                    flushIfOverThreshold(true)
+                    flushIfOverThreshold()
                 } catch (e: Throwable) {
                     config.logger.log("Event ${event.event} failed to parse: $e.")
                 }
@@ -94,10 +94,14 @@ internal class PostHogQueue(
         }
     }
 
-    private fun flushIfOverThreshold(onExecutor: Boolean) {
-        if (deque.size >= config.flushAt) {
-            flushBatch(onExecutor)
+    private fun flushIfOverThreshold() {
+        if (isAboveThreshold(config.flushAt)) {
+            flushBatch()
         }
+    }
+
+    private fun isAboveThreshold(flushAt: Int): Boolean {
+        return deque.size >= flushAt
     }
 
     private fun canFlushBatch(): Boolean {
@@ -117,7 +121,7 @@ internal class PostHogQueue(
         return events
     }
 
-    private fun flushBatch(onExecutor: Boolean) {
+    private fun flushBatch() {
         if (!canFlushBatch()) {
             config.logger.log("Cannot flush the Queue.")
             return
@@ -128,14 +132,7 @@ internal class PostHogQueue(
             return
         }
 
-        // if its called from the executor already, no need to schedule another one
-        if (onExecutor) {
-            executeBatch()
-        } else {
-            executor.executeSafely {
-                executeBatch()
-            }
-        }
+        executeBatch()
     }
 
     private fun executeBatch() {
@@ -212,6 +209,11 @@ internal class PostHogQueue(
     }
 
     fun flush() {
+        // only flushes if the queue is above the threshold (not empty in this case)
+        if (!isAboveThreshold(1)) {
+            return
+        }
+
         if (isFlushing.getAndSet(true)) {
             config.logger.log("Queue is flushing.")
             return
@@ -264,7 +266,8 @@ internal class PostHogQueue(
                     config.logger.log("Queue is flushing.")
                     return@schedule
                 }
-                flushIfOverThreshold(false)
+                // if the timer passes, send pending events, no need to wait for the flushAt threshold
+                flush()
             }
             this.timerTask = timerTask
             this.timer = timer

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -212,11 +212,6 @@ internal class PostHogQueue(
     }
 
     fun flush() {
-        if (!canFlushBatch()) {
-            config.logger.log("Cannot flush the Queue.")
-            return
-        }
-
         if (isFlushing.getAndSet(true)) {
             config.logger.log("Queue is flushing.")
             return

--- a/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
@@ -271,10 +271,6 @@ internal class PostHogQueueTest {
         val path = tmpDir.newFolder().absolutePath
         val sut = getSut(host = url.toString(), flushAt = 1, storagePrefix = path, dateProvider = fakeCurrentTime)
 
-        // to be sure that the delay is before now
-        val date = ISO8601Utils.parse("1970-09-20T11:58:49.000Z", ParsePosition(0))
-        fakeCurrentTime.setAddSecondsToCurrentDate(date)
-
         sut.add(generateEvent())
 
         executor.awaitExecution()


### PR DESCRIPTION
## :bulb: Motivation and Context
https://github.com/postHog/posthog-js-lite/ sends events regardless the timer if `flush` is called manually.

https://posthog.com/questions/flush-interval-seconds-not-working


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
