### PR TITLE
fix do not allow nullable sessionId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.13 - 2024-03-01
 
-- fix do not allow nullable `sessionId` ([#105](https://github.com/PostHog/posthog-android/pull/105))
+- fix do not allow nullable `sessionId` ([#107](https://github.com/PostHog/posthog-android/pull/107))
 
 ## 3.1.12 - 2024-02-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.1.13 - 2024-03-01
+
+- fix do not allow nullable `sessionId` ([#105](https://github.com/PostHog/posthog-android/pull/105))
+
 ## 3.1.12 - 2024-02-29
 
 - fix merge groups for events ([#105](https://github.com/PostHog/posthog-android/pull/105))

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -45,7 +45,7 @@ public class PostHog private constructor(
     private val groupsLock = Any()
 
     // do not move to companion object, otherwise sessionId will be null
-//    private val sessionIdNone = UUID(0, 0)
+    private val sessionIdNone = UUID(0, 0)
 
     private var sessionId = sessionIdNone
     private val featureFlagsCalledLock = Any()
@@ -686,7 +686,6 @@ public class PostHog private constructor(
     public companion object : PostHogInterface {
         private var shared: PostHogInterface = PostHog()
         private var defaultSharedInstance = shared
-        private val sessionIdNone = UUID(0, 0)
 
         private const val GROUP_IDENTIFY = "\$groupidentify"
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -43,6 +43,10 @@ public class PostHog private constructor(
     private val anonymousLock = Any()
     private val sessionLock = Any()
     private val groupsLock = Any()
+
+    // do not move to companion object, otherwise sessionId will be null
+    private val sessionIdNone = UUID(0, 0)
+
     private var sessionId = sessionIdNone
     private val featureFlagsCalledLock = Any()
 
@@ -678,8 +682,6 @@ public class PostHog private constructor(
     public companion object : PostHogInterface {
         private var shared: PostHogInterface = PostHog()
         private var defaultSharedInstance = shared
-
-        private val sessionIdNone = UUID(0, 0)
 
         private const val GROUP_IDENTIFY = "\$groupidentify"
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/PostHog/posthog-flutter/issues/89

For some reason, the companion object const val (aka static in Java) isn't available when the `sessionId` is declared
The non companion object vars are created before the companion object ones so the `sessionId` was assigned with null instead of `sessionIdNone`, static code analyzer should have gotten that.

Bug introduced by #105

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
