### PR TITLE
fix: allow changing person properties after identify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: allow changing person properties after identify ([#204](https://github.com/PostHog/posthog-android/pull/204)) 
+- fix: allow changing person properties after identify ([#205](https://github.com/PostHog/posthog-android/pull/205)) 
 
 ## 3.9.1 - 2024-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: allow changing person properties after identify ([#204](https://github.com/PostHog/posthog-android/pull/204)) 
+
 ## 3.9.1 - 2024-11-11
 
 - recording: fix observation on multiple threads in layout/draw is not supported for compose ([#204](https://github.com/PostHog/posthog-android/pull/204))

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -556,8 +556,6 @@ public class PostHog private constructor(
             config?.logger?.log("identify called with invalid anonymousId: $anonymousId.")
         }
 
-        var shouldReloadFlags = false
-
         if (previousDistinctId != distinctId && !isIdentified) {
             // this has to be set before capture since this flag will be read during the event
             // capture
@@ -580,7 +578,11 @@ public class PostHog private constructor(
                 config?.logger?.log("identify called with invalid former distinctId: $previousDistinctId.")
             }
             this.distinctId = distinctId
-            shouldReloadFlags = true
+
+            // only because of testing in isolation, this flag is always enabled
+            if (reloadFeatureFlags) {
+                reloadFeatureFlags()
+            }
         } else if (userProperties?.isNotEmpty() == true || userPropertiesSetOnce?.isNotEmpty() == true) {
             capture(
                 "\$set",
@@ -588,15 +590,9 @@ public class PostHog private constructor(
                 userProperties = userProperties,
                 userPropertiesSetOnce = userPropertiesSetOnce,
             )
-
-            shouldReloadFlags = true
+            // Note we don't reload flags on property changes as these get processed async
         } else {
             config?.logger?.log("already identified with id: $distinctId.")
-        }
-
-        // only because of testing in isolation, this flag(reloadFeatureFlags) is always enabled
-        if (shouldReloadFlags && reloadFeatureFlags) {
-            reloadFeatureFlags()
         }
     }
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -556,7 +556,8 @@ public class PostHog private constructor(
             config?.logger?.log("identify called with invalid anonymousId: $anonymousId.")
         }
 
-        if (previousDistinctId != distinctId && !isIdentified) {
+        val hasDifferentDistinctId = previousDistinctId != distinctId
+        if (hasDifferentDistinctId && !isIdentified) {
             // this has to be set before capture since this flag will be read during the event
             // capture
             synchronized(identifiedLock) {
@@ -583,7 +584,9 @@ public class PostHog private constructor(
             if (reloadFeatureFlags) {
                 reloadFeatureFlags()
             }
-        } else if (userProperties?.isNotEmpty() == true || userPropertiesSetOnce?.isNotEmpty() == true) {
+            // we need to make sure the user props update is for the same user
+            // otherwise they have to reset and identify again
+        } else if (!hasDifferentDistinctId && (userProperties?.isNotEmpty() == true || userPropertiesSetOnce?.isNotEmpty() == true)) {
             capture(
                 "\$set",
                 distinctId = distinctId,

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -596,6 +596,9 @@ internal class PostHogTest {
             userPropertiesSetOnce = userPropsOnce,
         )
 
+        val userProps = mapOf("user1" to "theResult")
+        val userPropsOnce = mapOf("logged" to false)
+
         sut.identify(
             DISTINCT_ID,
             userProperties = userProps,
@@ -612,6 +615,8 @@ internal class PostHogTest {
         val theEvent = batch.batch.last()
 
         assertEquals("\$set", theEvent.event)
+        assertEquals(userProps, theEvent.properties!!["\$set"])
+        assertEquals(userPropsOnce, theEvent.properties!!["\$set_once"])
 
         sut.close()
     }


### PR DESCRIPTION
## :bulb: Motivation and Context
Relates to https://github.com/PostHog/posthog-flutter/issues/120
@ioannisj we will need that for iOS as well
Reason is here https://github.com/PostHog/posthog-flutter/issues/120#issuecomment-2469771444


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
