### PR TITLE
chore: use getNetworkCapabilities instead of getNetworkInfo to avoid ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: use getNetworkCapabilities instead of getNetworkInfo to avoid ANRs ([#154](https://github.com/PostHog/posthog-android/pull/154))
+
 ## 3.5.0 - 2024-08-08
 
 - feat: add emulator detection property to static context ([#154](https://github.com/PostHog/posthog-android/pull/154))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: use getNetworkCapabilities instead of getNetworkInfo to avoid ANRs ([#154](https://github.com/PostHog/posthog-android/pull/154))
+- chore: use getNetworkCapabilities instead of getNetworkInfo to avoid ANRs ([#164](https://github.com/PostHog/posthog-android/pull/164))
 
 ## 3.5.0 - 2024-08-08
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release
-versionName=3.5.0
+versionName=3.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release
-versionName=3.5.1
+versionName=3.5.0

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -26,7 +26,7 @@ class MyApp : Application() {
                 flushAt = 1
                 captureDeepLinks = false
                 captureApplicationLifecycleEvents = false
-                captureScreenViews = false
+                captureScreenViews = true
                 sessionReplay = true
                 preloadFeatureFlags = true
                 onFeatureFlags = PostHogOnFeatureFlags { print("feature flags loaded") }


### PR DESCRIPTION
## :bulb: Motivation and Context
"thread 5" tid=5 Runnable
  #00  pc 0x000000000005c070  /apex/com.android.runtime/lib/bionic/libc.so (syscall+28)
  #01  pc 0x000000000014a873  /apex/com.android.art/lib/libart.so (art::ConditionVariable::WaitHoldingLocks(art::Thread*)+82)
  #02  pc 0x00000000004d6cdb  /apex/com.android.art/lib/libart.so (art::GoToRunnable(art::Thread*)+298)
  #03  pc 0x00000000004d6b91  /apex/com.android.art/lib/libart.so (art::JniMethodEnd(unsigned int, art::Thread*)+8)
  at android.os.BinderProxy.transactNative (Native method)
  at android.os.BinderProxy.transact (BinderProxy.java:571)
  at android.net.IConnectivityManager$Stub$Proxy.getNetworkInfo (IConnectivityManager.java:1669)
  at android.net.ConnectivityManager.getNetworkInfo (ConnectivityManager.java:1346)
  at com.posthog.android.internal.PostHogAndroidContext.getDynamicContext (PostHogAndroidContext.kt:158)
  at com.posthog.PostHog.buildProperties (PostHog.kt:244)
  at com.posthog.PostHog.capture (PostHog.kt:363)
  at com.posthog.PostHog$Companion.capture (PostHog.kt:785)
  at com.posthog.PostHogInterface$DefaultImpls.capture$default (PostHogInterface.kt:26)
  at <private>

from google SDK console


## :green_heart: How did you test it?
running example

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
