### PR TITLE
fix: maintain sdk name and version for flutter

### DIFF
--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -74,8 +74,12 @@ public class PostHogAndroid private constructor() {
             val preferences = config.cachePreferences ?: PostHogSharedPreferences(context, config)
             config.cachePreferences = preferences
             config.networkStatus = config.networkStatus ?: PostHogAndroidNetworkStatus(context)
-            config.sdkVersion = BuildConfig.VERSION_NAME
-            config.sdkName = "posthog-android"
+            // Flutter SDK sets the sdkName and sdkVersion, so this guard is not to allow
+            // the values to be overwritten again
+            if (config.sdkName != "posthog-flutter") {
+                config.sdkName = "posthog-android"
+                config.sdkVersion = BuildConfig.VERSION_NAME
+            }
 
             val mainHandler = MainHandler()
             config.addIntegration(PostHogReplayIntegration(context, config, mainHandler))


### PR DESCRIPTION
## :bulb: Motivation and Context
_#skip-changelog_
Noticed while debugging an issue on Flutter
https://github.com/PostHog/posthog-flutter/blob/b1d38521d98f47e54308867c11b96a63fd773fcc/android/src/main/kotlin/com/posthog/posthog_flutter/PosthogFlutterPlugin.kt#L54-L55


## :green_heart: How did you test it?
checked the captured event

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
