### PR TITLE
fix: add remote config response to proguard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.13.1 - 2025-04-01
+
+- fix: add remote config response to proguard rules ([#233](https://github.com/PostHog/posthog-android/pull/233))
+
 ## 3.13.0 - 2025-03-25
 
 - feat: use remote config API ([#233](https://github.com/PostHog/posthog-android/pull/233))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.13.1 - 2025-04-01
 
-- fix: add remote config response to proguard rules ([#233](https://github.com/PostHog/posthog-android/pull/233))
+- fix: add remote config response to proguard rules ([#238](https://github.com/PostHog/posthog-android/pull/238))
 
 ## 3.13.0 - 2025-03-25
 

--- a/posthog-android/consumer-rules.pro
+++ b/posthog-android/consumer-rules.pro
@@ -23,6 +23,9 @@
 -keep class com.posthog.internal.PostHogDecideResponse { *; }
 -keep class com.posthog.internal.PostHogDecideResponse { <init>(); }
 
+-keep class com.posthog.internal.PostHogRemoteConfigResponse { *; }
+-keep class com.posthog.internal.PostHogRemoteConfigResponse { <init>(); }
+
 # Session Replay
 -keep class com.posthog.internal.replay.** { *; }
 -keep class com.posthog.internal.replay.** { <init>(); }


### PR DESCRIPTION
## :bulb: Motivation and Context
Likely fix https://github.com/PostHog/posthog-flutter/issues/171
Proguard/r8 is minifying the remote config response, which depends on reflection


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
