### PR TITLE
chore: expose session id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: expose session id ([#166](https://github.com/PostHog/posthog-android/pull/166))
+
 ## 3.5.1 - 2024-08-26
 
 - recording: capture touch interaction off of main thread to avoid ANRs ([#165](https://github.com/PostHog/posthog-android/pull/165))

--- a/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
@@ -3,6 +3,7 @@ package com.posthog.android
 import com.posthog.PostHogConfig
 import com.posthog.PostHogInterface
 import com.posthog.PostHogOnFeatureFlags
+import java.util.UUID
 
 public class PostHogFake : PostHogInterface {
     public var event: String? = null
@@ -117,6 +118,10 @@ public class PostHogFake : PostHogInterface {
 
     override fun isSessionActive(): Boolean {
         return false
+    }
+
+    override fun getSessionId(): UUID? {
+        return null
     }
 
     override fun <T : PostHogConfig> getConfig(): T? {

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -302,6 +302,15 @@ public final class com/posthog/internal/PostHogSerializer {
 	public final fun serializeObject (Ljava/lang/Object;)Ljava/lang/String;
 }
 
+public final class com/posthog/internal/PostHogSessionManager {
+	public static final field INSTANCE Lcom/posthog/internal/PostHogSessionManager;
+	public final fun endSession ()V
+	public final fun getActiveSessionId ()Ljava/util/UUID;
+	public final fun isSessionActive ()Z
+	public final fun setSessionId (Ljava/util/UUID;)V
+	public final fun startSession ()V
+}
+
 public final class com/posthog/internal/PostHogThreadFactory : java/util/concurrent/ThreadFactory {
 	public fun <init> (Ljava/lang/String;)V
 	public fun newThread (Ljava/lang/Runnable;)Ljava/lang/Thread;

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -11,6 +11,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogInterface {
 	public fun getConfig ()Lcom/posthog/PostHogConfig;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getSessionId ()Ljava/util/UUID;
 	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
@@ -38,6 +39,7 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun getConfig ()Lcom/posthog/PostHogConfig;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getSessionId ()Ljava/util/UUID;
 	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
@@ -178,6 +180,7 @@ public abstract interface class com/posthog/PostHogInterface {
 	public abstract fun getConfig ()Lcom/posthog/PostHogConfig;
 	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getSessionId ()Ljava/util/UUID;
 	public abstract fun group (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
 	public abstract fun isFeatureEnabled (Ljava/lang/String;Z)Z

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -166,6 +166,10 @@ public class PostHog private constructor(
     public override fun close() {
         synchronized(setupLock) {
             try {
+                if (!isEnabled()) {
+                    return
+                }
+
                 enabled = false
 
                 config?.let { config ->
@@ -691,18 +695,34 @@ public class PostHog private constructor(
     }
 
     override fun startSession() {
+        if (!isEnabled()) {
+            return
+        }
+
         PostHogSessionManager.startSession()
     }
 
     override fun endSession() {
+        if (!isEnabled()) {
+            return
+        }
+
         PostHogSessionManager.endSession()
     }
 
     override fun isSessionActive(): Boolean {
+        if (!isEnabled()) {
+            return false
+        }
+
         return PostHogSessionManager.isSessionActive()
     }
 
     override fun getSessionId(): UUID? {
+        if (!isEnabled()) {
+            return null
+        }
+
         return PostHogSessionManager.getActiveSessionId()
     }
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -20,6 +20,7 @@ import com.posthog.internal.PostHogSerializer
 import com.posthog.internal.PostHogSessionManager
 import com.posthog.internal.PostHogThreadFactory
 import com.posthog.vendor.uuid.TimeBasedEpochGenerator
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -701,6 +702,10 @@ public class PostHog private constructor(
         return PostHogSessionManager.isSessionActive()
     }
 
+    override fun getSessionId(): UUID? {
+        return PostHogSessionManager.getActiveSessionId()
+    }
+
     override fun <T : PostHogConfig> getConfig(): T? {
         @Suppress("UNCHECKED_CAST")
         return config as? T
@@ -877,6 +882,10 @@ public class PostHog private constructor(
 
         override fun isSessionActive(): Boolean {
             return shared.isSessionActive()
+        }
+
+        override fun getSessionId(): UUID? {
+            return shared.getSessionId()
         }
 
         override fun <T : PostHogConfig> getConfig(): T? {

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -1,5 +1,7 @@
 package com.posthog
 
+import java.util.UUID
+
 /**
  * The PostHog SDK entry point
  */
@@ -188,6 +190,11 @@ public interface PostHogInterface {
      * Returns if a session is active
      */
     public fun isSessionActive(): Boolean
+
+    /**
+     * Returns the session Id if a session is active
+     */
+    public fun getSessionId(): UUID?
 
     @PostHogInternal
     public fun <T : PostHogConfig> getConfig(): T?

--- a/posthog/src/main/java/com/posthog/internal/PostHogSessionManager.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogSessionManager.kt
@@ -1,0 +1,54 @@
+package com.posthog.internal
+
+import com.posthog.PostHogInternal
+import com.posthog.vendor.uuid.TimeBasedEpochGenerator
+import java.util.UUID
+
+/**
+ * Class that manages the Session ID
+ */
+@PostHogInternal
+public object PostHogSessionManager {
+    private val sessionLock = Any()
+
+    // do not move to companion object, otherwise sessionId will be null
+    private val sessionIdNone = UUID(0, 0)
+
+    private var sessionId = sessionIdNone
+
+    public fun startSession() {
+        synchronized(sessionLock) {
+            if (sessionId == sessionIdNone) {
+                sessionId = TimeBasedEpochGenerator.generate()
+            }
+        }
+    }
+
+    public fun endSession() {
+        synchronized(sessionLock) {
+            sessionId = sessionIdNone
+        }
+    }
+
+    public fun getActiveSessionId(): UUID? {
+        var tempSessionId: UUID?
+        synchronized(sessionLock) {
+            tempSessionId = if (sessionId != sessionIdNone) sessionId else null
+        }
+        return tempSessionId
+    }
+
+    public fun setSessionId(sessionId: UUID) {
+        synchronized(sessionLock) {
+            this.sessionId = sessionId
+        }
+    }
+
+    public fun isSessionActive(): Boolean {
+        var active: Boolean
+        synchronized(sessionLock) {
+            active = sessionId != sessionIdNone
+        }
+        return active
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context
Exposes session id, similar to [JS](https://github.com/PostHog/posthog-js/blob/82fd8399b0bc13b43e354fa3cd407ab82b3d2105/src/posthog-core.ts#L1517-L1526)
Exposes a setter but not publically


## :green_heart: How did you test it?
there are unit tests already, only refactored to its class so it is accessible (the getter) but not the setter via the public API

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
