### PR TITLE
fix: touches fall back to single touches if out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: touches fall back to single touches if out of bounds ([#219](https://github.com/PostHog/posthog-android/pull/219))
+- fix: touches fall back to single touches if out of bounds ([#221](https://github.com/PostHog/posthog-android/pull/221))
 
 ## 3.11.1 - 2025-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: touches fall back to single touches if out of bounds ([#219](https://github.com/PostHog/posthog-android/pull/219))
+
 ## 3.11.1 - 2025-01-30
 
 - fix: do not allow default integrations multiple times ([#219](https://github.com/PostHog/posthog-android/pull/219))

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -1237,18 +1237,26 @@ public class PostHogReplayIntegration(
     }
 
     private fun MotionEvent.getRawXCompat(index: Int): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            getRawX(index)
+        return if (index < 0 || index >= pointerCount) {
+            rawX // Fallback to single-touch `rawX` to prevent crashes
         } else {
-            rawX
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                getRawX(index)
+            } else {
+                rawX
+            }
         }
     }
 
     private fun MotionEvent.getRawYCompat(index: Int): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            getRawY(index)
+        return if (index < 0 || index >= pointerCount) {
+            rawY // Fallback to single-touch `rawY` to prevent crashes
         } else {
-            rawY
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                getRawY(index)
+            } else {
+                rawY
+            }
         }
     }
 

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -261,20 +261,24 @@ public class PostHogReplayIntegration(
     ) {
         val mouseInteractions = mutableListOf<RRIncrementalMouseInteractionEvent>()
         for (index in 0 until motionEvent.pointerCount) {
-            // if the id is 0, BE transformer will set it to the virtual bodyId
-            val id = motionEvent.getPointerId(index)
-            val absX = motionEvent.getRawXCompat(index).toInt().densityValue(displayMetrics.density)
-            val absY = motionEvent.getRawYCompat(index).toInt().densityValue(displayMetrics.density)
+            try {
+                // if the id is 0, BE transformer will set it to the virtual bodyId
+                val id = motionEvent.getPointerId(index)
+                val absX = motionEvent.getRawXCompat(index).toInt().densityValue(displayMetrics.density)
+                val absY = motionEvent.getRawYCompat(index).toInt().densityValue(displayMetrics.density)
 
-            val mouseInteractionData =
-                RRIncrementalMouseInteractionData(
-                    id = id,
-                    type = type,
-                    x = absX,
-                    y = absY,
-                )
-            val mouseInteraction = RRIncrementalMouseInteractionEvent(mouseInteractionData, timestamp)
-            mouseInteractions.add(mouseInteraction)
+                val mouseInteractionData =
+                    RRIncrementalMouseInteractionData(
+                        id = id,
+                        type = type,
+                        x = absX,
+                        y = absY,
+                    )
+                val mouseInteraction = RRIncrementalMouseInteractionEvent(mouseInteractionData, timestamp)
+                mouseInteractions.add(mouseInteraction)
+            } catch (e: Throwable) {
+                config.logger.log("Reading MotionEvent pointers failed: $e.")
+            }
         }
 
         if (mouseInteractions.isNotEmpty()) {


### PR DESCRIPTION
## :bulb: Motivation and Context
https://posthoghelp.zendesk.com/agent/tickets/22478 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/26649)

Abort message: 'ubsan: pointer-overflow by 0x00007cbfdd4a8b71'
...
#01 pc 0000000000097f98 /system/lib64/libinput.so (__ubsan_handle_pointer_overflow_minimal_abort+104) (BuildId: 5f23a8b8723840951044cedfab315961)
...
#12 pc 00000000002b5364 <anonymous:7cbcbc143000> (com.posthog.android.replay.PostHogReplayIntegration.getRawXCompat+0)
...

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
