### PR TITLE
chore: delete queue files if serialization fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Next
 
 - feat: support reuse of `anonymousId` between user changes ([#229](https://github.com/PostHog/posthog-android/pull/229))
-- chore: delete queue files if serialization fail
+- chore: delete queue files if serialization fails ([#232](https://github.com/PostHog/posthog-android/pull/232))
 
 ## 3.11.3 - 2025-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
 
 - feat: support reuse of `anonymousId` between user changes ([#229](https://github.com/PostHog/posthog-android/pull/229))
+- chore: delete queue files if serialization fail
 
 ## 3.11.3 - 2025-02-26
 


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-android/issues/231


## :green_heart: How did you test it?
I cannot reproduce this issue.
I cannot mock the serializer right now, since the catch block already deletes the file, I just did the same if the serializer returns null.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
