### PR TITLE
do not allow empty or blank `distinct_id` or `anon_distinct_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- do not allow empty or blank `distinct_id` or `anon_distinct_id` ([#101](https://github.com/PostHog/posthog-android/pull/101))
+
 ## 3.1.9 - 2024-02-22
 
 - roll back compile API to 33 to keep back compatibility ([#98](https://github.com/PostHog/posthog-android/pull/98))

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -420,6 +420,8 @@ public class PostHog private constructor(
         val anonymousId = this.anonymousId
         if (anonymousId.isNotBlank()) {
             props["\$anon_distinct_id"] = anonymousId
+        } else {
+            config?.logger?.log("identify called with invalid anonymousId: $anonymousId.")
         }
 
         capture(
@@ -434,6 +436,8 @@ public class PostHog private constructor(
             // We keep the AnonymousId to be used by decide calls and identify to link the previousId
             if (previousDistinctId.isNotBlank()) {
                 this.anonymousId = previousDistinctId
+            } else {
+                config?.logger?.log("identify called with invalid former distinctId: $previousDistinctId.")
             }
             this.distinctId = distinctId
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -207,6 +207,7 @@ public class PostHog private constructor(
         }
 
     private fun buildProperties(
+        distinctId: String,
         properties: Map<String, Any>?,
         userProperties: Map<String, Any>?,
         userPropertiesSetOnce: Map<String, Any>?,
@@ -278,10 +279,8 @@ public class PostHog private constructor(
         // remove after https://github.com/PostHog/posthog/pull/18954 gets merged
         val propDistinctId = props["distinct_id"] as? String
         if (propDistinctId.isNullOrBlank() && !appendSharedProps) {
-            val distinctId = this.distinctId
-            if (distinctId.isNotBlank()) {
-                props["distinct_id"] = distinctId
-            }
+            // distinctId is already validated hence not empty or blank
+            props["distinct_id"] = distinctId
         }
 
         return props
@@ -316,6 +315,7 @@ public class PostHog private constructor(
         }
 
         val mergedProperties = buildProperties(
+            newDistinctId,
             properties = properties,
             userProperties = userProperties,
             userPropertiesSetOnce = userPropertiesSetOnce,

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -501,12 +501,12 @@ public class PostHog private constructor(
         val distinctId = this.distinctId
         val anonymousId = this.anonymousId
 
-        if (distinctId.isBlank() || anonymousId.isBlank()) {
-            config?.logger?.log("Feature flags not loaded, distinctId: $distinctId or anonymousId: $anonymousId are invalid.")
+        if (distinctId.isBlank()) {
+            config?.logger?.log("Feature flags not loaded, distinctId is invalid: $distinctId")
             return
         }
 
-        featureFlags?.loadFeatureFlags(distinctId, anonymousId, groups, onFeatureFlags)
+        featureFlags?.loadFeatureFlags(distinctId, anonymousId = anonymousId, groups, onFeatureFlags)
     }
 
     public override fun isFeatureEnabled(key: String, defaultValue: Boolean): Boolean {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -92,10 +92,10 @@ internal class PostHogApi(
     @Throws(PostHogApiError::class, IOException::class)
     fun decide(
         distinctId: String,
-        anonymousId: String,
+        anonymousId: String?,
         groups: Map<String, Any>?,
     ): PostHogDecideResponse? {
-        val decideRequest = PostHogDecideRequest(config.apiKey, distinctId, anonymousId, groups)
+        val decideRequest = PostHogDecideRequest(config.apiKey, distinctId, anonymousId = anonymousId, groups)
 
         val request = makeRequest("$theHost/decide/?v=3") {
             config.serializer.serialize(decideRequest, it.bufferedWriter())

--- a/posthog/src/main/java/com/posthog/internal/PostHogDecideRequest.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogDecideRequest.kt
@@ -6,14 +6,16 @@ package com.posthog.internal
 internal class PostHogDecideRequest(
     apiKey: String,
     distinctId: String,
-    anonymousId: String,
+    anonymousId: String?,
     groups: Map<String, Any>?,
     // add person_properties, group_properties
 ) : HashMap<String, Any>() {
     init {
         this["api_key"] = apiKey
         this["distinct_id"] = distinctId
-        this["\$anon_distinct_id"] = anonymousId
+        if (!anonymousId.isNullOrBlank()) {
+            this["\$anon_distinct_id"] = anonymousId
+        }
         if (groups?.isNotEmpty() == true) {
             this["\$groups"] = groups
         }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -31,7 +31,7 @@ internal class PostHogFeatureFlags(
 
     fun loadFeatureFlags(
         distinctId: String,
-        anonymousId: String,
+        anonymousId: String?,
         groups: Map<String, Any>?,
         onFeatureFlags: PostHogOnFeatureFlags?,
     ) {
@@ -47,7 +47,7 @@ internal class PostHogFeatureFlags(
             }
 
             try {
-                val response = api.decide(distinctId, anonymousId, groups)
+                val response = api.decide(distinctId, anonymousId = anonymousId, groups)
 
                 response?.let {
                     synchronized(featureFlagsLock) {

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -472,6 +472,26 @@ internal class PostHogTest {
     }
 
     @Test
+    fun `does not capture an identify event with invalid distinct id`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false)
+
+        sut.identify(
+            "   ",
+            userProperties = userProps,
+            userPropertiesSetOnce = userPropsOnce,
+        )
+
+        queueExecutor.shutdownAndAwaitTermination()
+
+        assertEquals(0, http.requestCount)
+
+        sut.close()
+    }
+
+    @Test
     fun `captures an alias event`() {
         val http = mockHttp()
         val url = http.url("/")

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -75,7 +75,7 @@ internal class PostHogApiTest {
 
         val sut = getSut(host = url.toString())
 
-        val response = sut.decide("distinctId", "anonId", emptyMap())
+        val response = sut.decide("distinctId", anonymousId = "anonId", emptyMap())
 
         val request = http.takeRequest()
 
@@ -96,7 +96,7 @@ internal class PostHogApiTest {
         val sut = getSut(host = url.toString())
 
         val exc = assertThrows(PostHogApiError::class.java) {
-            sut.decide("distinctId", "anonId", emptyMap())
+            sut.decide("distinctId", anonymousId = "anonId", emptyMap())
         }
         assertEquals(400, exc.statusCode)
         assertEquals("Client Error", exc.message)

--- a/posthog/src/test/java/com/posthog/internal/PostHogDecideRequestTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogDecideRequestTest.kt
@@ -11,7 +11,7 @@ internal class PostHogDecideRequestTest {
 
     @Test
     fun `sets the decide request content`() {
-        val request = PostHogDecideRequest(apiKey, distinctId, anonId, groups)
+        val request = PostHogDecideRequest(apiKey, distinctId, anonymousId = anonId, groups)
 
         assertEquals(apiKey, request["api_key"])
         assertEquals(distinctId, request["distinct_id"])

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
@@ -55,7 +55,7 @@ internal class PostHogFeatureFlagsTest {
             false
         })
 
-        sut.loadFeatureFlags("distinctId", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("distinctId", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -74,7 +74,7 @@ internal class PostHogFeatureFlagsTest {
         val sut = getSut(host = url.toString())
 
         var callback = false
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap()) {
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap()) {
             callback = true
         }
 
@@ -96,7 +96,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -122,7 +122,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -141,7 +141,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -159,7 +159,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.awaitExecution()
 
@@ -169,7 +169,7 @@ internal class PostHogFeatureFlagsTest {
             .setBody(file.readText())
         http.enqueue(response)
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -193,7 +193,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -216,7 +216,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 
@@ -267,7 +267,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        sut.loadFeatureFlags("my_identify", "anonId", emptyMap(), null)
+        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
 
         executor.shutdownAndAwaitTermination()
 


### PR DESCRIPTION
## :bulb: Motivation and Context
https://posthog.com/docs/product-analytics/identify#what-happens-if-you-call-identify-or-alias-with-invalid-inputs

A customer has events with empty `$anon_distinct_id` which is likely a side effect of calling `identify` with an empty `distinct_id`, adding some validations and loggings.

## :green_heart: How did you test it?
Just running it, tests are in place for non nullable fields at least

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
