### PR TITLE
fix: rotate session id when reset is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - recording: expose session id ([#166](https://github.com/PostHog/posthog-android/pull/166))
-- fix: rotate session id when reset is called ([#166](https://github.com/PostHog/posthog-android/pull/166))
+- fix: rotate session id when reset is called ([#168](https://github.com/PostHog/posthog-android/pull/168))
 
 ## 3.5.1 - 2024-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - recording: expose session id ([#166](https://github.com/PostHog/posthog-android/pull/166))
+- fix: rotate session id when reset is called ([#166](https://github.com/PostHog/posthog-android/pull/166))
 
 ## 3.5.1 - 2024-08-26
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -650,6 +650,7 @@ public class PostHog private constructor(
         replayQueue?.clear()
         featureFlagsCalled.clear()
         endSession()
+        startSession()
     }
 
     private fun isEnabled(): Boolean {

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -935,7 +935,7 @@ internal class PostHogTest {
     }
 
     @Test
-    fun `does not set session id when reset is called`() {
+    fun `reset session id when reset is called`() {
         val http = mockHttp()
         val url = http.url("/")
 
@@ -959,7 +959,8 @@ internal class PostHogTest {
         var batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
 
         var theEvent = batch.batch.first()
-        assertNotNull(theEvent.properties!!["\$session_id"])
+        val currentSessionId = theEvent.properties!!["\$session_id"]
+        assertNotNull(currentSessionId)
 
         sut.reset()
 
@@ -981,7 +982,10 @@ internal class PostHogTest {
         batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
 
         theEvent = batch.batch.first()
-        assertNull(theEvent.properties!!["\$session_id"])
+        val newSessionId = theEvent.properties!!["\$session_id"]
+        assertNotNull(newSessionId)
+
+        assertTrue(currentSessionId != newSessionId)
 
         sut.close()
     }


### PR DESCRIPTION
## :bulb: Motivation and Context
found during the https://github.com/PostHog/posthog-android/pull/167 testing
when reset is called, the session id was set to null, so the next events wouldn't contain a session id anymore, in this case, the correct behaviour would be just rotating the session id.
this would affect session recording as well.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
