### PR TITLE
recording: react native has window attached but needs view ready callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- no user facing changes
+
 ## 3.7.2 - 2024-09-17
 
 - no user facing changes

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -126,6 +126,8 @@ public class PostHogReplayIntegration(
             view.phoneWindow?.let { window ->
                 var hasDecorView = false
 
+                // react native already has the window attached
+                // so we check if the decor view exists otherwise we need the onDecorViewReady anyways
                 window.peekDecorView()?.let { decorView ->
                     hasDecorView = decorViews[decorView] != null
                 }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -120,12 +120,17 @@ public class PostHogReplayIntegration(
 
     private fun addView(
         view: View,
-        added: Boolean,
+        added: Boolean = true,
     ) {
         try {
-            if (added) {
-                view.phoneWindow?.let { window ->
-                    if (view.windowAttachCount == 0) {
+            view.phoneWindow?.let { window ->
+                var hasDecorView = false
+
+                window.peekDecorView()?.let { decorView ->
+                    hasDecorView = decorViews[decorView] != null
+                }
+                if (added) {
+                    if (view.windowAttachCount == 0 || !hasDecorView) {
                         window.onDecorViewReady { decorView ->
                             try {
                                 val listener =
@@ -158,10 +163,10 @@ public class PostHogReplayIntegration(
                         window.touchEventInterceptors += onTouchEventListener
                         // TODO: can check if user pressed hardware back button (KEYCODE_BACK)
                         // window.keyEventInterceptors
+                    } else {
+                        config.logger.log("Session Replay already has onDecorViewReady.")
                     }
-                }
-            } else {
-                view.phoneWindow?.let { window ->
+                } else {
                     window.peekDecorView()?.let { decorView ->
                         decorViews[decorView]?.let { status ->
                             cleanSessionState(decorView, status)
@@ -299,15 +304,7 @@ public class PostHogReplayIntegration(
         // workaround for react native that is started after the window is added
         // Curtains.rootViews should be empty for normal apps yet
         Curtains.rootViews.forEach { view ->
-            view.phoneWindow?.let { window ->
-                window.peekDecorView()?.let { decorView ->
-                    val hasDecorView = decorViews[decorView] != null
-
-                    if (!hasDecorView) {
-                        addView(view, true)
-                    }
-                }
-            }
+            addView(view)
         }
 
         try {


### PR DESCRIPTION
## :bulb: Motivation and Context
follow up https://github.com/PostHog/posthog-android/pull/179
_#skip-changelog_
the window is already attached but we don't have the callback yet so we need to allow this


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
