### PR TITLE
fix: do not clear events and reload flags after reset is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- fix: do not clear events when reset is called ([#168](https://github.com/PostHog/posthog-android/pull/168))
+- fix: reload feature flags as anon user after reset is called ([#168](https://github.com/PostHog/posthog-android/pull/168))
+
 ## 3.6.0 - 2024-08-29
 
 - recording: expose session id ([#166](https://github.com/PostHog/posthog-android/pull/166))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
-- fix: do not clear events when reset is called ([#168](https://github.com/PostHog/posthog-android/pull/168))
-- fix: reload feature flags as anon user after reset is called ([#168](https://github.com/PostHog/posthog-android/pull/168))
+- fix: do not clear events when reset is called ([#170](https://github.com/PostHog/posthog-android/pull/170))
+- fix: reload feature flags as anon user after reset is called ([#170](https://github.com/PostHog/posthog-android/pull/170))
 
 ## 3.6.0 - 2024-08-29
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -678,16 +678,16 @@ public class PostHog private constructor(
         val except = listOf(VERSION, BUILD)
         getPreferences().clear(except = except)
         featureFlags?.clear()
-        queue?.clear()
-        replayQueue?.clear()
         featureFlagsCalled.clear()
-
         synchronized(identifiedLock) {
             isIdentifiedLoaded = false
         }
 
         endSession()
         startSession()
+
+        // reload flags as anon user
+        reloadFeatureFlags()
     }
 
     private fun isEnabled(): Boolean {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -687,7 +687,10 @@ public class PostHog private constructor(
         startSession()
 
         // reload flags as anon user
-        reloadFeatureFlags()
+        // only because of testing in isolation, this flag is always enabled
+        if (reloadFeatureFlags) {
+            reloadFeatureFlags()
+        }
     }
 
     private fun isEnabled(): Boolean {

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -1107,32 +1107,12 @@ internal class PostHogTest {
 
         val sut = getSut(url.toString(), preloadFeatureFlags = false)
 
-        sut.capture(
-            EVENT,
-            DISTINCT_ID,
-            props,
-            userProperties = userProps,
-            userPropertiesSetOnce = userPropsOnce,
-            groups = groups,
-        )
-
-        queueExecutor.awaitExecution()
-
-        assertEquals(1, http.requestCount)
-
-        var request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        val theEvent = batch.batch.first()
-        assertNotNull(theEvent)
-
         sut.reset()
 
         featureFlagsExecutor.shutdownAndAwaitTermination()
 
-        request = http.takeRequest()
-        assertEquals(2, http.requestCount)
+        val request = http.takeRequest()
+        assertEquals(1, http.requestCount)
         assertEquals("/decide/?v=3", request.path)
 
         sut.close()


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-android/issues/169


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
