### PR TITLE
recording: fix registering the ViewTreeObserver when its not attached yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - chore: migrate UUID from v4 to v7 ([#142](https://github.com/PostHog/posthog-android/pull/142))
-- recording: fix registering the ViewTreeObserver when its not attached yet ([#134](https://github.com/PostHog/posthog-android/pull/134))
+- recording: fix registering the ViewTreeObserver when its not attached yet ([#144](https://github.com/PostHog/posthog-android/pull/144))
 
 ## 3.3.1 - 2024-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - chore: migrate UUID from v4 to v7 ([#142](https://github.com/PostHog/posthog-android/pull/142))
+- recording: fix registering the ViewTreeObserver when its not attached yet ([#134](https://github.com/PostHog/posthog-android/pull/134))
 
 ## 3.3.1 - 2024-06-11
 

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
@@ -23,7 +23,7 @@ internal class NextDrawListener(
     }
 
     private fun safelyRegisterForNextDraw() {
-        if (view.isAliveAndAttachedToWindow()) {
+        if (view.isAlive()) {
             view.viewTreeObserver?.addOnDrawListener(this)
         }
     }
@@ -47,5 +47,9 @@ internal fun View.isAliveAndAttachedToWindow(): Boolean {
     // Prior to API 26, OnDrawListener wasn't merged back from the floating ViewTreeObserver into
     // the real ViewTreeObserver.
     // https://android.googlesource.com/platform/frameworks/base/+/9f8ec54244a5e0343b9748db3329733f259604f3
-    return viewTreeObserver?.isAlive == true && isAttachedToWindow
+    return isAlive() && isAttachedToWindow
+}
+
+internal fun View.isAlive(): Boolean {
+    return viewTreeObserver?.isAlive == true
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
sometimes the SDK inits so early that the view isn't attached yet.


## :green_heart: How did you test it?
running and debugging before view is attached

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
