### PR TITLE
Do not capture console logs and network requests if session replay and session are not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Do not capture console logs and network requests if session replay and session are not active ([#81](https://github.com/PostHog/posthog-android/pull/81))
+
 ## 3.1.2 - 2024-01-15
 
 - Send wireframe children for updated wireframes - mutation ([#81](https://github.com/PostHog/posthog-android/pull/81))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Do not capture console logs and network requests if session replay and session are not active ([#81](https://github.com/PostHog/posthog-android/pull/81))
+- Do not capture console logs and network requests if session replay and session are not active ([#83](https://github.com/PostHog/posthog-android/pull/83))
 
 ## 3.1.2 - 2024-01-15
 

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -81,7 +81,7 @@ public class PostHogAndroid private constructor() {
             if (config.captureApplicationLifecycleEvents) {
                 config.addIntegration(PostHogAppInstallIntegration(context, config))
             }
-            config.addIntegration(PostHogLifecycleObserverIntegration(context, config, replayIntegration, mainHandler))
+            config.addIntegration(PostHogLifecycleObserverIntegration(context, config, mainHandler))
         }
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -14,6 +14,7 @@ import com.posthog.android.internal.PostHogLifecycleObserverIntegration
 import com.posthog.android.internal.PostHogSharedPreferences
 import com.posthog.android.internal.appContext
 import com.posthog.android.replay.PostHogReplayIntegration
+import com.posthog.android.replay.internal.PostHogLogCatIntegration
 import com.posthog.internal.PostHogPrintLogger
 import java.io.File
 
@@ -71,8 +72,8 @@ public class PostHogAndroid private constructor() {
             config.sdkName = "posthog-android"
 
             val mainHandler = MainHandler()
-            val replayIntegration = PostHogReplayIntegration(context, config, mainHandler)
-            config.addIntegration(replayIntegration)
+            config.addIntegration(PostHogReplayIntegration(context, config, mainHandler))
+            config.addIntegration(PostHogLogCatIntegration(config))
             if (context is Application) {
                 if (config.captureDeepLinks || config.captureScreenViews || config.sessionReplay) {
                     config.addIntegration(PostHogActivityLifecycleCallbackIntegration(context, config))

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogLifecycleObserverIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogLifecycleObserverIntegration.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.posthog.PostHog
 import com.posthog.PostHogIntegration
 import com.posthog.android.PostHogAndroidConfig
-import com.posthog.android.replay.PostHogReplayIntegration
 import java.util.Timer
 import java.util.TimerTask
 import java.util.concurrent.atomic.AtomicLong
@@ -22,7 +21,6 @@ import java.util.concurrent.atomic.AtomicLong
 internal class PostHogLifecycleObserverIntegration(
     private val context: Context,
     private val config: PostHogAndroidConfig,
-    private val replayIntegration: PostHogReplayIntegration,
     private val mainHandler: MainHandler,
     private val lifecycle: Lifecycle = ProcessLifecycleOwner.get().lifecycle,
 ) : DefaultLifecycleObserver, PostHogIntegration {
@@ -70,7 +68,6 @@ internal class PostHogLifecycleObserverIntegration(
             (lastUpdatedSession + sessionMaxInterval) <= currentTimeMillis
         ) {
             PostHog.startSession()
-            replayIntegration.sessionActive(true)
         }
         this.lastUpdatedSession.set(currentTimeMillis)
     }
@@ -88,7 +85,6 @@ internal class PostHogLifecycleObserverIntegration(
             timerTask = object : TimerTask() {
                 override fun run() {
                     PostHog.endSession()
-                    replayIntegration.sessionActive(false)
                 }
             }
             timer.schedule(timerTask, sessionMaxInterval)

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -43,7 +43,6 @@ import com.posthog.android.internal.densityValue
 import com.posthog.android.internal.displayMetrics
 import com.posthog.android.internal.screenSize
 import com.posthog.android.replay.internal.NextDrawListener.Companion.onNextDraw
-import com.posthog.android.replay.internal.PostHogLogCatWatcher
 import com.posthog.android.replay.internal.ViewTreeSnapshotStatus
 import com.posthog.internal.PostHogThreadFactory
 import com.posthog.internal.replay.RRCustomEvent
@@ -83,8 +82,6 @@ public class PostHogReplayIntegration(
     private val executor by lazy {
         Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("PostHogReplayThread"))
     }
-
-    private val logCatWatcher = PostHogLogCatWatcher(config)
 
     private val displayMetrics by lazy {
         context.displayMetrics()
@@ -222,8 +219,6 @@ public class PostHogReplayIntegration(
         }
 
         Curtains.onRootViewsChangedListeners += onRootViewsChangedListener
-
-        logCatWatcher.init()
     }
 
     override fun uninstall() {
@@ -232,8 +227,6 @@ public class PostHogReplayIntegration(
         decorViews.entries.forEach {
             cleanSessionState(it.key, it.value)
         }
-
-        logCatWatcher.stop()
     }
 
     private fun Resources.Theme.toRGBColor(): String? {

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/PostHogLogCatIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/PostHogLogCatIntegration.kt
@@ -3,6 +3,7 @@ package com.posthog.android.replay.internal
 import android.annotation.SuppressLint
 import android.os.Build
 import com.posthog.PostHog
+import com.posthog.PostHogIntegration
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.internal.interruptSafely
 import com.posthog.internal.replay.RRPluginEvent
@@ -10,7 +11,7 @@ import com.posthog.internal.replay.capture
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-internal class PostHogLogCatWatcher(private val config: PostHogAndroidConfig) {
+internal class PostHogLogCatIntegration(private val config: PostHogAndroidConfig) : PostHogIntegration {
 
     @Volatile
     private var logcatInProgress = false
@@ -20,7 +21,7 @@ internal class PostHogLogCatWatcher(private val config: PostHogAndroidConfig) {
     private val isSessionReplayEnabled: Boolean
         get() = config.sessionReplay && PostHog.isSessionActive()
 
-    fun init() {
+    override fun install() {
         if (!config.sessionReplayConfig.captureLogcat || !isSupported()) {
             return
         }
@@ -85,7 +86,7 @@ internal class PostHogLogCatWatcher(private val config: PostHogAndroidConfig) {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
     }
 
-    fun stop() {
+    override fun uninstall() {
         logcatInProgress = false
         logcatThread?.interruptSafely()
     }

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/PostHogLogCatWatcher.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/PostHogLogCatWatcher.kt
@@ -2,6 +2,7 @@ package com.posthog.android.replay.internal
 
 import android.annotation.SuppressLint
 import android.os.Build
+import com.posthog.PostHog
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.internal.interruptSafely
 import com.posthog.internal.replay.RRPluginEvent
@@ -15,6 +16,9 @@ internal class PostHogLogCatWatcher(private val config: PostHogAndroidConfig) {
     private var logcatInProgress = false
 
     private var logcatThread: Thread? = null
+
+    private val isSessionReplayEnabled: Boolean
+        get() = config.sessionReplay && PostHog.isSessionActive()
 
     fun init() {
         if (!config.sessionReplayConfig.captureLogcat || !isSupported()) {
@@ -37,6 +41,11 @@ internal class PostHogLogCatWatcher(private val config: PostHogAndroidConfig) {
                     do {
                         try {
                             line = it.readLine()
+
+                            // do not capture console logs if session replay is disabled
+                            if (!isSessionReplayEnabled) {
+                                continue
+                            }
 
                             if (line.isNullOrEmpty()) {
                                 continue

--- a/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
@@ -95,4 +95,12 @@ public class PostHogFake : PostHogInterface {
 
     override fun endSession() {
     }
+
+    override fun isSessionActive(): Boolean {
+        return false
+    }
+
+    override fun <T : PostHogConfig> getConfig(): T? {
+        return null
+    }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogLifecycleObserverIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogLifecycleObserverIntegrationTest.kt
@@ -10,7 +10,6 @@ import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.apiKey
 import com.posthog.android.createPostHogFake
 import com.posthog.android.mockPackageInfo
-import com.posthog.android.replay.PostHogReplayIntegration
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import kotlin.test.BeforeTest
@@ -25,8 +24,7 @@ internal class PostHogLifecycleObserverIntegrationTest {
     private fun getSut(): PostHogLifecycleObserverIntegration {
         val config = PostHogAndroidConfig(apiKey)
         val mainHandler = MainHandler()
-        val replay = PostHogReplayIntegration(context, config, mainHandler)
-        return PostHogLifecycleObserverIntegration(context, config, replay, mainHandler, lifecycle = fakeLifecycle)
+        return PostHogLifecycleObserverIntegration(context, config, mainHandler, lifecycle = fakeLifecycle)
     }
 
     @BeforeTest

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/NormalActivity.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/NormalActivity.kt
@@ -1,9 +1,11 @@
 package com.posthog.android.sample
 
 import android.os.Bundle
+import android.widget.Button
 import androidx.activity.ComponentActivity
 import com.posthog.PostHogOkHttpInterceptor
 import okhttp3.OkHttpClient
+import okhttp3.internal.closeQuietly
 
 class NormalActivity : ComponentActivity() {
 
@@ -19,9 +21,9 @@ class NormalActivity : ComponentActivity() {
 //        val webview = findViewById<WebView>(R.id.webview)
 //        webview.loadUrl("https://www.google.com")
 
-//        val button = findViewById<Button>(R.id.button)
+        val button = findViewById<Button>(R.id.button)
 //        val imvAndroid = findViewById<ImageView>(R.id.imvAndroid)
-//        button.setOnClickListener {
+        button.setOnClickListener {
 //            Log.e("MyApp", "Clicked on button ${button.text}")
 //            button.text = "Test: ${(0..10).random()}"
 //            if (imvAndroid.visibility == View.VISIBLE) {
@@ -31,13 +33,13 @@ class NormalActivity : ComponentActivity() {
 //            }
 //            startActivity(Intent(this, NothingActivity::class.java))
 //            finish()
-//            Thread {
-//                client.newCall(
-//                    okhttp3.Request.Builder()
-//                        .url("https://google.com")
-//                        .build(),
-//                ).execute().closeQuietly()
-//            }.start()
-//        }
+            Thread {
+                client.newCall(
+                    okhttp3.Request.Builder()
+                        .url("https://google.com")
+                        .build(),
+                ).execute().closeQuietly()
+            }.start()
+        }
     }
 }

--- a/posthog-samples/posthog-android-sample/src/main/res/layout/normal_activity.xml
+++ b/posthog-samples/posthog-android-sample/src/main/res/layout/normal_activity.xml
@@ -33,13 +33,13 @@
     <!--                />-->
     <!--            &lt;!&ndash;        android:tag="ph-no-capture"&ndash;&gt;-->
 
-    <!--            <Button-->
-    <!--                android:layout_width="wrap_content"-->
-    <!--                android:layout_height="wrap_content"-->
-    <!--                android:text="Button text"-->
-    <!--                android:textColor="#FF0000"-->
-    <!--                android:id="@+id/button"-->
-    <!--                />-->
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Button text"
+                    android:textColor="#FF0000"
+                    android:id="@+id/button"
+                    />
 
     <!--            &lt;!&ndash;    <View&ndash;&gt;-->
     <!--            &lt;!&ndash;        android:layout_width="match_parent"&ndash;&gt;-->
@@ -115,11 +115,11 @@
     <!--        android:id="@+id/webview"-->
     <!--        />-->
 
-    <RatingBar
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:numStars="4"
-        android:rating="3.5" />
+<!--    <RatingBar-->
+<!--        android:layout_width="wrap_content"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:numStars="4"-->
+<!--        android:rating="3.5" />-->
 
     <!--    <Spinner-->
     <!--        android:layout_width="wrap_content"-->

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -8,12 +8,14 @@ public final class com/posthog/PostHog : com/posthog/PostHogInterface {
 	public fun distinctId ()Ljava/lang/String;
 	public fun endSession ()V
 	public fun flush ()V
+	public fun getConfig ()Lcom/posthog/PostHogConfig;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public fun isOptOut ()Z
+	public fun isSessionActive ()Z
 	public fun optIn ()V
 	public fun optOut ()V
 	public fun register (Ljava/lang/String;Ljava/lang/Object;)V
@@ -33,12 +35,14 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun distinctId ()Ljava/lang/String;
 	public fun endSession ()V
 	public fun flush ()V
+	public fun getConfig ()Lcom/posthog/PostHogConfig;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public fun isOptOut ()Z
+	public fun isSessionActive ()Z
 	public fun optIn ()V
 	public fun optOut ()V
 	public final fun overrideSharedInstance (Lcom/posthog/PostHogInterface;)V
@@ -169,12 +173,14 @@ public abstract interface class com/posthog/PostHogInterface {
 	public abstract fun distinctId ()Ljava/lang/String;
 	public abstract fun endSession ()V
 	public abstract fun flush ()V
+	public abstract fun getConfig ()Lcom/posthog/PostHogConfig;
 	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public abstract fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public abstract fun isOptOut ()Z
+	public abstract fun isSessionActive ()Z
 	public abstract fun optIn ()V
 	public abstract fun optOut ()V
 	public abstract fun register (Ljava/lang/String;Ljava/lang/Object;)V

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -597,6 +597,19 @@ public class PostHog private constructor(
         }
     }
 
+    override fun isSessionActive(): Boolean {
+        var active: Boolean
+        synchronized(sessionLock) {
+            active = sessionId != sessionIdNone
+        }
+        return active
+    }
+
+    override fun <T : PostHogConfig> getConfig(): T? {
+        @Suppress("UNCHECKED_CAST")
+        return config as? T
+    }
+
     public companion object : PostHogInterface {
         private var shared: PostHogInterface = PostHog()
         private var defaultSharedInstance = shared
@@ -744,6 +757,14 @@ public class PostHog private constructor(
 
         override fun endSession() {
             shared.endSession()
+        }
+
+        override fun isSessionActive(): Boolean {
+            return shared.isSessionActive()
+        }
+
+        override fun <T : PostHogConfig> getConfig(): T? {
+            return shared.getConfig()
         }
     }
 }

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -151,7 +151,26 @@ public interface PostHogInterface {
      */
     public fun debug(enable: Boolean = true)
 
+    /**
+     * Starts a session
+     * The SDK will automatically start a session when you call [setup]
+     * On Android, the SDK will automatically start a session when the app is in the foreground
+     */
     public fun startSession()
 
+    /**
+     * Ends a session
+     * The SDK will automatically end a session when you call [close]
+     * On Android, the SDK will automatically end a session when the app is in the background
+     * for at least 30 minutes
+     */
     public fun endSession()
+
+    /**
+     * Returns if a session is active
+     */
+    public fun isSessionActive(): Boolean
+
+    @PostHogInternal
+    public fun <T : PostHogConfig> getConfig(): T?
 }

--- a/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
@@ -7,6 +7,10 @@ import okhttp3.Request
 import okhttp3.Response
 
 public class PostHogOkHttpInterceptor(private val captureNetworkTelemetry: Boolean = true) : Interceptor {
+
+    private val isSessionReplayEnabled: Boolean
+        get() = PostHog.getConfig<PostHogConfig>()?.sessionReplay == true && PostHog.isSessionActive()
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
 
@@ -22,7 +26,8 @@ public class PostHogOkHttpInterceptor(private val captureNetworkTelemetry: Boole
     }
 
     private fun captureNetworkEvent(request: Request, response: Response) {
-        if (!captureNetworkTelemetry) {
+        // do not capture network logs if session replay is disabled
+        if (!captureNetworkTelemetry || !isSessionReplayEnabled) {
             return
         }
         val url = request.url.toString()


### PR DESCRIPTION
## :bulb: Motivation and Context
If session replay was disabled or session not active, console logs and network requests were still captured since the check was done only early in the app lifecycle.


## :green_heart: How did you test it?
Running both with session replay and session active and not active

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
