### PR TITLE
fix: device_model and device_name properties were inverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: `device_model` and `device_name` properties were inverted ([#91](https://github.com/PostHog/posthog-android/pull/91))
+
 ## 3.1.6 - 2024-02-01
 
 - recording: clone drawable before using ([#91](https://github.com/PostHog/posthog-android/pull/91))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: `device_model` and `device_name` properties were inverted ([#91](https://github.com/PostHog/posthog-android/pull/91))
+- fix: `device_model` and `device_name` properties were inverted ([#94](https://github.com/PostHog/posthog-android/pull/94))
 
 ## 3.1.6 - 2024-02-01
 

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -41,8 +41,8 @@ internal class PostHogAndroidContext(
         staticContext["\$app_name"] = context.applicationInfo.loadLabel(context.packageManager)
 
         staticContext["\$device_manufacturer"] = Build.MANUFACTURER
-        staticContext["\$device_model"] = Build.MODEL
-        staticContext["\$device_name"] = Build.DEVICE
+        staticContext["\$device_model"] = Build.DEVICE // returns eg lynx (industrial name)
+        staticContext["\$device_name"] = Build.MODEL // returns eg Pixel 7a (end name)
         // Check https://github.com/PostHog/posthog-flutter/issues/49 and change if needed
         staticContext["\$device_type"] = "Mobile"
         staticContext["\$os_name"] = "Android"


### PR DESCRIPTION
## :bulb: Motivation and Context
They now match the taxonomy https://github.com/PostHog/posthog/edit/master/frontend/src/lib/taxonomy.tsx


## :green_heart: How did you test it?
fix: device_model and device_name properties were inverted

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
