### PR TITLE
fix: set correct User-Agent for Android and returns session recording even if authorized domains is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## Next
 
+## 3.1.18 - 2024-04-24
+
+- fix: set correct `User-Agent` for Android and returns session recording even if authorized domains is enabled  ([#118](https://github.com/PostHog/posthog-android/pull/118))
+
 ## 3.1.17 - 2024-04-11
 
-recording: multiple fixes for better frame rate, padding, drawables ([#118](https://github.com/PostHog/posthog-android/pull/118))
+- recording: multiple fixes for better frame rate, padding, drawables ([#118](https://github.com/PostHog/posthog-android/pull/118))
 
 ## 3.1.16 - 2024-03-27
 
-fix: add replay props only if replay is enabled ([#112](https://github.com/PostHog/posthog-android/pull/112))
+- fix: add replay props only if replay is enabled ([#112](https://github.com/PostHog/posthog-android/pull/112))
 
 ## 3.1.15 - 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.18 - 2024-04-24
 
-- fix: set correct `User-Agent` for Android and returns session recording even if authorized domains is enabled  ([#118](https://github.com/PostHog/posthog-android/pull/118))
+- fix: set correct `User-Agent` for Android and returns session recording even if authorized domains is enabled  ([#125](https://github.com/PostHog/posthog-android/pull/125))
 
 ## 3.1.17 - 2024-04-11
 

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -114,7 +114,10 @@ public open class PostHogConfig(
     @PostHogInternal
     public var sdkVersion: String = BuildConfig.VERSION_NAME
 
-    internal val userAgent: String = "$sdkName/$sdkVersion"
+    internal val userAgent: String
+        get() {
+            return "$sdkName/$sdkVersion"
+        }
 
     @PostHogInternal
     public var legacyStoragePrefix: String? = null

--- a/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
@@ -81,6 +81,12 @@ internal class PostHogConfigTest {
     }
 
     @Test
+    fun `user agent is returned correctly if changed`() {
+        config.sdkName = "posthog-android"
+        assertEquals("posthog-android/${BuildConfig.VERSION_NAME}", config.userAgent)
+    }
+
+    @Test
     fun `user agent is set the java sdk by default`() {
         assertEquals("posthog-java/${BuildConfig.VERSION_NAME}", config.userAgent)
     }


### PR DESCRIPTION
## :bulb: Motivation and Context
`User-Agent` was still posthog-java for Android


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
