### PR TITLE
Set `Content-Length` header for `gzip` bodies because of more strict proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Set `Content-Length` header for gzip bodies because of more strict proxies ([#83](https://github.com/PostHog/posthog-android/pull/83))
+- Set `Content-Length` header for gzip bodies because of more strict proxies ([#86](https://github.com/PostHog/posthog-android/pull/86))
 
 ## 3.1.3 - 2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- Set `Content-Length` header for gzip bodies because of more strict proxies ([#83](https://github.com/PostHog/posthog-android/pull/83))
+
 ## 3.1.3 - 2024-01-17
 
 - Do not capture console logs and network requests if session replay and session are not active ([#83](https://github.com/PostHog/posthog-android/pull/83))

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -49,7 +49,7 @@ object PosthogBuildConfig {
         // runtime
         val LIFECYCLE = "2.6.2"
         val GSON = "2.10.1"
-        val OKHTTP = "4.11.0"
+        val OKHTTP = "4.12.0"
         val CURTAINS = "1.2.4"
         val ANDROIDX_CORE = "1.5.0"
 

--- a/posthog/src/main/java/com/posthog/internal/GzipRequestInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/GzipRequestInterceptor.kt
@@ -24,6 +24,7 @@ import okhttp3.MediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.Response
+import okio.Buffer
 import okio.BufferedSink
 import okio.GzipSink
 import okio.buffer
@@ -50,7 +51,7 @@ internal class GzipRequestInterceptor(private val config: PostHogConfig) : Inter
             val compressedRequest = try {
                 originalRequest.newBuilder()
                     .header("Content-Encoding", "gzip")
-                    .method(originalRequest.method, gzip(body))
+                    .method(originalRequest.method, forceContentLength(gzip(body)))
                     .build()
             } catch (e: Throwable) {
                 config.logger.log("Failed to gzip the request body: $e.")
@@ -76,6 +77,28 @@ internal class GzipRequestInterceptor(private val config: PostHogConfig) : Inter
                 val gzipSink = GzipSink(sink).buffer()
                 body.writeTo(gzipSink)
                 gzipSink.close()
+            }
+        }
+    }
+
+    // https://github.com/square/okhttp/issues/350
+    @Throws(IOException::class)
+    private fun forceContentLength(body: RequestBody): RequestBody {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+
+        return object : RequestBody() {
+            override fun contentType(): MediaType? {
+                return body.contentType()
+            }
+
+            override fun contentLength(): Long {
+                return buffer.size
+            }
+
+            @Throws(IOException::class)
+            override fun writeTo(sink: BufferedSink) {
+                sink.write(buffer.snapshot())
             }
         }
     }


### PR DESCRIPTION
## :bulb: Motivation and Context
Set `Content-Length` header for `gzip` bodies because of more strict proxies
https://posthog.com/questions/not-able-to-trigger-any-event

## :green_heart: How did you test it?
Testing using a self hosted version given by the user

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
