### PR TITLE
bump kotlin tooling

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,9 +14,9 @@ kotlin {
 
 dependencies {
     // also update PosthogBuildConfig.Kotlin.KOTLIN
-    val kotlinVersion = "1.8.22"
-    // there's no 1.8.22 for dokka yet
-    val dokkaVersion = "1.8.20"
+    val kotlinVersion = "1.9.22"
+    // there's no 1.9.22 for dokka yet
+    val dokkaVersion = "1.9.10"
     implementation("com.android.tools.build:gradle:8.1.3")
     // kotlin version has to match kotlinCompilerExtensionVersion
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -25,12 +25,12 @@ object PosthogBuildConfig {
     object Kotlin {
         // compiler has to match kotlin version
         // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-        val COMPILER_EXTENSION_VERSION = "1.4.8" // kotlin 1.8.22
+        val COMPILER_EXTENSION_VERSION = "1.5.10" // kotlin 1.9.22
 
         val KOTLIN_COMPATIBILITY = "1.6"
 
         // also update buildSrc/gradle.kts - kotlinVersion
-        val KOTLIN = "1.8.22"
+        val KOTLIN = "1.9.22"
     }
 
     object Plugins {

--- a/posthog/src/main/java/com/posthog/internal/PostHogDecideResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogDecideResponse.kt
@@ -1,11 +1,14 @@
 package com.posthog.internal
 
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
 /**
  * The decide response data structure for calling the decide API
  * @property errorsWhileComputingFlags if there were errors computing feature flags
  * @property featureFlags the feature flags
  * @property featureFlagPayloads the feature flag payloads
  */
+@IgnoreJRERequirement
 internal data class PostHogDecideResponse(
     // assuming theres no errors if not present
     val errorsWhileComputingFlags: Boolean = false,


### PR DESCRIPTION
## :bulb: Motivation and Context
.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.9.10/72812e8a368917ab5c0a5081b56915ffdfec93b7/kotlin-stdlib-1.9.10.jar!/META-INF/kotlin-stdlib.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.9.0, expected version is 1.7.1.

It should not affect anything since we still set `languageVersion` to 1.6, so just optimizations and bug fixes.

_#skip-changelog_


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
