### PR TITLE
fix: respect session replay project settings from app start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: respect session replay project settings from app start ([#177](https://github.com/PostHog/posthog-android/pull/177))
+
 ## 3.7.0 - 2024-09-11
 
 - chore: add personProfiles support ([#171](https://github.com/PostHog/posthog-android/pull/171))

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -116,7 +116,7 @@ public class PostHogReplayIntegration(
         }
 
     private val isSessionReplayEnabled: Boolean
-        get() = config.sessionReplay && PostHog.isSessionActive()
+        get() = PostHog.isSessionReplayActive()
 
     private val onRootViewsChangedListener =
         OnRootViewsChangedListener { view, added ->

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/PostHogLogCatIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/PostHogLogCatIntegration.kt
@@ -18,7 +18,7 @@ internal class PostHogLogCatIntegration(private val config: PostHogAndroidConfig
     private var logcatThread: Thread? = null
 
     private val isSessionReplayEnabled: Boolean
-        get() = config.sessionReplay && PostHog.isSessionActive()
+        get() = PostHog.isSessionReplayActive()
 
     override fun install() {
         if (!config.sessionReplayConfig.captureLogcat || !isSupported()) {

--- a/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
@@ -120,6 +120,10 @@ public class PostHogFake : PostHogInterface {
         return false
     }
 
+    override fun isSessionReplayActive(): Boolean {
+        return false
+    }
+
     override fun getSessionId(): UUID? {
         return null
     }

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -17,6 +17,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogInterface {
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public fun isOptOut ()Z
 	public fun isSessionActive ()Z
+	public fun isSessionReplayActive ()Z
 	public fun optIn ()V
 	public fun optOut ()V
 	public fun register (Ljava/lang/String;Ljava/lang/Object;)V
@@ -45,6 +46,7 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public fun isOptOut ()Z
 	public fun isSessionActive ()Z
+	public fun isSessionReplayActive ()Z
 	public fun optIn ()V
 	public fun optOut ()V
 	public final fun overrideSharedInstance (Lcom/posthog/PostHogInterface;)V
@@ -188,6 +190,7 @@ public abstract interface class com/posthog/PostHogInterface {
 	public abstract fun isFeatureEnabled (Ljava/lang/String;Z)Z
 	public abstract fun isOptOut ()Z
 	public abstract fun isSessionActive ()Z
+	public abstract fun isSessionReplayActive ()Z
 	public abstract fun optIn ()V
 	public abstract fun optOut ()V
 	public abstract fun register (Ljava/lang/String;Ljava/lang/Object;)V

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -192,6 +192,12 @@ public interface PostHogInterface {
     public fun isSessionActive(): Boolean
 
     /**
+     * Returns if Session Replay is Active
+     * Android only.
+     */
+    public fun isSessionReplayActive(): Boolean
+
+    /**
      * Returns the session Id if a session is active
      */
     public fun getSessionId(): UUID?

--- a/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
@@ -10,7 +10,7 @@ public class PostHogOkHttpInterceptor
     @JvmOverloads
     constructor(private val captureNetworkTelemetry: Boolean = true) : Interceptor {
         private val isSessionReplayEnabled: Boolean
-            get() = PostHog.getConfig<PostHogConfig>()?.sessionReplay == true && PostHog.isSessionActive()
+            get() = PostHog.isSessionReplayActive()
 
         override fun intercept(chain: Interceptor.Chain): Response {
             val originalRequest = chain.request()

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -33,6 +33,7 @@ public interface PostHogPreferences {
         internal const val OPT_OUT = "opt-out"
         internal const val FEATURE_FLAGS = "featureFlags"
         internal const val FEATURE_FLAGS_PAYLOAD = "featureFlagsPayload"
+        internal const val SESSION_REPLAY = "sessionReplay"
         public const val VERSION: String = "version"
         public const val BUILD: String = "build"
         public const val STRINGIFIED_KEYS: String = "stringifiedKeys"
@@ -47,6 +48,7 @@ public interface PostHogPreferences {
                 OPT_OUT,
                 FEATURE_FLAGS,
                 FEATURE_FLAGS_PAYLOAD,
+                SESSION_REPLAY,
                 VERSION,
                 BUILD,
                 STRINGIFIED_KEYS,

--- a/posthog/src/test/resources/json/basic-decide-recording.json
+++ b/posthog/src/test/resources/json/basic-decide-recording.json
@@ -1,0 +1,33 @@
+{
+  "autocaptureExceptions": false,
+  "toolbarParams": {},
+  "errorsWhileComputingFlags": false,
+  "capturePerformance": true,
+  "autocapture_opt_out": false,
+  "isAuthenticated": false,
+  "supportedCompression": [
+    "gzip",
+    "gzip-js"
+  ],
+  "config": {
+    "enable_collect_everything": true
+  },
+  "featureFlagPayloads": {
+    "thePayload": true
+  },
+  "featureFlags": {
+    "4535-funnel-bar-viz": true
+  },
+  "sessionRecording": {
+    "endpoint": "/b/"
+  },
+  "siteApps": [
+    {
+      "id": 21039.0,
+      "url": "/site_app/21039/EOsOSePYNyTzHkZ3f4mjrjUap8Hy8o2vUTAc6v1ZMFP/576ac89bc8aed72a21d9b19221c2c626/"
+    }
+  ],
+  "editorParams": {
+
+  }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context
Similar to https://github.com/PostHog/posthog-ios/pull/150
If replay is active in the SDK config but disabled in the project settings, a recording would start and would end after ~1s when the decide API finishes.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
