### PR TITLE
chore: change screenshot image type from JPEG to WEBP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- chore: change screenshot image type from JPEG to WEBP ([#130](https://github.com/PostHog/posthog-android/pull/130))
+- chore: change screenshot image type from JPEG to WEBP ([#211](https://github.com/PostHog/posthog-android/pull/211))
 
 ## 3.9.3 - 2024-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- chore: change screenshot image type from JPEG to WEBP ([#130](https://github.com/PostHog/posthog-android/pull/130))
+
 ## 3.9.3 - 2024-11-26
 
 - no user facing changes

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -45,6 +45,8 @@ public final class com/posthog/android/internal/PostHogAndroidUtilsKt {
 	public static final fun base64 (Landroid/graphics/Bitmap;Landroid/graphics/Bitmap$CompressFormat;I)Ljava/lang/String;
 	public static synthetic fun base64$default (Landroid/graphics/Bitmap;Landroid/graphics/Bitmap$CompressFormat;IILjava/lang/Object;)Ljava/lang/String;
 	public static final fun getApplicationInfo (Landroid/content/Context;)Landroid/content/pm/ApplicationInfo;
+	public static final fun webpBase64 (Landroid/graphics/Bitmap;I)Ljava/lang/String;
+	public static synthetic fun webpBase64$default (Landroid/graphics/Bitmap;IILjava/lang/Object;)Ljava/lang/String;
 }
 
 public abstract interface class com/posthog/android/replay/PostHogDrawableConverter {

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -36,7 +36,7 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.compose.ui:ui than 1.0.0 is available: 1.7.5"
+        message="A newer version of androidx.compose.ui:ui than 1.0.0 is available: 1.7.6"
         errorLine1="    compileOnly(&quot;androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}&quot;)"
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -217,6 +217,19 @@ private fun Bitmap.isValid(): Boolean {
 
 @PostHogInternal
 @Suppress("DEPRECATION")
+public fun Bitmap.webpBase64(quality: Int = 30): String? {
+    val format =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Bitmap.CompressFormat.WEBP_LOSSY
+        } else {
+            Bitmap.CompressFormat.WEBP
+        }
+
+    return base64(format, quality)
+}
+
+@PostHogInternal
+@Suppress("DEPRECATION")
 public fun Bitmap.base64(
     format: Bitmap.CompressFormat = Bitmap.CompressFormat.JPEG,
     quality: Int = 30,

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -53,10 +53,10 @@ import com.posthog.PostHog
 import com.posthog.PostHogIntegration
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.internal.MainHandler
-import com.posthog.android.internal.base64
 import com.posthog.android.internal.densityValue
 import com.posthog.android.internal.displayMetrics
 import com.posthog.android.internal.screenSize
+import com.posthog.android.internal.webpBase64
 import com.posthog.android.replay.PostHogMaskModifier.PostHogReplayMask
 import com.posthog.android.replay.internal.NextDrawListener.Companion.onNextDraw
 import com.posthog.android.replay.internal.ViewTreeSnapshotStatus
@@ -733,7 +733,7 @@ public class PostHogReplayIntegration(
                     canvas.drawRoundRect(RectF(it), 10f, 10f, paint)
                 }
 
-                base64 = bitmap.base64()
+                base64 = bitmap.webpBase64()
             }
         } catch (e: Throwable) {
             config.logger.log("Session Replay PixelCopy failed: $e.")
@@ -1106,7 +1106,7 @@ public class PostHogReplayIntegration(
     ): String? {
         val convertedBitmap = runDrawableConverter(this)
         if (convertedBitmap != null) {
-            return convertedBitmap.base64()
+            return convertedBitmap.webpBase64()
         }
 
         var clonedDrawable = this
@@ -1117,7 +1117,7 @@ public class PostHogReplayIntegration(
         when (clonedDrawable) {
             is BitmapDrawable -> {
                 try {
-                    return clonedDrawable.bitmap.base64()
+                    return clonedDrawable.bitmap.webpBase64()
                 } catch (_: Throwable) {
                     // ignore
                 }
@@ -1138,7 +1138,7 @@ public class PostHogReplayIntegration(
 
         try {
             val bitmap = clonedDrawable.toBitmap(width, height)
-            val base64 = bitmap.base64()
+            val base64 = bitmap.webpBase64()
             if (!bitmap.isRecycled) {
                 bitmap.recycle()
             }


### PR DESCRIPTION
## :bulb: Motivation and Context
File Info
• Resolution: 1080×2400
• MIME type: image/octet-stream
• Extension: bin
• Size: 6.69 KB
• Download: image.bin
WEBP_LOSSY

File Info
• Resolution: 1080×2400
• MIME type: image/octet-stream
• Extension: bin
• Size: 310.68 KB
• Download: image.bin
WEBP_LOSSLESS

File Info
• Resolution: 1080×2400
• MIME type: image/octet-stream
• Extension: bin
• Size: 6.69 KB
• Download: image.bin
WEBP or WEBP_LOSSY

File Info
• Resolution: 1080×2400
• MIME type: image/png
• Extension: png
• Size: 20.45 KB
• Download: image.png
• Bit depth: 8
PNG

File Info
• Resolution: 1080×2400
• MIME type: image/jpeg
• Extension: jpg
• Size: 20.25 KB
• Download: image.jpg
• Channels: 3
• Bit depth: 8
JPEG

Also this https://github.com/PostHog/posthog-ios/blob/5dceb9b86f6c65c1dcc6d18ae97e1face7236636/PostHog/Replay/PostHogReplayIntegration.swift#L178
Since the base64 image is lossy and loses all metadata, we won't be resending a new snapshot in case nothing changes in the generated image.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
