### PR TITLE
fix: Send wireframe children for updated wireframes - mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Send wireframe children for updated wireframes - mutation ([#81](https://github.com/PostHog/posthog-android/pull/81))
+
 ## 3.1.1 - 2024-01-11
 
 - fix: Events Queue is only paused if there were errors ([#78](https://github.com/PostHog/posthog-android/pull/78))

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -729,10 +729,11 @@ public class PostHogReplayIntegration(
             // we have to copy without the childWireframes, otherwise they all would be different
             // if one of the child is different, but we only wanna compare the parent
             val oldItem = oldMap[id]?.copy(childWireframes = null) ?: continue
-            val newItem = newMap[id]?.copy(childWireframes = null) ?: continue
+            val newItem = newMap[id] ?: continue
+            val newItemCopy = newItem.copy(childWireframes = null)
 
             // If the items are different (any property has a different value), add the new item to the updatedItems list
-            if (oldItem != newItem) {
+            if (oldItem != newItemCopy) {
                 updatedItems.add(newItem)
             }
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

When there are keyboard events (open/close), the view is redrawn and the wireframe has a new `height` due to making space for the keyboard hence the wireframe observed a mutation.
The mutation sends just the wireframe but not its children leading to all children being lost in the FE since its stateless.

## :green_heart: How did you test it?
https://us.posthog.com/project/41706/replay/5e3d9268-1d86-4d10-81dc-82239b885a40

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
