### PR TITLE
chore: file name in storage matches the event uuid

### DIFF
--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -75,7 +75,7 @@ internal class PostHogQueue(
                     dirCreated = true
                 }
 
-                val uuid = TimeBasedEpochGenerator.generate()
+                val uuid = event.uuid ?: TimeBasedEpochGenerator.generate()
                 val file = File(dir, "$uuid.event")
                 synchronized(dequeLock) {
                     deque.add(file)

--- a/posthog/src/test/java/com/posthog/Utils.kt
+++ b/posthog/src/test/java/com/posthog/Utils.kt
@@ -55,13 +55,16 @@ public val groupProps: Map<String, Any> = mapOf("premium" to true)
 public val props: Map<String, Any> = mapOf<String, Any>("prop" to "value")
 public val uuid: UUID = UUID.fromString("8c04e5c1-8f6e-4002-96fd-1804799b6ffe")
 
-public fun generateEvent(eventName: String? = null): PostHogEvent {
+public fun generateEvent(
+    eventName: String? = null,
+    givenUuuid: UUID? = null,
+): PostHogEvent {
     return PostHogEvent(
         eventName ?: EVENT,
         distinctId = DISTINCT_ID,
         properties = props,
         timestamp = date,
-        uuid = uuid,
+        uuid = givenUuuid ?: uuid,
     )
 }
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
@@ -14,6 +14,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.text.ParsePosition
+import java.util.UUID
 import java.util.concurrent.Executors
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -313,7 +314,7 @@ internal class PostHogQueueTest {
 
         http.enqueue(MockResponse().setResponseCode(300).setBody("error"))
 
-        sut.add(generateEvent())
+        sut.add(generateEvent(givenUuuid = UUID.randomUUID()))
 
         executor.awaitExecution()
 


### PR DESCRIPTION
## :bulb: Motivation and Context
I was looking at the logs and trying to find the event id based on the logs but they don't match, they should
_#skip-changelog_

## :green_heart: How did you test it?
matching the ids

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
