### PR TITLE
fix: reduce batch size if API returns 413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Next
 
+## 3.2.1 - 2024-05-08
+
+- fix: reduce batch size if API returns 413 ([#127](https://github.com/PostHog/posthog-android/pull/127))
+  - `screenshot` image is now a JPEG at 30% quality to reduce size
+
 ## 3.2.0 - 2024-04-30
 
 - recording: add `screenshot` option for session replay instead of wireframe ([#127](https://github.com/PostHog/posthog-android/pull/127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.2.1 - 2024-05-08
 
-- fix: reduce batch size if API returns 413 ([#127](https://github.com/PostHog/posthog-android/pull/127))
+- fix: reduce batch size if API returns 413 ([#130](https://github.com/PostHog/posthog-android/pull/130))
   - `screenshot` image is now a JPEG at 30% quality to reduce size
 
 ## 3.2.0 - 2024-04-30

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -25,7 +25,7 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.core:core than 1.5.0 is available: 1.13.0"
+        message="A newer version of androidx.core:core than 1.5.0 is available: 1.13.1"
         errorLine1="    implementation(&quot;androidx.core:core:${PosthogBuildConfig.Dependencies.ANDROIDX_CORE}&quot;)"
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -805,9 +805,11 @@ public class PostHogReplayIntegration(
         }
 
         ByteArrayOutputStream(allocationByteCount).use {
-            compress(Bitmap.CompressFormat.PNG, 30, it)
+            // we can make format and type configurable
+            compress(Bitmap.CompressFormat.JPEG, 30, it)
             val byteArray = it.toByteArray()
-            return Base64.encodeToString(byteArray, Base64.DEFAULT)
+            val encoded = Base64.encodeToString(byteArray, Base64.DEFAULT) ?: return null
+            return "data:image/jpeg;base64,$encoded"
         }
     }
 

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -23,7 +23,7 @@ class MyApp : Application() {
         val config =
             PostHogAndroidConfig(apiKey).apply {
                 debug = true
-                flushAt = 1
+//                flushAt = 1
                 captureDeepLinks = false
                 captureApplicationLifecycleEvents = false
                 captureScreenViews = false

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -23,7 +23,7 @@ class MyApp : Application() {
         val config =
             PostHogAndroidConfig(apiKey).apply {
                 debug = true
-//                flushAt = 1
+                flushAt = 1
                 captureDeepLinks = false
                 captureApplicationLifecycleEvents = false
                 captureScreenViews = false

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -5,7 +5,6 @@ import com.posthog.PostHogEvent
 import com.posthog.PostHogVisibleForTesting
 import java.io.File
 import java.io.IOException
-import java.lang.Math.floorDiv
 import java.util.Date
 import java.util.Timer
 import java.util.TimerTask
@@ -318,7 +317,7 @@ internal class PostHogQueue(
 }
 
 private fun calcFloor(currentValue: Int): Int {
-    return max(floorDiv(currentValue, 2), 1)
+    return max(currentValue.floorDiv(2), 1)
 }
 
 internal fun deleteFilesIfAPIError(

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -5,6 +5,7 @@ import com.posthog.PostHogEvent
 import com.posthog.PostHogVisibleForTesting
 import java.io.File
 import java.io.IOException
+import java.lang.Math.floorDiv
 import java.util.Date
 import java.util.Timer
 import java.util.TimerTask
@@ -12,6 +13,7 @@ import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.schedule
+import kotlin.math.max
 import kotlin.math.min
 
 /**
@@ -189,9 +191,8 @@ internal class PostHogQueue(
                 }
             }
         } catch (e: PostHogApiError) {
-            if (e.statusCode < 400) {
-                deleteFiles = false
-            }
+            deleteFiles = deleteFilesIfAPIError(e, config)
+
             throw e
         } catch (e: IOException) {
             // no connection should try again
@@ -210,6 +211,10 @@ internal class PostHogQueue(
                 }
             }
         }
+    }
+
+    private fun calcFloor(currentValue: Int): Int {
+        return max(floorDiv(currentValue, 2), 1)
     }
 
     fun flush() {
@@ -314,4 +319,27 @@ internal class PostHogQueue(
             }
             return tempFiles
         }
+}
+
+private fun calcFloor(currentValue: Int): Int {
+    return max(floorDiv(currentValue, 2), 1)
+}
+
+internal fun deleteFilesIfAPIError(
+    e: PostHogApiError,
+    config: PostHogConfig,
+): Boolean {
+    if (e.statusCode < 400) {
+        return false
+    }
+    // workaround due to png images exceed our max. limit in kafka
+    if (e.statusCode == 413 && config.maxBatchSize > 1) {
+        // try to reduce the batch size and flushAt until its 1
+        // and if it still throws 413 in the next retry, delete the files since we cannot handle anyway
+        config.maxBatchSize = calcFloor(config.maxBatchSize)
+        config.flushAt = calcFloor(config.flushAt)
+
+        return false
+    }
+    return true
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -213,10 +213,6 @@ internal class PostHogQueue(
         }
     }
 
-    private fun calcFloor(currentValue: Int): Int {
-        return max(floorDiv(currentValue, 2), 1)
-    }
-
     fun flush() {
         // only flushes if the queue is above the threshold (not empty in this case)
         if (!isAboveThreshold(1)) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogSendCachedEventsIntegration.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogSendCachedEventsIntegration.kt
@@ -186,9 +186,8 @@ internal class PostHogSendCachedEventsIntegration(
                                 PostHogApiEndpoint.SNAPSHOT -> api.snapshot(events)
                             }
                         } catch (e: PostHogApiError) {
-                            if (e.statusCode < 400) {
-                                deleteFiles = false
-                            }
+                            deleteFiles = deleteFilesIfAPIError(e, config)
+
                             throw e
                         } catch (e: IOException) {
                             // no connection should try again


### PR DESCRIPTION
## :bulb: Motivation and Context
Getting Flushing failed: PostHogApiError(statusCode=413, message=''). depending on the image size and batch size


## :green_heart: How did you test it?
Running and unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
