### PR TITLE
feat: add emulator detection property to static context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- feat: add emulator detection property to static context ([#154](https://github.com/PostHog/posthog-android/pull/154))
 - fix: ensure activity name is used when activity label is not defined ([#153](https://github.com/PostHog/posthog-android/pull/153))
 - recording: mask views with `contentDescription` setting and mask `WebView` if any masking is enabled ([#149](https://github.com/PostHog/posthog-android/pull/149))
 

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -55,6 +55,8 @@ internal class PostHogAndroidContext(
         staticContext["\$lib"] = config.sdkName
         staticContext["\$lib_version"] = config.sdkVersion
 
+        staticContext["\$is_emulator"] = isEmulator
+
         staticContext
     }
 
@@ -170,4 +172,20 @@ internal class PostHogAndroidContext(
 
         return dynamicContext
     }
+
+    private val isEmulator: Boolean
+        get() = ((Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+                || Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.HARDWARE.contains("goldfish")
+                || Build.HARDWARE.contains("ranchu")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                || Build.MANUFACTURER.contains("Genymotion")
+                || Build.PRODUCT.contains("sdk")
+                || Build.PRODUCT.contains("vbox86p")
+                || Build.PRODUCT.contains("emulator")
+                || Build.PRODUCT.contains("simulator"))
+
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -173,19 +173,21 @@ internal class PostHogAndroidContext(
         return dynamicContext
     }
 
+    // Inspired from https://github.com/fluttercommunity/plus_plugins/blob/a71a27c5fbdbbfc56a30359a1aff0a3d3da8dc73/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt#L105-L123
     private val isEmulator: Boolean
-        get() = ((Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
-                || Build.FINGERPRINT.startsWith("generic")
-                || Build.FINGERPRINT.startsWith("unknown")
-                || Build.HARDWARE.contains("goldfish")
-                || Build.HARDWARE.contains("ranchu")
-                || Build.MODEL.contains("google_sdk")
-                || Build.MODEL.contains("Emulator")
-                || Build.MODEL.contains("Android SDK built for x86")
-                || Build.MANUFACTURER.contains("Genymotion")
-                || Build.PRODUCT.contains("sdk")
-                || Build.PRODUCT.contains("vbox86p")
-                || Build.PRODUCT.contains("emulator")
-                || Build.PRODUCT.contains("simulator"))
-
+        get() = (
+            (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")) ||
+                Build.FINGERPRINT.startsWith("generic") ||
+                Build.FINGERPRINT.startsWith("unknown") ||
+                Build.HARDWARE.contains("goldfish") ||
+                Build.HARDWARE.contains("ranchu") ||
+                Build.MODEL.contains("google_sdk") ||
+                Build.MODEL.contains("Emulator") ||
+                Build.MODEL.contains("Android SDK built for x86") ||
+                Build.MANUFACTURER.contains("Genymotion") ||
+                Build.PRODUCT.contains("sdk") ||
+                Build.PRODUCT.contains("vbox86p") ||
+                Build.PRODUCT.contains("emulator") ||
+                Build.PRODUCT.contains("simulator")
+        )
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
@@ -68,6 +68,8 @@ internal class PostHogAndroidContextTest {
 
         assertEquals(config.sdkName, staticContext["\$lib"])
         assertEquals(config.sdkVersion, staticContext["\$lib_version"])
+
+        assertNotNull(staticContext["\$is_emulator"])
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR adds emulator detection to the static context and updates the tests to verify this functionality.

- Implemented `isEmulator` method to detect if the app is running on an emulator.
- Integrated emulator detection into the static context cache.
- Added assertions to verify emulator detection in the static context.
- Ensured static context includes the new `\$is_emulator` property.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A crucial property for future use as a filter.

<!--- If it fixes an open issue, please link to the issue here. -->
#113 

## How Has This Been Tested?

The tests have been updated to include checks for the new `\$is_emulator` property in the static context.
I tested it manually on both an emulator and a physical device.

## Checklist
<!--- Put an `x` in all the boxes that apply -->

- [x] I have reviewed the submitted code.
- [x] I have added tests to verify the changes.
- [ ] I have updated the documentation if necessary.
- [x] No breaking changes or changes to the changelog entry.
