### PR TITLE
feat: add replay masking to jetpack compose views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- recording: add replay masking to jetpack compose views ([#198](https://github.com/PostHog/posthog-android/pull/198))
+
 ## 3.8.3 - 2024-10-25
 
 - recording: fix crash when calling view.isVisible ([#201](https://github.com/PostHog/posthog-android/pull/201))

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -14,7 +14,7 @@ object PosthogBuildConfig {
     }
 
     object Android {
-        val COMPILE_SDK = 34
+        val COMPILE_SDK = 33
 
         // when changing this, remember to check the ANIMAL_SNIFFER_SDK_VERSION
         // Session Replay (addOnFrameMetricsAvailableListener requires API 26)
@@ -55,6 +55,7 @@ object PosthogBuildConfig {
         val OKHTTP = "4.11.0"
         val CURTAINS = "1.2.5"
         val ANDROIDX_CORE = "1.5.0"
+        val ANDROIDX_COMPOSE = "1.0.0"
 
         // tests
         val ANDROIDX_JUNIT = "1.1.5"

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -14,7 +14,7 @@ object PosthogBuildConfig {
     }
 
     object Android {
-        val COMPILE_SDK = 33
+        val COMPILE_SDK = 34
 
         // when changing this, remember to check the ANIMAL_SNIFFER_SDK_VERSION
         // Session Replay (addOnFrameMetricsAvailableListener requires API 26)

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -49,7 +49,16 @@ public abstract interface class com/posthog/android/replay/PostHogDrawableConver
 	public abstract fun convert (Landroid/graphics/drawable/Drawable;)Landroid/graphics/Bitmap;
 }
 
+public final class com/posthog/android/replay/PostHogMaskModifier {
+	public static final field INSTANCE Lcom/posthog/android/replay/PostHogMaskModifier;
+	public final fun postHogMask (Landroidx/compose/ui/Modifier;Z)Landroidx/compose/ui/Modifier;
+	public static synthetic fun postHogMask$default (Lcom/posthog/android/replay/PostHogMaskModifier;Landroidx/compose/ui/Modifier;ZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
 public final class com/posthog/android/replay/PostHogReplayIntegration : com/posthog/PostHogIntegration {
+	public static final field ANDROID_COMPOSE_VIEW Ljava/lang/String;
+	public static final field ANDROID_COMPOSE_VIEW_CLASS_NAME Ljava/lang/String;
+	public static final field PH_NO_CAPTURE_LABEL Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;Lcom/posthog/android/PostHogAndroidConfig;Lcom/posthog/android/internal/MainHandler;)V
 	public fun install ()V
 	public fun uninstall ()V

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -88,8 +88,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-process:${PosthogBuildConfig.Dependencies.LIFECYCLE}")
     implementation("androidx.lifecycle:lifecycle-common-java8:${PosthogBuildConfig.Dependencies.LIFECYCLE}")
     implementation("androidx.core:core:${PosthogBuildConfig.Dependencies.ANDROIDX_CORE}")
+    implementation("androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}")
     implementation("com.squareup.curtains:curtains:${PosthogBuildConfig.Dependencies.CURTAINS}")
-    implementation("androidx.compose.ui:ui-android:1.7.3")
 
     // compatibility
     signature("org.codehaus.mojo.signature:java18:${PosthogBuildConfig.Plugins.SIGNATURE_JAVA18}@signature")

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -88,8 +88,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-process:${PosthogBuildConfig.Dependencies.LIFECYCLE}")
     implementation("androidx.lifecycle:lifecycle-common-java8:${PosthogBuildConfig.Dependencies.LIFECYCLE}")
     implementation("androidx.core:core:${PosthogBuildConfig.Dependencies.ANDROIDX_CORE}")
-    implementation("androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}")
     implementation("com.squareup.curtains:curtains:${PosthogBuildConfig.Dependencies.CURTAINS}")
+
+    // compile only
+    compileOnly("androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}")
 
     // compatibility
     signature("org.codehaus.mojo.signature:java18:${PosthogBuildConfig.Plugins.SIGNATURE_JAVA18}@signature")

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-common-java8:${PosthogBuildConfig.Dependencies.LIFECYCLE}")
     implementation("androidx.core:core:${PosthogBuildConfig.Dependencies.ANDROIDX_CORE}")
     implementation("com.squareup.curtains:curtains:${PosthogBuildConfig.Dependencies.CURTAINS}")
+    implementation("androidx.compose.ui:ui-android:1.7.3")
 
     // compatibility
     signature("org.codehaus.mojo.signature:java18:${PosthogBuildConfig.Plugins.SIGNATURE_JAVA18}@signature")

--- a/posthog-android/consumer-rules.pro
+++ b/posthog-android/consumer-rules.pro
@@ -77,4 +77,8 @@
 -dontwarn org.conscrypt.**
 -dontwarn org.bouncycastle.**
 -dontwarn org.openjsse.**
+
+# used in reflection to check if compose is available at runtime
+-keepnames class androidx.compose.ui.platform.AndroidComposeView
+
 ##---------------End: proguard configuration for okhttp3  ----------

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -36,13 +36,13 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.mockito:mockito-inline than 4.11.0 is available: 5.2.0"
-        errorLine1="    testImplementation(&quot;org.mockito:mockito-inline:${PosthogBuildConfig.Dependencies.MOCKITO_INLINE}&quot;)"
-        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="A newer version of androidx.compose.ui:ui than 1.0.0 is available: 1.7.4"
+        errorLine1="    implementation(&quot;androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}&quot;)"
+        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
-            line="107"
-            column="24"/>
+            line="91"
+            column="20"/>
     </issue>
 
 </issues>

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -37,12 +37,12 @@
     <issue
         id="GradleDependency"
         message="A newer version of androidx.compose.ui:ui than 1.0.0 is available: 1.7.4"
-        errorLine1="    implementation(&quot;androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}&quot;)"
-        errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="    compileOnly(&quot;androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}&quot;)"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
-            line="91"
-            column="20"/>
+            line="94"
+            column="17"/>
     </issue>
 
 </issues>

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogMaskModifier.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogMaskModifier.kt
@@ -3,17 +3,21 @@ package com.posthog.android.replay
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.semantics
+import com.posthog.android.replay.PostHogReplayIntegration.Companion.PH_NO_CAPTURE_LABEL
 
 public object PostHogMaskModifier {
-    internal val PostHogReplayMask = SemanticsPropertyKey<Boolean>("ph-no-capture")
+    internal val PostHogReplayMask = SemanticsPropertyKey<Boolean>(PH_NO_CAPTURE_LABEL)
 
     /**
-     * Marks the element as not to be captured by PostHog Session Replay.
+     * Modifier to mask or unmask elements in the session replay.
+     * @param isEnabled If true, the element will be masked in the session replay.
+     * If false, the element will be unmasked in the session replay.
+     * This will override the defaults like maskAllTextInputs, maskAllImages etc. when used with the respective elements.
      */
-    public fun Modifier.postHogMaskReplay(): Modifier {
+    public fun Modifier.postHogMask(isEnabled: Boolean = true): Modifier {
         return semantics(
             properties = {
-                this[PostHogReplayMask] = true
+                this[PostHogReplayMask] = isEnabled
             },
         )
     }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogMaskModifier.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogMaskModifier.kt
@@ -1,0 +1,17 @@
+package com.posthog.android.replay
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.semantics
+
+public object PostHogMaskModifier {
+    internal val PostHogReplayMask = SemanticsPropertyKey<Boolean>("ph-no-capture")
+
+    public fun Modifier.postHogMaskReplay(): Modifier {
+        return semantics(
+            properties = {
+                this[PostHogReplayMask] = true
+            },
+        )
+    }
+}

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogMaskModifier.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogMaskModifier.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.semantics.semantics
 public object PostHogMaskModifier {
     internal val PostHogReplayMask = SemanticsPropertyKey<Boolean>("ph-no-capture")
 
+    /**
+     * Marks the element as not to be captured by PostHog Session Replay.
+     */
     public fun Modifier.postHogMaskReplay(): Modifier {
         return semantics(
             properties = {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -607,39 +607,44 @@ public class PostHogReplayIntegration(
         view: View,
         maskableWidgets: MutableList<Rect>,
     ) {
-        val semanticsOwner =
-            (view as? RootForTest)?.semanticsOwner ?: run {
-                config.logger.log("View is not a RootForTest: $view")
-                return
-            }
-        val semanticsNodes = semanticsOwner.getAllSemanticsNodes(true)
-
-        semanticsNodes.forEach { node ->
-            val hasText = node.config.contains(SemanticsProperties.Text)
-            val hasEditableText = node.config.contains(SemanticsProperties.EditableText)
-            val hasPassword = node.config.contains(SemanticsProperties.Password)
-            val hasImage = node.config.contains(SemanticsProperties.ContentDescription)
-
-            val hasMaskModifier = node.config.contains(PostHogReplayMask)
-            val isNoCapture = hasMaskModifier && node.config[PostHogReplayMask]
-
-            when {
-                isNoCapture -> {
-                    maskableWidgets.add(node.boundsInWindow.toRect())
+        try {
+            val semanticsOwner =
+                (view as? RootForTest)?.semanticsOwner ?: run {
+                    config.logger.log("View is not a RootForTest: $view")
+                    return
                 }
+            val semanticsNodes = semanticsOwner.getAllSemanticsNodes(true)
 
-                !hasMaskModifier -> {
-                    when {
-                        (hasText || hasEditableText) && (config.sessionReplayConfig.maskAllTextInputs || hasPassword) -> {
-                            maskableWidgets.add(node.boundsInWindow.toRect())
-                        }
+            semanticsNodes.forEach { node ->
+                val hasText = node.config.contains(SemanticsProperties.Text)
+                val hasEditableText = node.config.contains(SemanticsProperties.EditableText)
+                val hasPassword = node.config.contains(SemanticsProperties.Password)
+                val hasImage = node.config.contains(SemanticsProperties.ContentDescription)
 
-                        hasImage && config.sessionReplayConfig.maskAllImages -> {
-                            maskableWidgets.add(node.boundsInWindow.toRect())
+                val hasMaskModifier = node.config.contains(PostHogReplayMask)
+                val isNoCapture = hasMaskModifier && node.config[PostHogReplayMask]
+
+                when {
+                    isNoCapture -> {
+                        maskableWidgets.add(node.boundsInWindow.toRect())
+                    }
+
+                    !hasMaskModifier -> {
+                        when {
+                            (hasText || hasEditableText) && (config.sessionReplayConfig.maskAllTextInputs || hasPassword) -> {
+                                maskableWidgets.add(node.boundsInWindow.toRect())
+                            }
+
+                            hasImage && config.sessionReplayConfig.maskAllImages -> {
+                                maskableWidgets.add(node.boundsInWindow.toRect())
+                            }
                         }
                     }
                 }
             }
+        } catch (e: Throwable) {
+            // swallow possible errors due to compose versioning, etc
+            config.logger.log("Session Replay findMaskableComposeWidgets failed: $e")
         }
     }
 

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -540,7 +540,7 @@ public class PostHogReplayIntegration(
     ) {
         when {
             view.isComposeView() -> {
-                findMaskableComposeRects(view, maskableWidgets)
+                findMaskableComposeWidgets(view, maskableWidgets)
             }
 
             view.isNoCapture() -> {
@@ -603,9 +603,9 @@ public class PostHogReplayIntegration(
         }
     }
 
-    private fun findMaskableComposeRects(
+    private fun findMaskableComposeWidgets(
         view: View,
-        rectsToMask: MutableList<Rect>,
+        maskableWidgets: MutableList<Rect>,
     ) {
         val semanticsOwner =
             (view as? RootForTest)?.semanticsOwner ?: run {
@@ -625,17 +625,17 @@ public class PostHogReplayIntegration(
 
             when {
                 isNoCapture -> {
-                    rectsToMask.add(node.boundsInWindow.toRect())
+                    maskableWidgets.add(node.boundsInWindow.toRect())
                 }
 
                 !hasMaskModifier -> {
                     when {
                         (hasText || hasEditableText) && (config.sessionReplayConfig.maskAllTextInputs || hasPassword) -> {
-                            rectsToMask.add(node.boundsInWindow.toRect())
+                            maskableWidgets.add(node.boundsInWindow.toRect())
                         }
 
                         hasImage && config.sessionReplayConfig.maskAllImages -> {
-                            rectsToMask.add(node.boundsInWindow.toRect())
+                            maskableWidgets.add(node.boundsInWindow.toRect())
                         }
                     }
                 }

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MainActivity.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MainActivity.kt
@@ -4,10 +4,11 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,12 +45,12 @@ fun greeting(
 ) {
     var text by remember { mutableStateOf("Hello $name!") }
 
-    ClickableText(
+    Text(
         text = AnnotatedString(text),
-        modifier = modifier,
-        onClick = {
-            text = "Clicked!"
-        },
+        modifier =
+            modifier.clickable {
+                text = "Clicked!"
+            },
     )
 }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Fix  #158

## :green_heart: How did you test it?
Tested on a sample app. Auto as well as manual masking using `Modifier.postHogMaskReplay()`, both working as expected.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
