### PR TITLE
fix: Events Queue is only paused if there were errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
-- fix: Events Queue is only paused if there were errors ([#72](https://github.com/PostHog/posthog-android/pull/72))
-- fix: Do not report flag events if the flag has been reported with the same value ([#72](https://github.com/PostHog/posthog-android/pull/72))
+- fix: Events Queue is only paused if there were errors ([#78](https://github.com/PostHog/posthog-android/pull/78))
+- fix: Do not report flag events if the flag has been reported with the same value ([#78](https://github.com/PostHog/posthog-android/pull/78))
 
 ## 3.1.0 - 2024-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- fix: Events Queue is only paused if there were errors ([#72](https://github.com/PostHog/posthog-android/pull/72))
+- fix: Do not report flag events if the flag has been reported with the same value ([#72](https://github.com/PostHog/posthog-android/pull/72))
+
 ## 3.1.0 - 2024-01-08
 
 - chore: Add mutations support to Session Recording ([#72](https://github.com/PostHog/posthog-android/pull/72)) 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -497,7 +497,7 @@ public class PostHog private constructor(
             if (values.contains(value)) {
                 shouldSendFeatureFlagEvent = false
             } else {
-                values.add(key)
+                values.add(value)
                 featureFlagsCalled[key] = values
             }
         }

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -257,8 +257,10 @@ internal class PostHogQueue(
     }
 
     private fun calculateDelay(retry: Boolean) {
-        val delay = if (retry) min(retryCount * retryDelaySeconds, maxRetryDelaySeconds) else config.flushIntervalSeconds
-        pausedUntil = config.dateProvider.addSecondsToCurrentDate(delay)
+        if (retry) {
+            val delay = min(retryCount * retryDelaySeconds, maxRetryDelaySeconds)
+            pausedUntil = config.dateProvider.addSecondsToCurrentDate(delay)
+        }
     }
 
     fun start() {


### PR DESCRIPTION
## :bulb: Motivation and Context
The event Queue was paused even if there were no errors, so setting a lower `flushIntervalSeconds` did not have a lot of effects.

The `Do not report flag events if the flag has been reported with the same value` fix part of this PR was found after fixing the main issue and was necessary to be in the same PR to make the CI happy.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
