### PR TITLE
recording: OnTouchEventListener try catch guard to swallow unexpected errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: `OnTouchEventListener` try catch guard to swallow unexpected errors ([#145](https://github.com/PostHog/posthog-android/pull/145))
+
 ## 3.4.0 - 2024-06-20
 
 - chore: screenshot masking ([#145](https://github.com/PostHog/posthog-android/pull/145))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- recording: `OnTouchEventListener` try catch guard to swallow unexpected errors ([#145](https://github.com/PostHog/posthog-android/pull/145))
+- recording: `OnTouchEventListener` try catch guard to swallow unexpected errors ([#147](https://github.com/PostHog/posthog-android/pull/147))
 
 ## 3.4.0 - 2024-06-20
 

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -203,22 +203,21 @@ public class PostHogReplayIntegration(
 
     private val onTouchEventListener =
         OnTouchEventListener { motionEvent ->
-            if (!isSessionReplayEnabled) {
-                return@OnTouchEventListener
-            }
-            motionEvent.eventTime
-            val timestamp = config.dateProvider.currentTimeMillis()
-            when (motionEvent.action.and(MotionEvent.ACTION_MASK)) {
-                MotionEvent.ACTION_DOWN -> {
-                    generateMouseInteractions(timestamp, motionEvent, RRMouseInteraction.TouchStart)
+            try {
+                if (!isSessionReplayEnabled) {
+                    return@OnTouchEventListener
                 }
-                MotionEvent.ACTION_UP -> {
-                    generateMouseInteractions(timestamp, motionEvent, RRMouseInteraction.TouchEnd)
+                val timestamp = config.dateProvider.currentTimeMillis()
+                when (motionEvent.action.and(MotionEvent.ACTION_MASK)) {
+                    MotionEvent.ACTION_DOWN -> {
+                        generateMouseInteractions(timestamp, motionEvent, RRMouseInteraction.TouchStart)
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        generateMouseInteractions(timestamp, motionEvent, RRMouseInteraction.TouchEnd)
+                    }
                 }
-                // TODO: ACTION_MOVE requires the positions arrays caching since it triggers multiple times
-//            MotionEvent.ACTION_MOVE -> {
-//                generateMouseInteractions(timestamp, motionEvent, RRMouseInteraction.TouchMoveDeparted)
-//            }
+            } catch (e: Throwable) {
+                config.logger.log("OnTouchEventListener $motionEvent failed: $e.")
             }
         }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Events from https://play.google.com/sdk-console v3.3.1

### 1

Exception java.lang.IllegalStateException: Fragment already added
  at androidx.fragment.app.Fragment.setInitialSavedState (Fragment.java:833)
  at <private>
  at android.view.View.layout (View.java:24475)
  at android.view.ViewGroup.layout (ViewGroup.java:7383)
  at <private>
  at android.view.View.layout (View.java:24475)
  at android.view.ViewGroup.layout (ViewGroup.java:7383)
  at <private>
  at android.view.View.layout (View.java:24475)
  at android.view.ViewGroup.layout (ViewGroup.java:7383)
  at <private>
  at android.view.View.layout (View.java:24475)
  at android.view.ViewGroup.layout (ViewGroup.java:7383)
  at android.widget.FrameLayout.layoutChildren (FrameLayout.java:332)
  at android.widget.FrameLayout.onLayout (FrameLayout.java:270)
  at android.view.View.layout (View.java:24475)
  at android.view.ViewGroup.layout (ViewGroup.java:7383)
  at <private>
  at android.view.View.dispatchTouchEvent (View.java:15199)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3914)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3578)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at android.view.ViewGroup.dispatchTransformedTouchEvent (ViewGroup.java:3920)
  at android.view.ViewGroup.dispatchTouchEvent (ViewGroup.java:3594)
  at com.android.internal.policy.DecorView.superDispatchTouchEvent (DecorView.java:913)
  at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent (PhoneWindow.java:1957)
  at android.app.Activity.dispatchTouchEvent (Activity.java:4182)
  at <private>
  at curtains.internal.WindowCallbackWrapper$dispatchTouchEvent$dispatch$1.invoke (WindowCallbackWrapper.kt:58)
  at curtains.internal.WindowCallbackWrapper$dispatchTouchEvent$dispatch$1.invoke (WindowCallbackWrapper.kt:52)
  at curtains.OnTouchEventListener$DefaultImpls.intercept (OnTouchEventListener.java:96)
  at com.posthog.android.replay.PostHogReplayIntegration$onTouchEventListener$1.intercept (PostHogReplayIntegration.kt:195)
  at curtains.internal.WindowCallbackWrapper.dispatchTouchEvent (WindowCallbackWrapper.kt:65)
  at com.android.internal.policy.DecorView.dispatchTouchEvent (DecorView.java:871)
  at android.view.View.dispatchPointerEvent (View.java:15458)
  at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent (ViewRootImpl.java:7457)
  at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess (ViewRootImpl.java:7233)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:6595)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:6652)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:6618)
  at android.view.ViewRootImpl$AsyncInputStage.forward (ViewRootImpl.java:6786)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:6626)
  at android.view.ViewRootImpl$AsyncInputStage.apply (ViewRootImpl.java:6843)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:6599)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:6652)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:6618)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:6626)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:6599)
  at android.view.ViewRootImpl.deliverInputEvent (ViewRootImpl.java:9880)
  at android.view.ViewRootImpl.doProcessInputEvents (ViewRootImpl.java:9718)
  at android.view.ViewRootImpl.enqueueInputEvent (ViewRootImpl.java:9671)
  at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent (ViewRootImpl.java:10014)
  at android.view.InputEventReceiver.dispatchInputEvent (InputEventReceiver.java:220)
  at android.view.InputEventReceiver.nativeConsumeBatchedInputEvents
  at android.view.InputEventReceiver.consumeBatchedInputEvents (InputEventReceiver.java:200)
  at android.view.ViewRootImpl.doConsumeBatchedInput (ViewRootImpl.java:9960)
  at android.view.ViewRootImpl$ConsumeBatchedInputRunnable.run (ViewRootImpl.java:10056)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1010)
  at android.view.Choreographer.doCallbacks (Choreographer.java:809)
  at android.view.Choreographer.doFrame (Choreographer.java:737)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:995)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:246)
  at android.app.ActivityThread.main (ActivityThread.java:8625)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:602)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1130)

