### PR TITLE
fix merge groups for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix merge groups for events ([#105](https://github.com/PostHog/posthog-android/pull/105))
+
 ## 3.1.11 - 2024-02-28
 
 - fix back compatibility with Kotlin 1.7 ([#104](https://github.com/PostHog/posthog-android/pull/104))

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -271,7 +271,8 @@ public class PostHog private constructor(
             props["\$set_once"] = it
         }
 
-        groupProperties?.let {
+        // merge groups
+        mergeGroups(groupProperties)?.let {
             props["\$groups"] = it
         }
 
@@ -284,6 +285,24 @@ public class PostHog private constructor(
         }
 
         return props
+    }
+
+    private fun mergeGroups(groupProperties: Map<String, Any>?): Map<String, Any>? {
+        val preferences = getPreferences()
+
+        @Suppress("UNCHECKED_CAST")
+        val groups = preferences.getValue(GROUPS) as? Map<String, Any>
+        val newGroups = mutableMapOf<String, Any>()
+
+        groups?.let {
+            newGroups.putAll(it)
+        }
+
+        groupProperties?.let {
+            newGroups.putAll(it)
+        }
+
+        return newGroups.ifEmpty { null }
     }
 
     public override fun capture(


### PR DESCRIPTION
## :bulb: Motivation and Context
$groups were only sent if you were capturing events with `groupProperties`.
bug found by @Lior539 

## :green_heart: How did you test it?
unit test.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
