### PR TITLE
- recording: mask views with contentDescription setting and mask WebView if any masking is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: mask views with `contentDescription` setting and mask `WebView` if any masking is enabled ([#149](https://github.com/PostHog/posthog-android/pull/149))
+
 ## 3.4.2 - 2024-06-28
 
 - chore: create ctor overloads for better Java DX ([#148](https://github.com/PostHog/posthog-android/pull/148))

--- a/USAGE.md
+++ b/USAGE.md
@@ -219,7 +219,7 @@ val config = PostHogAndroidConfig(apiKey).apply {
 }
 ```
 
-If you don't want to mask everything, you can disable the mask config above and mask specific views using the `ph-no-capture` tag.
+If you don't want to mask everything, you can disable the mask config above and mask specific views using the `ph-no-capture` value in the [android:tag](https://developer.android.com/reference/android/view/View#attr_android:tag) or [android:contentDescription](https://developer.android.com/reference/android/view/View#attr_android:contentDescription)..
 
 ```xml
 <ImageView

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -46,7 +46,6 @@ public abstract interface class com/posthog/android/replay/PostHogDrawableConver
 }
 
 public final class com/posthog/android/replay/PostHogReplayIntegration : com/posthog/PostHogIntegration {
-	public static final field PH_NO_CAPTURE_LABEL Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;Lcom/posthog/android/PostHogAndroidConfig;Lcom/posthog/android/internal/MainHandler;)V
 	public fun install ()V
 	public fun uninstall ()V

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -46,6 +46,7 @@ public abstract interface class com/posthog/android/replay/PostHogDrawableConver
 }
 
 public final class com/posthog/android/replay/PostHogReplayIntegration : com/posthog/PostHogIntegration {
+	public static final field PH_NO_CAPTURE_LABEL Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;Lcom/posthog/android/PostHogAndroidConfig;Lcom/posthog/android/internal/MainHandler;)V
 	public fun install ()V
 	public fun uninstall ()V

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogLifecycleObserverIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogLifecycleObserverIntegration.kt
@@ -30,7 +30,7 @@ internal class PostHogLifecycleObserverIntegration(
     private val lastUpdatedSession = AtomicLong(0L)
     private val sessionMaxInterval = (1000 * 60 * 30).toLong() // 30 minutes
 
-    companion object {
+    private companion object {
         // in case there are multiple instances or the SDK is closed/setup again
         // the value is still cached
         @JvmStatic

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -211,7 +211,7 @@ internal class PostHogSharedPreferences(
         return preferences
     }
 
-    companion object {
+    private companion object {
         private val SPECIAL_KEYS = listOf(GROUPS)
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -499,9 +499,7 @@ public class PostHogReplayIntegration(
         }
 
         if (view is Spinner) {
-            val maskIt = view.shouldMaskSpinner()
-
-            if (maskIt) {
+            if (view.shouldMaskSpinner()) {
                 val rect = view.globalVisibleRect()
                 maskableWidgets.add(rect)
                 return
@@ -509,9 +507,7 @@ public class PostHogReplayIntegration(
         }
 
         if (view is ImageView) {
-            val maskIt = view.shouldMaskImage()
-
-            if (maskIt) {
+            if (view.shouldMaskImage()) {
                 val rect = view.globalVisibleRect()
                 maskableWidgets.add(rect)
                 return
@@ -519,9 +515,7 @@ public class PostHogReplayIntegration(
         }
 
         if (view is WebView) {
-            val maskIt = view.isAnyInputSensitive()
-
-            if (maskIt) {
+            if (view.isAnyInputSensitive()) {
                 val rect = view.globalVisibleRect()
                 maskableWidgets.add(rect)
                 return

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -1149,6 +1149,6 @@ public class PostHogReplayIntegration(
     }
 
     private companion object {
-        const val PH_NO_CAPTURE_LABEL = "ph-no-capture"
+        private const val PH_NO_CAPTURE_LABEL = "ph-no-capture"
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
@@ -28,7 +28,7 @@ internal class NextDrawListener(
         }
     }
 
-    companion object {
+    internal companion object {
         // only call if onDecorViewReady
         internal fun View.onNextDraw(
             mainHandler: MainHandler,


### PR DESCRIPTION
## :bulb: Motivation and Context

Appium and friends may use `tag` or `content-desc` for finding/tagging elements
https://appium.readthedocs.io/en/stable/en/commands/element/find-elements/
https://reactnative.dev/docs/accessibility#accessibilitylabel syncs down to `content-desc` on Android

Masks webviews on Android screenshots


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
