### PR TITLE
recording: capture touch interaction off of main thread to avoid ANRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: capture touch interaction off of main thread to avoid ANRs ([#154](https://github.com/PostHog/posthog-android/pull/154))
+
 ## 3.5.0 - 2024-08-08
 
 - feat: add emulator detection property to static context ([#154](https://github.com/PostHog/posthog-android/pull/154))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- recording: capture touch interaction off of main thread to avoid ANRs ([#154](https://github.com/PostHog/posthog-android/pull/154))
+- recording: capture touch interaction off of main thread to avoid ANRs ([#165](https://github.com/PostHog/posthog-android/pull/165))
 
 ## 3.5.0 - 2024-08-08
 


### PR DESCRIPTION
## :bulb: Motivation and Context
"main" tid=1 Native
  #00  pc 0x000000000009eeb8  /apex/com.android.runtime/lib64/bionic/libc.so (fsync+8)
  #01  pc 0x0000000000004700  /apex/com.android.art/lib64/libopenjdkjvm.so (JVM_Sync+20)
  #02  pc 0x0000000000022404  /apex/com.android.art/lib64/libopenjdk.so (FileDescriptor_sync+40)
  #03  pc 0x0000000000351e30  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144)
  #04  pc 0x00000000005b9a30  /apex/com.android.art/lib64/libart.so (nterp_helper+4016)
  #05  pc 0x000000000043c184  /system/framework/framework.jar (android.os.FileUtils.sync+12)
  at <private>
  #07  pc 0x00000000005ba854  /apex/com.android.art/lib64/libart.so (nterp_helper+7636)
  at <private>
  #09  pc 0x00000000005b99d4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  at <private>
  #11  pc 0x00000000005b99d4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  at <private>
  #13  pc 0x00000000005baecc  /apex/com.android.art/lib64/libart.so (nterp_helper+9292)
  at <private>
  #15  pc 0x00000000005baecc  /apex/com.android.art/lib64/libart.so (nterp_helper+9292)
  at <private>
  #17  pc 0x00000000005b99d4  /apex/com.android.art/lib64/libart.so (nterp_helper+3924)
  at <private>
  #19  pc 0x00000000005ba7f4  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  at <private>
  #21  pc 0x00000000005b8ab4  /apex/com.android.art/lib64/libart.so (nterp_helper+52)
  at <private>
  #23  pc 0x00000000005ba7f4  /apex/com.android.art/lib64/libart.so (nterp_helper+7540)
  at <private>
  #25  pc 0x00000000005baecc  /apex/com.android.art/lib64/libart.so (nterp_helper+9292)
  at <private>
  #27  pc 0x000000000033b3a4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
  #28  pc 0x0000000000339404  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeVirtualOrInterfaceWithVarArgs<art::ArtMethod*>+772)
  #29  pc 0x0000000000560f80  /apex/com.android.art/lib64/libart.so (art::JNI<false>::CallVoidMethodV+192)
  #30  pc 0x00000000000af5e8  /system/lib64/libandroid_runtime.so (_JNIEnv::CallVoidMethod+120)
  #31  pc 0x0000000000119e2c  /system/lib64/libandroid_runtime.so (android::NativeInputEventReceiver::consumeEvents+364)
  #32  pc 0x0000000000119bec  /system/lib64/libandroid_runtime.so (android::NativeInputEventReceiver::handleEvent+180)
  #33  pc 0x0000000000016bb0  /system/lib64/libutils.so (android::Looper::pollInner+912)
  #34  pc 0x00000000000167b8  /system/lib64/libutils.so (android::Looper::pollOnce+112)
  #35  pc 0x000000000014e3ec  /system/lib64/libandroid_runtime.so (android::android_os_MessageQueue_nativePollOnce+44)
  #36  pc 0x0000000000351e30  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144)
  at <private>
  #38  pc 0x000000000033b680  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #39  pc 0x000000000037cb18  /apex/com.android.art/lib64/libart.so (_jobject* art::InvokeMethod<8>+1556)
  #40  pc 0x000000000037c4f4  /apex/com.android.art/lib64/libart.so (art::Method_invoke +32)
  #41  pc 0x0000000000351e30  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+144)
  at <private>
  #43  pc 0x00000000005ba854  /apex/com.android.art/lib64/libart.so (nterp_helper+7636)
  #44  pc 0x0000000000268b10  /system/framework/framework.jar (com.android.internal.os.ZygoteInit.main+632)
  #45  pc 0x000000000033b680  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #46  pc 0x00000000004e2b58  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>+728)
  #47  pc 0x000000000057abe0  /apex/com.android.art/lib64/libart.so (art::JNI<true>::CallStaticVoidMethodV+156)
  #48  pc 0x00000000000b0b28  /system/lib64/libandroid_runtime.so (_JNIEnv::CallStaticVoidMethod+120)
  #49  pc 0x00000000000bc22c  /system/lib64/libandroid_runtime.so (android::AndroidRuntime::start+948)
  #50  pc 0x0000000000002580  /system/bin/app_process64 (main+1320)
  #51  pc 0x00000000000489e0  /apex/com.android.runtime/lib64/bionic/libc.so (__libc_init+96)
  at java.io.FileDescriptor.sync (Native method)
  at android.os.FileUtils.sync (FileUtils.java:256)
  at android.app.SharedPreferencesImpl.writeToFile (SharedPreferencesImpl.java:807)
  at android.app.SharedPreferencesImpl.access$900 (SharedPreferencesImpl.java:59)
  at android.app.SharedPreferencesImpl$2.run (SharedPreferencesImpl.java:672)
  at android.app.SharedPreferencesImpl.enqueueDiskWrite (SharedPreferencesImpl.java:691)
  at android.app.SharedPreferencesImpl.access$100 (SharedPreferencesImpl.java:59)
  at android.app.SharedPreferencesImpl$EditorImpl.commit (SharedPreferencesImpl.java:604)
  at <private>
  at android.app.Activity.dispatchTouchEvent (Activity.java:4241)
  at <private>
  at curtains.internal.WindowCallbackWrapper$dispatchTouchEvent$dispatch$1.invoke (WindowCallbackWrapper.kt:1)
  at curtains.internal.WindowCallbackWrapper$dispatchTouchEvent$dispatch$1.invoke (WindowCallbackWrapper.kt:1)
  at curtains.OnTouchEventListener$DefaultImpls.intercept (Listeners.kt:1)
  at com.posthog.android.replay.PostHogReplayIntegration$onTouchEventListener$1.intercept (PostHogReplayIntegration.kt:1)

Input dispatching timed out

from google sdk console


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
