### PR TITLE
fix: Check keyboard status during snapshot instead of using WindowInsets listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: Check keyboard status during snapshot instead of using Window listener ([#72](https://github.com/PostHog/posthog-android/pull/72))
+
 ## 3.1.0 - 2024-01-08
 
 - chore: Add mutations support to Session Recording ([#72](https://github.com/PostHog/posthog-android/pull/72)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: Check keyboard status during snapshot instead of using Window listener ([#72](https://github.com/PostHog/posthog-android/pull/72))
+- fix: Check keyboard status during snapshot instead of using WindowInsets listener ([#77](https://github.com/PostHog/posthog-android/pull/77))
 
 ## 3.1.0 - 2024-01-08
 

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -131,11 +131,11 @@ public class PostHogReplayIntegration(
         }
     }
 
-    private fun detectKeyboardOpen(view: View, open: Boolean): Pair<Boolean, RRCustomEvent?> {
-        val insets = ViewCompat.getRootWindowInsets(view) ?: return Pair(open, null)
+    private fun detectKeyboardVisibility(view: View, visible: Boolean): Pair<Boolean, RRCustomEvent?> {
+        val insets = ViewCompat.getRootWindowInsets(view) ?: return Pair(visible, null)
         val imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
-        if (open == imeVisible) {
-            return Pair(open, null)
+        if (visible == imeVisible) {
+            return Pair(visible, null)
         }
 
         val payload = mutableMapOf<String, Any>()
@@ -339,8 +339,8 @@ public class PostHogReplayIntegration(
         }
 
         // detect keyboard status
-        val (open, event) = detectKeyboardOpen(view, status.keyboardOpen)
-        status.keyboardOpen = open
+        val (visible, event) = detectKeyboardVisibility(view, status.keyboardVisible)
+        status.keyboardVisible = visible
         event?.let {
             events.add(it)
         }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -338,7 +338,7 @@ public class PostHogReplayIntegration(
             }
         }
 
-        // detect keyboard status
+        // detect keyboard visibility
         val (visible, event) = detectKeyboardVisibility(view, status.keyboardVisible)
         status.keyboardVisible = visible
         event?.let {

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/ViewTreeSnapshotStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/ViewTreeSnapshotStatus.kt
@@ -6,6 +6,6 @@ internal class ViewTreeSnapshotStatus(
     val listener: NextDrawListener,
     var sentFullSnapshot: Boolean = false,
     var sentMetaEvent: Boolean = false,
-    var keyboardOpen: Boolean = false,
+    var keyboardVisible: Boolean = false,
     var lastSnapshot: RRWireframe? = null,
 )

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/ViewTreeSnapshotStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/ViewTreeSnapshotStatus.kt
@@ -6,5 +6,6 @@ internal class ViewTreeSnapshotStatus(
     val listener: NextDrawListener,
     var sentFullSnapshot: Boolean = false,
     var sentMetaEvent: Boolean = false,
+    var keyboardOpen: Boolean = false,
     var lastSnapshot: RRWireframe? = null,
 )

--- a/posthog-samples/posthog-android-sample/build.gradle.kts
+++ b/posthog-samples/posthog-android-sample/build.gradle.kts
@@ -34,9 +34,6 @@ android {
         sourceCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
         targetCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 
     kotlinOptions.postHogConfig(false)
 

--- a/posthog-samples/posthog-android-sample/build.gradle.kts
+++ b/posthog-samples/posthog-android-sample/build.gradle.kts
@@ -34,6 +34,9 @@ android {
         sourceCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
         targetCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
     }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 
     kotlinOptions.postHogConfig(false)
 


### PR DESCRIPTION
## :bulb: Motivation and Context
https://posthog.com/questions/status-bar-color-not-updating

I recall fixing something [similar](https://github.com/getsentry/sentry-java/pull/1769) in the past as well.
Sometimes the new APIs (setOnApplyWindowInsetsListener) are not well documented on when and how to use them, this is just another weird corner case/side effect.

## :green_heart: How did you test it?
Testing the sample app with a different theme and status colors

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
