### PR TITLE
fix: returns simple acitvity name instead of full class name

### DIFF
--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -130,7 +130,11 @@ internal fun Activity.activityLabelOrName(config: PostHogAndroidConfig): String?
         val applicationLabel = applicationInfo.loadLabel(packageManager).toString()
 
         if (activityLabel.isNotEmpty() && activityLabel != applicationLabel) {
-            activityLabel
+            if (activityLabel == activityInfo.name) {
+                activityLabel.substringAfterLast('.')
+            } else {
+                activityLabel
+            }
         } else {
             activityInfo.name.substringAfterLast('.')
         }


### PR DESCRIPTION
## :bulb: Motivation and Context
Follow up https://github.com/PostHog/posthog-android/pull/153
If there's no label on the activity and app, the class name is returned with the full package name.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
