### PR TITLE
chore: custom drawable converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - recording: fix issue with nullable hint ([#109](https://github.com/PostHog/posthog-android/pull/109))
+- recording: adds `drawableConverter` option to convert custom Drawable to Bitmap ([#110](https://github.com/PostHog/posthog-android/pull/110))
 
 ## 3.1.13 - 2024-03-01
 

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -36,6 +36,10 @@ public final class com/posthog/android/internal/MainHandler {
 	public final fun getMainLooper ()Landroid/os/Looper;
 }
 
+public abstract interface class com/posthog/android/replay/PostHogDrawableConverter {
+	public abstract fun convert (Landroid/graphics/drawable/Drawable;)Landroid/graphics/Bitmap;
+}
+
 public final class com/posthog/android/replay/PostHogReplayIntegration : com/posthog/PostHogIntegration {
 	public fun <init> (Landroid/content/Context;Lcom/posthog/android/PostHogAndroidConfig;Lcom/posthog/android/internal/MainHandler;)V
 	public fun install ()V
@@ -44,12 +48,14 @@ public final class com/posthog/android/replay/PostHogReplayIntegration : com/pos
 
 public final class com/posthog/android/replay/PostHogSessionReplayConfig {
 	public fun <init> ()V
-	public fun <init> (ZZZ)V
-	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;)V
+	public synthetic fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCaptureLogcat ()Z
+	public final fun getDrawableConverter ()Lcom/posthog/android/replay/PostHogDrawableConverter;
 	public final fun getMaskAllImages ()Z
 	public final fun getMaskAllTextInputs ()Z
 	public final fun setCaptureLogcat (Z)V
+	public final fun setDrawableConverter (Lcom/posthog/android/replay/PostHogDrawableConverter;)V
 	public final fun setMaskAllImages (Z)V
 	public final fun setMaskAllTextInputs (Z)V
 }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogDrawableConverter.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogDrawableConverter.kt
@@ -1,0 +1,8 @@
+package com.posthog.android.replay
+
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+
+public fun interface PostHogDrawableConverter {
+    public fun convert(drawable: Drawable): Bitmap?
+}

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -683,11 +683,6 @@ public class PostHogReplayIntegration(
     }
 
     private fun Drawable.base64(width: Int, height: Int): String? {
-//        val convertedBitmap = config.sessionReplayConfig.drawableConverter?.convert(this)
-//        if (convertedBitmap != null) {
-//            return convertedBitmap.base64()
-//        }
-
         when (this) {
             is BitmapDrawable -> {
                 try {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
@@ -24,4 +24,12 @@ public class PostHogSessionReplayConfig(
      */
     @PostHogExperimental
     public var captureLogcat: Boolean = true,
+
+    /**
+     * Converts custom Drawable to Bitmap
+     * By default PostHog tries to convert the Drawable to Bitmap, the supported types are
+     * BitmapDrawable, ColorDrawable, GradientDrawable, InsetDrawable, LayerDrawable, RippleDrawable
+     */
+    @PostHogExperimental
+    public var drawableConverter: PostHogDrawableConverter? = null,
 )


### PR DESCRIPTION
## :bulb: Motivation and Context
Drawables using https://github.com/mikepenz/Android-Iconics/blob/develop/iconics-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.kt won't be possible to convert to Bitmap automatically


## :green_heart: How did you test it?

```
            sessionReplayConfig.drawableConverter = PostHogDrawableConverter { drawable ->
                if (drawable is IconicsDrawable) {
                    drawable.toBitmap()
                }
                null
            }
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
