### PR TITLE
fix: ensure activity name is used when activity label is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- fix: ensure activity name is used when activity label is not defined ([#153](https://github.com/PostHog/posthog-android/pull/153))
 - recording: mask views with `contentDescription` setting and mask `WebView` if any masking is enabled ([#149](https://github.com/PostHog/posthog-android/pull/149))
 
 ## 3.4.2 - 2024-06-28

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -51,7 +51,6 @@ internal class PostHogActivityLifecycleCallbackIntegration(
         }
     }
 
-
     override fun onActivityResumed(activity: Activity) {
     }
 

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -3,6 +3,7 @@ package com.posthog.android.internal
 import android.app.Activity
 import android.app.Application
 import android.app.Application.ActivityLifecycleCallbacks
+import android.content.pm.PackageManager.GET_META_DATA
 import android.os.Bundle
 import com.posthog.PostHog
 import com.posthog.PostHogIntegration
@@ -41,20 +42,15 @@ internal class PostHogActivityLifecycleCallbackIntegration(
         }
     }
 
-    override fun onActivityStarted(activity: Activity) {
-        if (config.captureScreenViews) {
-            val activityLabel = activity.activityLabel(config)
-            val screenName = if (!activityLabel.isNullOrEmpty()) {
-                activityLabel
-            } else {
-                activity.activityName(config)
-            }
+        override fun onActivityStarted(activity: Activity) {
+            if (config.captureScreenViews) {
+                val screenName = activity.activityLabelOrName(config)
 
-            if (!screenName.isNullOrEmpty()) {
-                PostHog.screen(screenName)
+                if (!screenName.isNullOrEmpty()) {
+                    PostHog.screen(screenName)
+                }
             }
         }
-    }
 
 
     override fun onActivityResumed(activity: Activity) {

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -44,11 +44,18 @@ internal class PostHogActivityLifecycleCallbackIntegration(
     override fun onActivityStarted(activity: Activity) {
         if (config.captureScreenViews) {
             val activityLabel = activity.activityLabel(config)
-            if (!activityLabel.isNullOrEmpty()) {
-                PostHog.screen(activityLabel)
+            val screenName = if (!activityLabel.isNullOrEmpty()) {
+                activityLabel
+            } else {
+                activity.activityName(config)
+            }
+
+            if (!screenName.isNullOrEmpty()) {
+                PostHog.screen(screenName)
             }
         }
     }
+
 
     override fun onActivityResumed(activity: Activity) {
     }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -41,15 +41,15 @@ internal class PostHogActivityLifecycleCallbackIntegration(
         }
     }
 
-        override fun onActivityStarted(activity: Activity) {
-            if (config.captureScreenViews) {
-                val screenName = activity.activityLabelOrName(config)
+    override fun onActivityStarted(activity: Activity) {
+        if (config.captureScreenViews) {
+            val screenName = activity.activityLabelOrName(config)
 
-                if (!screenName.isNullOrEmpty()) {
-                    PostHog.screen(screenName)
-                }
+            if (!screenName.isNullOrEmpty()) {
+                PostHog.screen(screenName)
             }
         }
+    }
 
 
     override fun onActivityResumed(activity: Activity) {

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -3,7 +3,6 @@ package com.posthog.android.internal
 import android.app.Activity
 import android.app.Application
 import android.app.Application.ActivityLifecycleCallbacks
-import android.content.pm.PackageManager.GET_META_DATA
 import android.os.Bundle
 import com.posthog.PostHog
 import com.posthog.PostHogIntegration

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -123,39 +123,19 @@ internal fun Context.telephonyManager(): TelephonyManager? {
 }
 
 @Suppress("DEPRECATION")
-internal fun Activity.activityLabel(config: PostHogAndroidConfig): String? {
+internal fun Activity.activityLabelOrName(config: PostHogAndroidConfig): String? {
     return try {
-        val packageManager = packageManager
-        val componentName = componentName
         val activityInfo = packageManager.getActivityInfo(componentName, GET_META_DATA)
-        val applicationInfo = applicationInfo
-
-        val activityLabel =
-            activityInfo.nonLocalizedLabel?.toString() ?: activityInfo.loadLabel(packageManager)
-                .toString()
-        val applicationLabel =
-            applicationInfo.nonLocalizedLabel?.toString() ?: applicationInfo.loadLabel(
-                packageManager
-            ).toString()
+        val activityLabel = activityInfo.loadLabel(packageManager).toString()
+        val applicationLabel = applicationInfo.loadLabel(packageManager).toString()
 
         if (activityLabel.isNotEmpty() && activityLabel != applicationLabel) {
             activityLabel
         } else {
-            null
+            activityInfo.name.substringAfterLast('.')
         }
     } catch (e: Throwable) {
-        config.logger.log("Error getting the Activity's label: $e.")
-        null
-    }
-}
-
-@Suppress("DEPRECATION")
-internal fun Activity.activityName(config: PostHogAndroidConfig): String? {
-    return try {
-        val info = packageManager.getActivityInfo(componentName, GET_META_DATA)
-        info.name.substringAfterLast('.')
-    } catch (e: Throwable) {
-        config.logger.log("Error getting the Activity's name: $e.")
+        config.logger.log("Error getting the Activity's label or name: $e.")
         null
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -125,10 +125,37 @@ internal fun Context.telephonyManager(): TelephonyManager? {
 @Suppress("DEPRECATION")
 internal fun Activity.activityLabel(config: PostHogAndroidConfig): String? {
     return try {
-        val info = packageManager.getActivityInfo(componentName, GET_META_DATA)
-        info.loadLabel(packageManager).toString()
+        val packageManager = packageManager
+        val componentName = componentName
+        val activityInfo = packageManager.getActivityInfo(componentName, GET_META_DATA)
+        val applicationInfo = applicationInfo
+
+        val activityLabel =
+            activityInfo.nonLocalizedLabel?.toString() ?: activityInfo.loadLabel(packageManager)
+                .toString()
+        val applicationLabel =
+            applicationInfo.nonLocalizedLabel?.toString() ?: applicationInfo.loadLabel(
+                packageManager
+            ).toString()
+
+        if (activityLabel.isNotEmpty() && activityLabel != applicationLabel) {
+            activityLabel
+        } else {
+            null
+        }
     } catch (e: Throwable) {
         config.logger.log("Error getting the Activity's label: $e.")
+        null
+    }
+}
+
+@Suppress("DEPRECATION")
+internal fun Activity.activityName(config: PostHogAndroidConfig): String? {
+    return try {
+        val info = packageManager.getActivityInfo(componentName, GET_META_DATA)
+        info.name.substringAfterLast('.')
+    } catch (e: Throwable) {
+        config.logger.log("Error getting the Activity's name: $e.")
         null
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/Utils.kt
+++ b/posthog-android/src/test/java/com/posthog/android/Utils.kt
@@ -40,19 +40,32 @@ public fun mockActivityUri(uri: String): Activity {
 public fun mockScreenTitle(
     throws: Boolean,
     title: String,
+    activityName: String,
+    applicationLabel: String
 ): Activity {
     val activity = mock<Activity>()
     val pm = mock<PackageManager>()
-    val ac = mock<ActivityInfo>()
+    val ac = mock<ActivityInfo>().apply {
+        name = activityName
+    }
+    val appInfo = mock<ApplicationInfo>()
+
     whenever(ac.loadLabel(any())).thenReturn(title)
+    whenever(appInfo.loadLabel(any())).thenReturn(applicationLabel)
+
     if (throws) {
         whenever(pm.getActivityInfo(any(), any<Int>())).thenThrow(PackageManager.NameNotFoundException())
     } else {
         whenever(pm.getActivityInfo(any(), any<Int>())).thenReturn(ac)
     }
+
+    whenever(pm.getApplicationInfo(any(), any<Int>())).thenReturn(appInfo)
+
     val component = mock<ComponentName>()
     whenever(activity.componentName).thenReturn(component)
     whenever(activity.packageManager).thenReturn(pm)
+    whenever(activity.applicationInfo).thenReturn(appInfo) // Ensure applicationInfo is not null
+
     return activity
 }
 

--- a/posthog-android/src/test/java/com/posthog/android/Utils.kt
+++ b/posthog-android/src/test/java/com/posthog/android/Utils.kt
@@ -41,13 +41,14 @@ public fun mockScreenTitle(
     throws: Boolean,
     title: String,
     activityName: String,
-    applicationLabel: String
+    applicationLabel: String,
 ): Activity {
     val activity = mock<Activity>()
     val pm = mock<PackageManager>()
-    val ac = mock<ActivityInfo>().apply {
-        name = activityName
-    }
+    val ac =
+        mock<ActivityInfo>().apply {
+            name = activityName
+        }
     val appInfo = mock<ApplicationInfo>()
 
     whenever(ac.loadLabel(any())).thenReturn(title)

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
@@ -107,9 +107,11 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
         captureScreenViews: Boolean = true,
         throws: Boolean = false,
         title: String = "Title",
+        activityName: String = "com.example.MyActivity",
+        applicationLabel: String = "AppLabel",
     ): PostHogFake {
         val sut = getSut(captureScreenViews = captureScreenViews)
-        val activity = mockScreenTitle(throws, title)
+        val activity = mockScreenTitle(throws, title, activityName, applicationLabel)
 
         val fake = createPostHogFake()
 
@@ -123,6 +125,17 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
         val fake = executeCaptureScreenViewsTest()
 
         assertEquals("Title", fake.screenTitle)
+    }
+
+    @Test
+    fun `onActivityStarted returns activityInfo name if labels are the same`() {
+        val fake = executeCaptureScreenViewsTest(
+            captureScreenViews = true,
+            title = "AppLabel",
+            activityName = "com.example.MyActivity",
+            applicationLabel = "AppLabel"
+        )
+        assertEquals("MyActivity", fake.screenTitle)
     }
 
     @Test
@@ -140,9 +153,9 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
     }
 
     @Test
-    fun `onActivityStarted does not capture if title is empty`() {
+    fun `onActivityStarted returns activity name if activity label are the empty`() {
         val fake = executeCaptureScreenViewsTest(title = "")
 
-        assertNull(fake.screenTitle)
+        assertEquals("MyActivity", fake.screenTitle)
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
@@ -129,12 +129,13 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
 
     @Test
     fun `onActivityStarted returns activityInfo name if labels are the same`() {
-        val fake = executeCaptureScreenViewsTest(
-            captureScreenViews = true,
-            title = "AppLabel",
-            activityName = "com.example.MyActivity",
-            applicationLabel = "AppLabel"
-        )
+        val fake =
+            executeCaptureScreenViewsTest(
+                captureScreenViews = true,
+                title = "AppLabel",
+                activityName = "com.example.MyActivity",
+                applicationLabel = "AppLabel",
+            )
         assertEquals("MyActivity", fake.screenTitle)
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The loadLabel method was loading the application label when an activity label was not defined. This change ensures that when an activity label is not defined, it defaults to the activity name instead of the application label. This improves the accuracy of screen name logging.

<!--- If it fixes an open issue, please link to the issue here. -->
fix #150 

## :green_heart: How did you test it?

- Unit tests were updated and run to verify the behavior of the new activityLabelOrName method.
- Additional test scenarios were added to ensure that the correct labels are returned when activity and application labels are the same or empty.
- Verified that existing tests pass without any issues.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