### 2

"main" tid=1 Native
  #00  pc 0x000000000009eeb8  /apex/com.android.runtime/lib64/bionic/libc.so (fsync+8)
  #01  pc 0x0000000000004700  /apex/com.android.art/lib64/libopenjdkjvm.so (JVM_Sync+20)
  #02  pc 0x0000000000022404  /apex/com.android.art/lib64/libopenjdk.so (FileDescriptor_sync+40)
  #03  pc 0x0000000000351e30  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144)
  #04  pc 0x00000000005b9930  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
  #05  pc 0x000000000043c654  /system/framework/framework.jar (android.os.FileUtils.sync+12)
  at <private>
  #07  pc 0x00000000005ba754  /apex/com.android.art/lib64/libart.so (nterp_helper+7636)
  at <private>
  #09  pc 0x00000000005b98d4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  at <private>
  #11  pc 0x00000000005b98d4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  at <private>
  #13  pc 0x00000000005badcc  /apex/com.android.art/lib64/libart.so (nterp_helper+9292)
  at <private>
  #15  pc 0x00000000005badcc  /apex/com.android.art/lib64/libart.so (nterp_helper+9292)
  at <private>
  #17  pc 0x00000000005b98d4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  at <private>
  #19  pc 0x00000000005ba6f4  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  at <private>
  #21  pc 0x00000000005b89b4  /apex/com.android.art/lib64/libart.so (nterp_helper+52)
  at <private>
  #23  pc 0x00000000005ba6f4  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  at <private>
  #25  pc 0x00000000005badcc  /apex/com.android.art/lib64/libart.so (nterp_helper+9292)
  at <private>
  #27  pc 0x000000000033b3a4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
  #28  pc 0x0000000000339404  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithVarArgs<art::ArtMethod*>+772)
  #29  pc 0x0000000000560eb8  /apex/com.android.art/lib64/libart.so (art::JNI<false>::CallVoidMethodV+192)
  #30  pc 0x00000000000af5e8  /system/lib64/libandroid_runtime.so (_JNIEnv::CallVoidMethod+120)
  #31  pc 0x0000000000119e2c  /system/lib64/libandroid_runtime.so (android::NativeInputEventReceiver::consumeEvents+364)
  #32  pc 0x0000000000119bec  /system/lib64/libandroid_runtime.so (android::NativeInputEventReceiver::handleEvent+180)
  #33  pc 0x0000000000016bb0  /system/lib64/libutils.so (android::Looper::pollInner+912)
  #34  pc 0x00000000000167b8  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #35  pc 0x000000000014e3ec  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  #36  pc 0x0000000000351e30  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144)
  at <private>
  #38  pc 0x000000000033b680  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #39  pc 0x000000000037cb18  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<8>+1556)
  #40  pc 0x000000000037c4f4  /apex/com.android.art/lib64/libart.so (art::Method_invoke +32)
  #41  pc 0x0000000000351e30  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144)
  at <private>
  #43  pc 0x00000000005ba754  /apex/com.android.art/lib64/libart.so (nterp_helper+7636)
  #44  pc 0x0000000000268480  /system/framework/framework.jar (com.android.internal.os.ZygoteInit.main+632)
  #45  pc 0x000000000033b680  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #46  pc 0x00000000004e2a90  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>+728)
  #47  pc 0x000000000057ab18  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV+156)
  #48  pc 0x00000000000b0b28  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod+120)
  #49  pc 0x00000000000bc22c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start+948)
  #50  pc 0x0000000000002580  /system/bin/app_process64 (main+1320)
  #51  pc 0x00000000000489e0  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+96)
  at java.io.FileDescriptor.sync (Native method)
  at android.os.FileUtils.sync (FileUtils.java:256)
  at android.app.SharedPreferencesImpl.writeToFile (SharedPreferencesImpl.java:807)
  at android.app.SharedPreferencesImpl.access$900 (SharedPreferencesImpl.java:59)
  at android.app.SharedPreferencesImpl$2.run (SharedPreferencesImpl.java:672)
  at android.app.SharedPreferencesImpl.enqueueDiskWrite (SharedPreferencesImpl.java:691)
  at android.app.SharedPreferencesImpl.access$100 (SharedPreferencesImpl.java:59)
  at android.app.SharedPreferencesImpl$EditorImpl.commit (SharedPreferencesImpl.java:604)
  at <private>
  at android.app.Activity.dispatchTouchEvent (Activity.java:4241)
  at <private>
  at curtains.internal.WindowCallbackWrapper$dispatchTouchEvent$dispatch$1.invoke (WindowCallbackWrapper.kt:1)
  at curtains.internal.WindowCallbackWrapper$dispatchTouchEvent$dispatch$1.invoke (WindowCallbackWrapper.kt:1)
  at curtains.OnTouchEventListener$DefaultImpls.intercept (Listeners.kt:1)
  at com.posthog.android.replay.PostHogReplayIntegration$onTouchEventListener$1.intercept (PostHogReplayIntegration.kt:1)
  at curtains.internal.WindowCallbackWrapper.dispatchTouchEvent (WindowCallbackWrapper.kt:1)
  at com.microsoft.clarity.g.g$b.dispatchTouchEvent (SourceFile:1)
  at com.android.internal.policy.DecorView.dispatchTouchEvent (DecorView.java:475)
  at android.view.View.dispatchPointerEvent (View.java:14853)
  at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent (ViewRootImpl.java:6785)
  at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess (ViewRootImpl.java:6567)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:6041)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:6098)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:6064)
  at android.view.ViewRootImpl$AsyncInputStage.forward (ViewRootImpl.java:6229)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:6072)
  at android.view.ViewRootImpl$AsyncInputStage.apply (ViewRootImpl.java:6286)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:6045)
  at android.view.ViewRootImpl$InputStage.onDeliverToNext (ViewRootImpl.java:6098)
  at android.view.ViewRootImpl$InputStage.forward (ViewRootImpl.java:6064)
  at android.view.ViewRootImpl$InputStage.apply (ViewRootImpl.java:6072)
  at android.view.ViewRootImpl$InputStage.deliver (ViewRootImpl.java:6045)
  at android.view.ViewRootImpl.deliverInputEvent (ViewRootImpl.java:9124)
  at android.view.ViewRootImpl.doProcessInputEvents (ViewRootImpl.java:9064)
  at android.view.ViewRootImpl.enqueueInputEvent (ViewRootImpl.java:9019)
  at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent (ViewRootImpl.java:9256)
  at android.view.InputEventReceiver.dispatchInputEvent (InputEventReceiver.java:259)
  at android.os.MessageQueue.nativePollOnce (Native method)
  at android.os.MessageQueue.next (MessageQueue.java:335)
  at android.os.Looper.loopOnce (Looper.java:195)
  at android.os.Looper.loop (Looper.java:342)
  at android.app.ActivityThread.main (ActivityThread.java:8143)
  at java.lang.reflect.Method.invoke (Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:583)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1045)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
