### PR TITLE
roll back compile API to 33 to keep back compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- roll back compile API to 33 to keep back compatibility ([#97](https://github.com/PostHog/posthog-android/pull/97))
+- roll back compile API to 33 to keep back compatibility ([#98](https://github.com/PostHog/posthog-android/pull/98))
 
 ## 3.1.8 - 2024-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- roll back compile API to 33 to keep back compatibility ([#97](https://github.com/PostHog/posthog-android/pull/97))
+
 ## 3.1.8 - 2024-02-19
 
 - fix reset session when reset or close are called ([#97](https://github.com/PostHog/posthog-android/pull/97))

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -14,7 +14,7 @@ object PosthogBuildConfig {
     }
 
     object Android {
-        val COMPILE_SDK = 34
+        val COMPILE_SDK = 33
 
         // when changing this, remember to check the ANIMAL_SNIFFER_SDK_VERSION
         // Session Replay (addOnFrameMetricsAvailableListener requires API 26)
@@ -47,7 +47,7 @@ object PosthogBuildConfig {
 
     object Dependencies {
         // runtime
-        val LIFECYCLE = "2.7.0"
+        val LIFECYCLE = "2.6.2"
         val GSON = "2.10.1"
         val OKHTTP = "4.12.0"
         val CURTAINS = "1.2.5"

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release
-versionName=3.1.7
+versionName=3.1.8

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -3,6 +3,28 @@
 
     <issue
         id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-process than 2.6.2 is available: 2.7.0"
+        errorLine1="    implementation(&quot;androidx.lifecycle:lifecycle-process:${PosthogBuildConfig.Dependencies.LIFECYCLE}&quot;)"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="83"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-common-java8 than 2.6.2 is available: 2.7.0"
+        errorLine1="    implementation(&quot;androidx.lifecycle:lifecycle-common-java8:${PosthogBuildConfig.Dependencies.LIFECYCLE}&quot;)"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="84"
+            column="20"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
         message="A newer version of androidx.core:core than 1.5.0 is available: 1.12.0"
         errorLine1="    implementation(&quot;androidx.core:core:${PosthogBuildConfig.Dependencies.ANDROIDX_CORE}&quot;)"
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -16,6 +16,7 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import com.posthog.android.PostHogAndroidConfig
 
+@Suppress("DEPRECATION")
 internal fun getPackageInfo(
     context: Context,
     config: PostHogAndroidConfig,
@@ -69,11 +70,13 @@ internal fun Context.screenSize(): PostHogScreenSizeInfo? {
         val currentWindowMetrics = windowManager.currentWindowMetrics
         val screenBounds = currentWindowMetrics.bounds
 
-        density = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            currentWindowMetrics.density
-        } else {
-            displayMetrics.density
-        }
+//        TODO: do this when we upgrade API to 34
+//        density = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+//            currentWindowMetrics.density
+//        } else {
+//            displayMetrics.density
+//        }
+        density = displayMetrics.density
 
         screenHeight = (screenBounds.bottom - screenBounds.top).densityValue(density)
         screenWidth = (screenBounds.right - screenBounds.left).densityValue(density)
@@ -119,6 +122,7 @@ internal fun Context.telephonyManager(): TelephonyManager? {
     return getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
 }
 
+@Suppress("DEPRECATION")
 internal fun Activity.activityLabel(config: PostHogAndroidConfig): String? {
     return try {
         val info = packageManager.getActivityInfo(componentName, GET_META_DATA)

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -422,18 +422,19 @@ public class PostHogReplayIntegration(
                 value = text
                 text = null
             }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                style.fontFamily = view.typeface?.systemFontFamilyName
-            } else {
-                view.typeface?.let {
-                    when (it) {
-                        Typeface.DEFAULT -> style.fontFamily = "sans-serif"
-                        Typeface.DEFAULT_BOLD -> style.fontFamily = "sans-serif-bold"
-                        Typeface.MONOSPACE -> style.fontFamily = "monospace"
-                        Typeface.SERIF -> style.fontFamily = "serif"
-                    }
+//            TODO: do this when we upgrade API to 34
+//            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+//                style.fontFamily = view.typeface?.systemFontFamilyName
+//            } else {
+            view.typeface?.let {
+                when (it) {
+                    Typeface.DEFAULT -> style.fontFamily = "sans-serif"
+                    Typeface.DEFAULT_BOLD -> style.fontFamily = "sans-serif-bold"
+                    Typeface.MONOSPACE -> style.fontFamily = "monospace"
+                    Typeface.SERIF -> style.fontFamily = "serif"
                 }
             }
+//            }
             style.fontSize = view.textSize.toInt().densityValue(displayMetrics.density)
             when (view.textAlignment) {
                 View.TEXT_ALIGNMENT_CENTER -> {

--- a/posthog-samples/posthog-android-sample/build.gradle.kts
+++ b/posthog-samples/posthog-android-sample/build.gradle.kts
@@ -73,7 +73,7 @@ kotlin {
 dependencies {
     implementation(project(mapOf("path" to ":posthog-android")))
 
-    implementation("androidx.activity:activity-compose:1.8.0")
+    implementation("androidx.activity:activity-compose:1.7.2")
     implementation(platform("androidx.compose:compose-bom:2023.03.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")


### PR DESCRIPTION
## :bulb: Motivation and Context
       1.  Dependency 'androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :app is currently compiled against android-33.

           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 7.4.2 is 33.

           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 34, then update this project to use
           compileSdkVerion of at least 34.

There were more like this, we cannot force people to use the latest version.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
