### PR TITLE
recording: OnTouchEventListener try catch guard to swallow unexpected errors take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- recording: `OnTouchEventListener` try catch guard to swallow unexpected errors take 2 ([#147](https://github.com/PostHog/posthog-android/pull/147))
+- recording: `OnTouchEventListener` try catch guard to swallow unexpected errors take 2 ([#196](https://github.com/PostHog/posthog-android/pull/196))
 
 ## 3.8.0 - 2024-10-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: `OnTouchEventListener` try catch guard to swallow unexpected errors take 2 ([#147](https://github.com/PostHog/posthog-android/pull/147))
+
 ## 3.8.0 - 2024-10-03
 
 - feat: add referrerURL automatically ([#186](https://github.com/PostHog/posthog-android/pull/186))


### PR DESCRIPTION
## :bulb: Motivation and Context
Tries to fix https://github.com/PostHog/posthog-react-native-session-replay/issues/4
It's unclear if PostHog SDK is responsible for that, since the SDK intercepts the touch, the SDK will be always part of the stack trace, it does not mean its the SDK causing it.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
