### PR TITLE
feat(feature-flags): support quota limiting for feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-## 3.11.3 - 2025-02-24
+## 3.11.3 - 2025-02-25
 
 - feat: support quota limiting for feature flags ([#228](https://github.com/PostHog/posthog-android/pull/228))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-## 3.11.3 - 2025-02-21
+## 3.11.3 - 2025-02-24
 
 - feat: support quota limiting for feature flags ([#228](https://github.com/PostHog/posthog-android/pull/228))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.11.3 - 2025-02-21
+
+- feat: support quota limiting for feature flags ([#228](https://github.com/PostHog/posthog-android/pull/228))
+
 ## 3.11.2 - 2025-02-04
 
 - fix: touches fall back to single touches if out of bounds ([#221](https://github.com/PostHog/posthog-android/pull/221))

--- a/posthog-android/lint-baseline.xml
+++ b/posthog-android/lint-baseline.xml
@@ -36,24 +36,13 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.compose.ui:ui than 1.0.0 is available: 1.7.7"
+        message="A newer version of androidx.compose.ui:ui than 1.0.0 is available: 1.7.8"
         errorLine1="    compileOnly(&quot;androidx.compose.ui:ui:${PosthogBuildConfig.Dependencies.ANDROIDX_COMPOSE}&quot;)"
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
             line="94"
             column="17"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlin:kotlin-test-junit than 1.8.22 is available: 1.9.20"
-        errorLine1="    testImplementation(&quot;org.jetbrains.kotlin:kotlin-test-junit:${PosthogBuildConfig.Kotlin.KOTLIN}&quot;)"
-        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle.kts"
-            line="108"
-            column="24"/>
     </issue>
 
 </issues>

--- a/posthog/src/main/java/com/posthog/internal/PostHogDecideResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogDecideResponse.kt
@@ -17,5 +17,5 @@ internal data class PostHogDecideResponse(
     val featureFlagPayloads: Map<String, Any?>?,
     // its either a boolean or a map, see https://github.com/PostHog/posthog-js/blob/10fd7f4fa083f997d31a4a4c7be7d311d0a95e74/src/types.ts#L235-L243
     val sessionRecording: Any? = false,
-    val quotaLimited: Array<String>? = null,
+    val quotaLimited: List<String>? = null,
 )

--- a/posthog/src/main/java/com/posthog/internal/PostHogDecideResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogDecideResponse.kt
@@ -7,6 +7,7 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property errorsWhileComputingFlags if there were errors computing feature flags
  * @property featureFlags the feature flags
  * @property featureFlagPayloads the feature flag payloads
+ * @property quotaLimited array of quota limited features
  */
 @IgnoreJRERequirement
 internal data class PostHogDecideResponse(
@@ -16,4 +17,5 @@ internal data class PostHogDecideResponse(
     val featureFlagPayloads: Map<String, Any?>?,
     // its either a boolean or a map, see https://github.com/PostHog/posthog-js/blob/10fd7f4fa083f997d31a4a4c7be7d311d0a95e74/src/types.ts#L235-L243
     val sessionRecording: Any? = false,
+    val quotaLimited: Array<String>? = null,
 )

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -97,7 +97,7 @@ internal class PostHogFeatureFlags(
                                 preferences.remove(FEATURE_FLAGS)
                                 preferences.remove(FEATURE_FLAGS_PAYLOAD)
                             }
-                            return@executeSafely
+                            return@synchronized
                         }
 
                         if (response.errorsWhileComputingFlags) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -89,6 +89,17 @@ internal class PostHogFeatureFlags(
 
                 response?.let {
                     synchronized(featureFlagsLock) {
+                        if (response.quotaLimited?.contains("feature_flags") == true) {
+                            config.logger.log("Feature flags are quota limited, clearing existing flags")
+                            this.featureFlags = null
+                            this.featureFlagPayloads = null
+                            config.cachePreferences?.let { preferences ->
+                                preferences.remove(FEATURE_FLAGS)
+                                preferences.remove(FEATURE_FLAGS_PAYLOAD)
+                            }
+                            return@executeSafely
+                        }
+
                         if (response.errorsWhileComputingFlags) {
                             // if not all flags were computed, we upsert flags instead of replacing them
                             this.featureFlags =

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlags.kt
@@ -97,7 +97,7 @@ internal class PostHogFeatureFlags(
                                 preferences.remove(FEATURE_FLAGS)
                                 preferences.remove(FEATURE_FLAGS_PAYLOAD)
                             }
-                            return@synchronized
+                            return@let
                         }
 
                         if (response.errorsWhileComputingFlags) {

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
@@ -438,9 +438,10 @@ internal class PostHogFeatureFlagsTest {
     @Test
     fun `clear flags when quota limited`() {
         // First load some feature flags
-        val http = mockHttp(
-            response = MockResponse().setBody(responseDecideApi),
-        )
+        val http =
+            mockHttp(
+                response = MockResponse().setBody(responseDecideApi),
+            )
         val url = http.url("/")
         val sut = getSut(host = url.toString())
 
@@ -453,19 +454,20 @@ internal class PostHogFeatureFlagsTest {
         assertNotNull(preferences.getValue(FEATURE_FLAGS_PAYLOAD))
 
         // Now send a quota limited response
-        val quotaLimitedResponse = """
+        val quotaLimitedResponse =
+            """
             {
                 "featureFlags": {},
                 "featureFlagPayloads": {},
                 "quotaLimited": ["feature_flags"]
             }
-        """.trimIndent()
-        
+            """.trimIndent()
+
         http.enqueue(MockResponse().setBody(quotaLimitedResponse))
 
         // Reload flags
         sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap(), null)
-        
+
         executor.shutdownAndAwaitTermination()
 
         // Verify flags are cleared


### PR DESCRIPTION
with https://github.com/PostHog/posthog/pull/28564, we now start to respond different with the /decide and /local_evaluation APIs if users have gone over their quota limit. Now we need to change the SDKs to handle these new responses.