### PR TITLE
recording: fix removing the ViewTreeObserver when its not alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
-- allow anonymous uuid generation to be customizable ([#132](https://github.com/PostHog/posthog-android/pull/132))
+- feat: allow anonymous uuid generation to be customizable ([#132](https://github.com/PostHog/posthog-android/pull/132))
+- recording: fix removing the ViewTreeObserver when its not alive ([#132](https://github.com/PostHog/posthog-android/pull/132))
 
 ## 3.2.2 - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - feat: allow anonymous uuid generation to be customizable ([#132](https://github.com/PostHog/posthog-android/pull/132))
-- recording: fix removing the ViewTreeObserver when its not alive ([#132](https://github.com/PostHog/posthog-android/pull/132))
+- recording: fix removing the ViewTreeObserver when its not alive ([#134](https://github.com/PostHog/posthog-android/pull/134))
 
 ## 3.2.2 - 2024-05-21
 

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -254,6 +254,7 @@ public class PostHogReplayIntegration(
                 // Since the post might be executed a bit later if the thread is busy
                 if (isAliveAndAttached(view)) {
                     try {
+                        // swallow the exception because we still wanna remove it from the decorViews
                         view.viewTreeObserver?.removeOnDrawListener(status.listener)
                     } catch (e: Throwable) {
                         config.logger.log("Removing the viewTreeObserver failed: $e.")

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -52,6 +52,7 @@ import com.posthog.android.internal.displayMetrics
 import com.posthog.android.internal.screenSize
 import com.posthog.android.replay.internal.NextDrawListener.Companion.onNextDraw
 import com.posthog.android.replay.internal.ViewTreeSnapshotStatus
+import com.posthog.android.replay.internal.isAliveAndAttachedToWindow
 import com.posthog.internal.PostHogThreadFactory
 import com.posthog.internal.replay.RRCustomEvent
 import com.posthog.internal.replay.RREvent
@@ -247,12 +248,12 @@ public class PostHogReplayIntegration(
         view: View,
         status: ViewTreeSnapshotStatus,
     ) {
-        if (isAliveAndAttached(view)) {
+        if (view.isAliveAndAttachedToWindow()) {
             mainHandler.handler.post {
                 // 2nd check to avoid:
                 // Exception java.lang.IllegalStateException: This ViewTreeObserver is not alive
                 // Since the post might be executed a bit later if the thread is busy
-                if (isAliveAndAttached(view)) {
+                if (view.isAliveAndAttachedToWindow()) {
                     try {
                         // swallow the exception because we still wanna remove it from the decorViews
                         view.viewTreeObserver?.removeOnDrawListener(status.listener)
@@ -268,10 +269,6 @@ public class PostHogReplayIntegration(
         }
 
         decorViews.remove(view)
-    }
-
-    private fun isAliveAndAttached(view: View): Boolean {
-        return view.viewTreeObserver?.isAlive == true && view.isAttachedToWindow
     }
 
     override fun install() {

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
@@ -2,7 +2,6 @@
 
 package com.posthog.android.replay.internal
 
-import android.os.Build
 import android.view.View
 import android.view.ViewTreeObserver
 import com.posthog.android.internal.MainHandler
@@ -24,13 +23,8 @@ internal class NextDrawListener(
     }
 
     private fun safelyRegisterForNextDraw() {
-        // Prior to API 26, OnDrawListener wasn't merged back from the floating ViewTreeObserver into
-        // the real ViewTreeObserver.
-        // https://android.googlesource.com/platform/frameworks/base/+/9f8ec54244a5e0343b9748db3329733f259604f3
-        view.viewTreeObserver?.let { viewTreeObserver ->
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O || (viewTreeObserver.isAlive && view.isAttachedToWindow)) {
-                viewTreeObserver.addOnDrawListener(this)
-            }
+        if (view.isAliveAndAttachedToWindow()) {
+            view.viewTreeObserver?.addOnDrawListener(this)
         }
     }
 
@@ -47,4 +41,11 @@ internal class NextDrawListener(
             return nextDrawListener
         }
     }
+}
+
+internal fun View.isAliveAndAttachedToWindow(): Boolean {
+    // Prior to API 26, OnDrawListener wasn't merged back from the floating ViewTreeObserver into
+    // the real ViewTreeObserver.
+    // https://android.googlesource.com/platform/frameworks/base/+/9f8ec54244a5e0343b9748db3329733f259604f3
+    return viewTreeObserver?.isAlive == true && isAttachedToWindow
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
Fixes https://github.com/PostHog/posthog-android/issues/133


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
