### PR TITLE
chore: sdk info in recordings

### DIFF
--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -30,6 +30,15 @@ internal class PostHogAndroidContext(
     private val context: Context,
     private val config: PostHogAndroidConfig,
 ) : PostHogContext {
+    private val cacheSdkInfo by lazy {
+        val sdkInfo = mutableMapOf<String, Any>()
+
+        sdkInfo["\$lib"] = config.sdkName
+        sdkInfo["\$lib_version"] = config.sdkVersion
+
+        sdkInfo
+    }
+
     private val cacheStaticContext by lazy {
         val staticContext = mutableMapOf<String, Any>()
 
@@ -56,9 +65,6 @@ internal class PostHogAndroidContext(
         staticContext["\$device_type"] = getDeviceType(context, displayMetrics) ?: "Mobile"
         staticContext["\$os_name"] = "Android"
         staticContext["\$os_version"] = Build.VERSION.RELEASE
-
-        staticContext["\$lib"] = config.sdkName
-        staticContext["\$lib_version"] = config.sdkVersion
 
         staticContext["\$is_emulator"] = isEmulator
 
@@ -189,6 +195,10 @@ internal class PostHogAndroidContext(
         }
 
         return dynamicContext
+    }
+
+    override fun getSdkInfo(): Map<String, Any> {
+        return cacheSdkInfo
     }
 
     // Inspired from https://github.com/fluttercommunity/plus_plugins/blob/a71a27c5fbdbbfc56a30359a1aff0a3d3da8dc73/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt#L105-L123

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
@@ -71,7 +71,7 @@ internal class PostHogAndroidContextTest {
 
     fun `returns sdk info`() {
         val sut = getSut()
-        val sdkInfo = sut.getStaticContext()
+        val sdkInfo = sut.getSdkInfo()
 
         assertEquals(config.sdkName, sdkInfo["\$lib"])
         assertEquals(config.sdkVersion, sdkInfo["\$lib_version"])

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
@@ -66,10 +66,15 @@ internal class PostHogAndroidContextTest {
         // its dynamic
         assertNotNull(staticContext["\$os_version"])
 
-        assertEquals(config.sdkName, staticContext["\$lib"])
-        assertEquals(config.sdkVersion, staticContext["\$lib_version"])
-
         assertNotNull(staticContext["\$is_emulator"])
+    }
+
+    fun `returns sdk info`() {
+        val sut = getSut()
+        val sdkInfo = sut.getStaticContext()
+
+        assertEquals(config.sdkName, sdkInfo["\$lib"])
+        assertEquals(config.sdkVersion, sdkInfo["\$lib_version"])
     }
 
     @Test

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -2,7 +2,6 @@ package com.posthog.android.sample
 
 import android.app.Application
 import android.os.StrictMode
-import com.posthog.PostHog
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.PostHogPropertiesSanitizer
 import com.posthog.android.PostHogAndroid
@@ -43,7 +42,6 @@ class MyApp : Application() {
                 sessionReplayConfig.screenshot = true
             }
         PostHogAndroid.setup(this, config)
-        PostHog.capture("test")
     }
 
     private fun enableStrictMode() {

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -2,6 +2,7 @@ package com.posthog.android.sample
 
 import android.app.Application
 import android.os.StrictMode
+import com.posthog.PostHog
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.PostHogPropertiesSanitizer
 import com.posthog.android.PostHogAndroid
@@ -42,6 +43,7 @@ class MyApp : Application() {
                 sessionReplayConfig.screenshot = true
             }
         PostHogAndroid.setup(this, config)
+        PostHog.capture("test")
     }
 
     private fun enableStrictMode() {

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -242,6 +242,7 @@ public final class com/posthog/internal/PersonProfiles : java/lang/Enum {
 
 public abstract interface class com/posthog/internal/PostHogContext {
 	public abstract fun getDynamicContext ()Ljava/util/Map;
+	public abstract fun getSdkInfo ()Ljava/util/Map;
 	public abstract fun getStaticContext ()Ljava/util/Map;
 }
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -346,7 +346,8 @@ public class PostHog private constructor(
         PostHogSessionManager.getActiveSessionId()?.let { sessionId ->
             val tempSessionId = sessionId.toString()
             props["\$session_id"] = tempSessionId
-            if (config?.sessionReplay == true) {
+            // only Session replay needs $window_id
+            if (!appendSharedProps && config?.sessionReplay == true) {
                 // Session replay requires $window_id, so we set as the same as $session_id.
                 // the backend might fallback to $session_id if $window_id is not present next.
                 props["\$window_id"] = tempSessionId
@@ -357,7 +358,7 @@ public class PostHog private constructor(
             props.putAll(it)
         }
 
-        // Session replay needs distinct_id also in the props
+        // only Session replay needs distinct_id also in the props
         // remove after https://github.com/PostHog/posthog/pull/18954 gets merged
         val propDistinctId = props["distinct_id"] as? String
         if (!appendSharedProps && config?.sessionReplay == true && propDistinctId.isNullOrBlank()) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogContext.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogContext.kt
@@ -11,4 +11,6 @@ public interface PostHogContext {
     public fun getStaticContext(): Map<String, Any>
 
     public fun getDynamicContext(): Map<String, Any>
+
+    public fun getSdkInfo(): Map<String, Any>
 }


### PR DESCRIPTION
## :bulb: Motivation and Context
Recordings were appending groups wrongly
Recordings didn't have SDK info

_#skip-changelog_ since its not a user facing change


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [X] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
