### PR TITLE
fix back compatibility with Kotlin 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix back compatibility with Kotlin 1.7 ([#101](https://github.com/PostHog/posthog-android/pull/101))
+
 ## 3.1.10 - 2024-02-27
 
 - do not allow empty or blank `distinct_id` or `anon_distinct_id` ([#101](https://github.com/PostHog/posthog-android/pull/101))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix back compatibility with Kotlin 1.7 ([#101](https://github.com/PostHog/posthog-android/pull/101))
+- fix back compatibility with Kotlin 1.7 ([#104](https://github.com/PostHog/posthog-android/pull/104))
 
 ## 3.1.10 - 2024-02-27
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,10 +13,11 @@ kotlin {
 }
 
 dependencies {
+    // do not upgrade to >= 1.9 otherwise it does not work with Kotlin 1.7
     // also update PosthogBuildConfig.Kotlin.KOTLIN
-    val kotlinVersion = "1.9.22"
-    // there's no 1.9.22 for dokka yet
-    val dokkaVersion = "1.9.10"
+    val kotlinVersion = "1.8.22"
+    // there's no 1.8.22 for dokka yet
+    val dokkaVersion = "1.8.20"
     implementation("com.android.tools.build:gradle:8.2.2")
     // kotlin version has to match kotlinCompilerExtensionVersion
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -25,12 +25,13 @@ object PosthogBuildConfig {
     object Kotlin {
         // compiler has to match kotlin version
         // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-        val COMPILER_EXTENSION_VERSION = "1.5.10" // kotlin 1.9.22
+        val COMPILER_EXTENSION_VERSION = "1.4.8" // kotlin 1.8.22
 
         val KOTLIN_COMPATIBILITY = "1.6"
 
+        // do not upgrade to >= 1.9 otherwise it does not work with Kotlin 1.7
         // also update buildSrc/gradle.kts - kotlinVersion
-        val KOTLIN = "1.9.22"
+        val KOTLIN = "1.8.22"
     }
 
     object Plugins {
@@ -49,7 +50,8 @@ object PosthogBuildConfig {
         // runtime
         val LIFECYCLE = "2.6.2"
         val GSON = "2.10.1"
-        val OKHTTP = "4.12.0"
+        // do not upgrade to >= 4.12 otherwise it does not work with Kotlin 1.7
+        val OKHTTP = "4.11.0"
         val CURTAINS = "1.2.5"
         val ANDROIDX_CORE = "1.5.0"
 

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -50,6 +50,7 @@ object PosthogBuildConfig {
         // runtime
         val LIFECYCLE = "2.6.2"
         val GSON = "2.10.1"
+
         // do not upgrade to >= 4.12 otherwise it does not work with Kotlin 1.7
         val OKHTTP = "4.11.0"
         val CURTAINS = "1.2.5"

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -8,7 +8,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
-            line="83"
+            line="86"
             column="20"/>
     </issue>
 
@@ -19,7 +19,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
-            line="84"
+            line="87"
             column="20"/>
     </issue>
 
@@ -30,7 +30,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
-            line="85"
+            line="88"
             column="20"/>
     </issue>
 
@@ -42,6 +42,28 @@
         <location
             file="build.gradle.kts"
             line="100"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of org.jetbrains.kotlin:kotlin-test-junit than 1.8.22 is available: 1.9.22"
+        errorLine1="    testImplementation(&quot;org.jetbrains.kotlin:kotlin-test-junit:${PosthogBuildConfig.Kotlin.KOTLIN}&quot;)"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="102"
+            column="24"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.squareup.okhttp3:mockwebserver than 4.11.0 is available: 4.12.0"
+        errorLine1="    testImplementation(&quot;com.squareup.okhttp3:mockwebserver:${PosthogBuildConfig.Dependencies.OKHTTP}&quot;)"
+        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="103"
             column="24"/>
     </issue>
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Reverts https://github.com/PostHog/posthog-android/pull/99
Fixes https://github.com/PostHog/posthog-android/issues/103
Okhttp and Okio were upgraded to Kotlin 1.8 https://square.github.io/okhttp/changelogs/changelog_4x/#version-4120
Downgrade Okhttp upgraded in this [PR](https://github.com/PostHog/posthog-android/pull/86)

## :green_heart: How did you test it?
Created an empty project using Kotlin 1.7

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
