### PR TITLE
recording: add `screenshot` option for session replay instead of wireframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## Next
 
+## 3.2.0 - 2024-04-29
+
+- recording: add `screenshot` option for session replay instead of wireframe ([#127](https://github.com/PostHog/posthog-android/pull/127))
+
 ## 3.1.18 - 2024-04-24
 
-- fix: set correct `User-Agent` for Android and returns session recording even if authorized domains is enabled  ([#125](https://github.com/PostHog/posthog-android/pull/125))
+- fix: set correct `User-Agent` for Android and returns session recording even if authorized domains is enabled ([#125](https://github.com/PostHog/posthog-android/pull/125))
 
 ## 3.1.17 - 2024-04-11
 
@@ -191,7 +195,7 @@ Check out the [USAGE](https://github.com/PostHog/posthog-android/blob/main/USAGE
 
 ## 2.0.0 - 2022-08-29
 
-- Add support for groups, simplefeature flags, and  multivariate feature flags
+- Add support for groups, simplefeature flags, and multivariate feature flags
 
 ## 1.1.2 - 2021-03-11
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -211,6 +211,8 @@ val config = PostHogAndroidConfig(apiKey).apply {
     sessionReplayConfig.maskAllTextInputs = true
     sessionReplayConfig.maskAllImages = true
     sessionReplayConfig.captureLogcat = true
+    // screenshot is disabled by default 
+    sessionReplayConfig.screenshot = false
 }
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -213,6 +213,8 @@ val config = PostHogAndroidConfig(apiKey).apply {
     sessionReplayConfig.captureLogcat = true
     // screenshot is disabled by default 
     sessionReplayConfig.screenshot = false
+    // debouncerDelayMs is 500ms by default
+    sessionReplayConfig.debouncerDelayMs = 1000
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release
-versionName=3.2.0-alpha.1
+versionName=3.1.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release
-versionName=3.1.18
+versionName=3.2.0-alpha.1

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -48,16 +48,18 @@ public final class com/posthog/android/replay/PostHogReplayIntegration : com/pos
 
 public final class com/posthog/android/replay/PostHogSessionReplayConfig {
 	public fun <init> ()V
-	public fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;)V
-	public synthetic fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;Z)V
+	public synthetic fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCaptureLogcat ()Z
 	public final fun getDrawableConverter ()Lcom/posthog/android/replay/PostHogDrawableConverter;
 	public final fun getMaskAllImages ()Z
 	public final fun getMaskAllTextInputs ()Z
+	public final fun getScreenshot ()Z
 	public final fun setCaptureLogcat (Z)V
 	public final fun setDrawableConverter (Lcom/posthog/android/replay/PostHogDrawableConverter;)V
 	public final fun setMaskAllImages (Z)V
 	public final fun setMaskAllTextInputs (Z)V
+	public final fun setScreenshot (Z)V
 }
 
 public class com/posthog/android/replay/internal/LogLine {

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -48,14 +48,16 @@ public final class com/posthog/android/replay/PostHogReplayIntegration : com/pos
 
 public final class com/posthog/android/replay/PostHogSessionReplayConfig {
 	public fun <init> ()V
-	public fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;Z)V
-	public synthetic fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ZJ)V
+	public synthetic fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCaptureLogcat ()Z
+	public final fun getDebouncerDelayMs ()J
 	public final fun getDrawableConverter ()Lcom/posthog/android/replay/PostHogDrawableConverter;
 	public final fun getMaskAllImages ()Z
 	public final fun getMaskAllTextInputs ()Z
 	public final fun getScreenshot ()Z
 	public final fun setCaptureLogcat (Z)V
+	public final fun setDebouncerDelayMs (J)V
 	public final fun setDrawableConverter (Lcom/posthog/android/replay/PostHogDrawableConverter;)V
 	public final fun setMaskAllImages (Z)V
 	public final fun setMaskAllTextInputs (Z)V

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -116,7 +116,11 @@ public class PostHogReplayIntegration(
                             window.onDecorViewReady { decorView ->
                                 try {
                                     val listener =
-                                        decorView.onNextDraw(mainHandler, config.dateProvider) {
+                                        decorView.onNextDraw(
+                                            mainHandler,
+                                            config.dateProvider,
+                                            config.sessionReplayConfig.debouncerDelayMs,
+                                        ) {
                                             if (!isSessionReplayEnabled) {
                                                 return@onNextDraw
                                             }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -460,7 +460,7 @@ public class PostHogReplayIntegration(
                 y = y,
                 width = width,
                 height = height,
-                type = "image",
+                type = "screenshot",
                 base64 = base64,
                 style = RRStyle(),
             )

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -305,7 +305,7 @@ public class PostHogReplayIntegration(
         val wireframe = view.toWireframe(window) ?: return
 
         // if the decorView has no backgroundColor, we use the theme color
-        if (wireframe.style?.backgroundColor == null) {
+        if (wireframe.style?.backgroundColor == null && !config.sessionReplayConfig.screenshot) {
             context.theme?.toRGBColor()?.let {
                 wireframe.style?.backgroundColor = it
             }
@@ -398,6 +398,7 @@ public class PostHogReplayIntegration(
         status.lastSnapshot = wireframe
     }
 
+    // PixelCopy is only API >= 24 but this is already protected by the isSupported method
     @SuppressLint("NewApi")
     private fun View.toWireframe(
         window: Window,

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -430,6 +430,7 @@ public class PostHogReplayIntegration(
             val thread = HandlerThread("PostHogReplayScreenshot")
             thread.start()
 
+            // unfortunately we cannot use the Looper.myLooper() because it will be null
             val handler = Handler(thread.looper)
 
             try {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -305,6 +305,7 @@ public class PostHogReplayIntegration(
         val wireframe = view.toWireframe(window) ?: return
 
         // if the decorView has no backgroundColor, we use the theme color
+        // no need to do this if we are capturing a screenshot
         if (wireframe.style?.backgroundColor == null && !config.sessionReplayConfig.screenshot) {
             context.theme?.toRGBColor()?.let {
                 wireframe.style?.backgroundColor = it

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -431,15 +431,20 @@ public class PostHogReplayIntegration(
             val handler = Handler(thread.looper)
 
             try {
+                var success = false
                 PixelCopy.request(window, bitmap, { copyResult ->
                     if (copyResult == PixelCopy.SUCCESS) {
-                        base64 = bitmap.base64()
+                        success = true
                     }
                     latch.countDown()
                 }, handler)
 
                 // await for 1s max
                 latch.await(1000, TimeUnit.MILLISECONDS)
+
+                if (success) {
+                    base64 = bitmap.base64()
+                }
             } catch (e: Throwable) {
                 config.logger.log("Session Replay PixelCopy failed: $e.")
             } finally {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
@@ -29,6 +29,11 @@ public class PostHogSessionReplayConfig(
      */
     @PostHogExperimental
     public var drawableConverter: PostHogDrawableConverter? = null,
+    /**
+     * By default Session replay will capture all the views on the screen as a wireframe,
+     * By enabling this option, PostHog will capture the screenshot of the screen.
+     * The screenshot may contain sensitive information, use with caution.
+     */
     @PostHogExperimental
     public var screenshot: Boolean = false,
 )

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
@@ -6,12 +6,14 @@ import com.posthog.PostHogExperimental
 public class PostHogSessionReplayConfig(
     /**
      * Enable masking of all text input fields
+     * This is ignored if the [screenshot] option is enabled
      * Defaults to true
      */
     @PostHogExperimental
     public var maskAllTextInputs: Boolean = true,
     /**
      * Enable masking of all images to a placeholder
+     * This is ignored if the [screenshot] option is enabled
      * Defaults to true
      */
     @PostHogExperimental
@@ -36,4 +38,12 @@ public class PostHogSessionReplayConfig(
      */
     @PostHogExperimental
     public var screenshot: Boolean = false,
+    /**
+     * Deboucer delay used to reduce the number of snapshots captured and reduce performance impact
+     * This is used for capturing the view as a wireframe or screenshot
+     * The lower the number more snapshots will be captured but higher the performance impact
+     * Defaults to 500ms
+     */
+    @PostHogExperimental
+    public var debouncerDelayMs: Long = 500,
 )

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
@@ -29,4 +29,6 @@ public class PostHogSessionReplayConfig(
      */
     @PostHogExperimental
     public var drawableConverter: PostHogDrawableConverter? = null,
+    @PostHogExperimental
+    public var screenshot: Boolean = false,
 )

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/Debouncer.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/Debouncer.kt
@@ -8,9 +8,10 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class Debouncer(
     private val mainHandler: MainHandler,
     private val dateProvider: PostHogDateProvider,
+    private val debouncerDelayMs: Long,
 ) {
     private var lastCall = 0L
-    private val delayNs = TimeUnit.MILLISECONDS.toNanos(DELAY_MS)
+    private val delayNs = TimeUnit.MILLISECONDS.toNanos(debouncerDelayMs)
     private val hasPendingRunnable = AtomicBoolean(false)
 
     /**
@@ -34,7 +35,7 @@ internal class Debouncer(
                     } finally {
                         hasPendingRunnable.set(false)
                     }
-                }, DELAY_MS)
+                }, debouncerDelayMs)
             }
         }
     }
@@ -42,9 +43,5 @@ internal class Debouncer(
     private fun execute(runnable: Runnable) {
         runnable.run()
         lastCall = dateProvider.nanoTime()
-    }
-
-    companion object {
-        private const val DELAY_MS = 500L
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
@@ -12,9 +12,10 @@ internal class NextDrawListener(
     private val view: View,
     mainHandler: MainHandler,
     dateProvider: PostHogDateProvider,
+    debouncerDelayMs: Long,
     private val onDrawCallback: () -> Unit,
 ) : ViewTreeObserver.OnDrawListener {
-    private val debounce = Debouncer(mainHandler, dateProvider)
+    private val debounce = Debouncer(mainHandler, dateProvider, debouncerDelayMs)
 
     override fun onDraw() {
         debounce.debounce {
@@ -38,9 +39,10 @@ internal class NextDrawListener(
         internal fun View.onNextDraw(
             mainHandler: MainHandler,
             dateProvider: PostHogDateProvider,
+            debouncerDelayMs: Long,
             onDrawCallback: () -> Unit,
         ): NextDrawListener {
-            val nextDrawListener = NextDrawListener(this, mainHandler, dateProvider, onDrawCallback)
+            val nextDrawListener = NextDrawListener(this, mainHandler, dateProvider, debouncerDelayMs, onDrawCallback)
             nextDrawListener.safelyRegisterForNextDraw()
             return nextDrawListener
         }

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -25,8 +25,8 @@ class MyApp : Application() {
                 debug = true
                 flushAt = 1
                 captureDeepLinks = false
-                captureApplicationLifecycleEvents = true
-                captureScreenViews = true
+                captureApplicationLifecycleEvents = false
+                captureScreenViews = false
                 sessionReplay = true
                 preloadFeatureFlags = true
                 onFeatureFlags = PostHogOnFeatureFlags { print("feature flags loaded") }
@@ -38,7 +38,8 @@ class MyApp : Application() {
                     }
                 sessionReplayConfig.maskAllTextInputs = false
                 sessionReplayConfig.maskAllImages = false
-                sessionReplayConfig.captureLogcat = true
+                sessionReplayConfig.captureLogcat = false
+                sessionReplayConfig.screenshot = true
             }
         PostHogAndroid.setup(this, config)
     }

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -25,8 +25,8 @@ class MyApp : Application() {
                 debug = true
                 flushAt = 1
                 captureDeepLinks = false
-                captureApplicationLifecycleEvents = true
-                captureScreenViews = true
+                captureApplicationLifecycleEvents = false
+                captureScreenViews = false
                 sessionReplay = true
                 preloadFeatureFlags = true
                 onFeatureFlags = PostHogOnFeatureFlags { print("feature flags loaded") }

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -25,8 +25,8 @@ class MyApp : Application() {
                 debug = true
                 flushAt = 1
                 captureDeepLinks = false
-                captureApplicationLifecycleEvents = false
-                captureScreenViews = false
+                captureApplicationLifecycleEvents = true
+                captureScreenViews = true
                 sessionReplay = true
                 preloadFeatureFlags = true
                 onFeatureFlags = PostHogOnFeatureFlags { print("feature flags loaded") }
@@ -38,7 +38,7 @@ class MyApp : Application() {
                     }
                 sessionReplayConfig.maskAllTextInputs = false
                 sessionReplayConfig.maskAllImages = false
-                sessionReplayConfig.captureLogcat = false
+                sessionReplayConfig.captureLogcat = true
                 sessionReplayConfig.screenshot = true
             }
         PostHogAndroid.setup(this, config)

--- a/posthog/src/main/java/com/posthog/internal/replay/RRWireframe.kt
+++ b/posthog/src/main/java/com/posthog/internal/replay/RRWireframe.kt
@@ -13,7 +13,7 @@ public data class RRWireframe(
     public val width: Int,
     public val height: Int,
     public val childWireframes: List<RRWireframe>? = null,
-    // text|image|rectangle|input|div
+    // text|image|rectangle|input|div|screenshot
     public val type: String? = null,
     // checkbox|radio|text|password|email|number|search|tel|url|select|textarea|button
     public val inputType: String? = null,


### PR DESCRIPTION
## :bulb: Motivation and Context
Adds a screenshot with high-fidelity UI instead of the wireframe option.
Adds more overhead to the app.
Enables Session replay for apps using Jetpack Compose.

The mutation updates seem to be buggy, waiting for @pauldambra so we can pair up on that, won't merge before this.


## :green_heart: How did you test it?
Running the sample and some open source apps

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
