### PR TITLE
fix: Reimplement `isfeatureEnabled` using `getFeatureFlag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Next
 
+## 3.14.1 - 2025-04-21
+
+- fix: Send correct `$feature_flag_response` for the `$feature_flag_called` event when calling `isFeatureEnabled` ([#244](https://github.com/PostHog/posthog-android/pull/244))
+
 ## 3.14.0 - 2025-04-21
 
 - feat: add `$feature_flag_id`, `$feature_flag_version`, `$feature_flag_reason` and `$feature_flag_request_id` properties to `$feature_flag_called` event ([#243](https://github.com/PostHog/posthog-android/pull/243))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-## 3.14.1 - 2025-04-21
+## 3.14.1 - 2025-04-23
 
 - fix: Send correct `$feature_flag_response` for the `$feature_flag_called` event when calling `isFeatureEnabled` ([#244](https://github.com/PostHog/posthog-android/pull/244))
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -731,14 +731,17 @@ public class PostHog private constructor(
         key: String,
         defaultValue: Boolean,
     ): Boolean {
-        if (!isEnabled()) {
-            return defaultValue
+        var value = getFeatureFlag(key, defaultValue)
+
+        if (value is Boolean) {
+            return value
         }
-        val value = remoteConfig?.isFeatureEnabled(key, defaultValue) ?: defaultValue
 
-        sendFeatureFlagCalled(key, value)
+        if (value is String) {
+            return value.isNotEmpty()
+        }
 
-        return value
+        return false
     }
 
     private fun sendFeatureFlagCalled(

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -731,7 +731,7 @@ public class PostHog private constructor(
         key: String,
         defaultValue: Boolean,
     ): Boolean {
-        var value = getFeatureFlag(key, defaultValue)
+        val value = getFeatureFlag(key, defaultValue)
 
         if (value is Boolean) {
             return value

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -381,31 +381,6 @@ internal class PostHogRemoteConfig(
         return decideResponse
     }
 
-    fun isFeatureEnabled(
-        key: String,
-        defaultValue: Boolean,
-    ): Boolean {
-        if (!isFeatureFlagsLoaded) {
-            loadFeatureFlagsFromCache()
-        }
-        val value: Any?
-
-        synchronized(featureFlagsLock) {
-            value = featureFlags?.get(key)
-        }
-
-        return if (value != null) {
-            if (value is Boolean) {
-                value
-            } else {
-                // if its multivariant flag, its enabled by default
-                true
-            }
-        } else {
-            defaultValue
-        }
-    }
-
     private fun readFeatureFlag(
         key: String,
         defaultValue: Any?,

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -381,14 +381,17 @@ internal class PostHogRemoteConfig(
         return decideResponse
     }
 
+    private fun loadFeatureFlagsFromCacheIfNeeded() {
+        if (!isFeatureFlagsLoaded) {
+            loadFeatureFlagsFromCache()
+        }
+    }
+
     private fun readFeatureFlag(
         key: String,
         defaultValue: Any?,
         flags: Map<String, Any?>?,
     ): Any? {
-        if (!isFeatureFlagsLoaded) {
-            loadFeatureFlagsFromCache()
-        }
         val value: Any?
 
         synchronized(featureFlagsLock) {
@@ -402,6 +405,9 @@ internal class PostHogRemoteConfig(
         key: String,
         defaultValue: Any?,
     ): Any? {
+        // since we pass featureFlags as a value, we need to load it from cache if needed
+        loadFeatureFlagsFromCacheIfNeeded()
+
         return readFeatureFlag(key, defaultValue, featureFlags)
     }
 
@@ -409,6 +415,9 @@ internal class PostHogRemoteConfig(
         key: String,
         defaultValue: Any?,
     ): Any? {
+        // since we pass featureFlags as a value, we need to load it from cache if needed
+        loadFeatureFlagsFromCacheIfNeeded()
+
         return readFeatureFlag(key, defaultValue, featureFlagPayloads)
     }
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
@@ -212,7 +212,7 @@ internal class PostHogFeatureFlagsTest {
 
         assertTrue(sut.getFeatureFlag("4535-funnel-bar-viz", defaultValue = false) as Boolean)
         assertFalse(sut.getFeatureFlag("IAmInactive", defaultValue = true) as Boolean)
-        assertTrue(sut.getFeatureFlag("splashScreenName", defaultValue = false) as Boolean)
+        assertNotNull(sut.getFeatureFlag("splashScreenName", defaultValue = false) as String)
         assertTrue(sut.getFeatureFlag("IDontExist", defaultValue = true) as Boolean)
     }
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsTest.kt
@@ -210,10 +210,10 @@ internal class PostHogFeatureFlagsTest {
 
         executor.shutdownAndAwaitTermination()
 
-        assertTrue(sut.isFeatureEnabled("4535-funnel-bar-viz", defaultValue = false))
-        assertFalse(sut.isFeatureEnabled("IAmInactive", defaultValue = true))
-        assertTrue(sut.isFeatureEnabled("splashScreenName", defaultValue = false))
-        assertTrue(sut.isFeatureEnabled("IDontExist", defaultValue = true))
+        assertTrue(sut.getFeatureFlag("4535-funnel-bar-viz", defaultValue = false) as Boolean)
+        assertFalse(sut.getFeatureFlag("IAmInactive", defaultValue = true) as Boolean)
+        assertTrue(sut.getFeatureFlag("splashScreenName", defaultValue = false) as Boolean)
+        assertTrue(sut.getFeatureFlag("IDontExist", defaultValue = true) as Boolean)
     }
 
     @Test
@@ -267,7 +267,7 @@ internal class PostHogFeatureFlagsTest {
 
         val sut = getSut(host = url.toString())
 
-        assertTrue(sut.isFeatureEnabled("foo", defaultValue = false))
+        assertTrue(sut.getFeatureFlag("foo", defaultValue = false) as Boolean)
         assertTrue(sut.getFeatureFlagPayload("foo", defaultValue = false) as Boolean)
     }
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsV3Test.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsV3Test.kt
@@ -212,7 +212,7 @@ internal class PostHogFeatureFlagsV3Test {
 
         assertTrue(sut.getFeatureFlag("4535-funnel-bar-viz", defaultValue = false) as Boolean)
         assertFalse(sut.getFeatureFlag("IAmInactive", defaultValue = true) as Boolean)
-        assertTrue(sut.getFeatureFlag("splashScreenName", defaultValue = false) as Boolean)
+        assertNotNull(sut.getFeatureFlag("splashScreenName", defaultValue = false) as String)
         assertTrue(sut.getFeatureFlag("IDontExist", defaultValue = true) as Boolean)
     }
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsV3Test.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagsV3Test.kt
@@ -210,10 +210,10 @@ internal class PostHogFeatureFlagsV3Test {
 
         executor.shutdownAndAwaitTermination()
 
-        assertTrue(sut.isFeatureEnabled("4535-funnel-bar-viz", defaultValue = false))
-        assertFalse(sut.isFeatureEnabled("IAmInactive", defaultValue = true))
-        assertTrue(sut.isFeatureEnabled("splashScreenName", defaultValue = false))
-        assertTrue(sut.isFeatureEnabled("IDontExist", defaultValue = true))
+        assertTrue(sut.getFeatureFlag("4535-funnel-bar-viz", defaultValue = false) as Boolean)
+        assertFalse(sut.getFeatureFlag("IAmInactive", defaultValue = true) as Boolean)
+        assertTrue(sut.getFeatureFlag("splashScreenName", defaultValue = false) as Boolean)
+        assertTrue(sut.getFeatureFlag("IDontExist", defaultValue = true) as Boolean)
     }
 
     @Test
@@ -267,7 +267,7 @@ internal class PostHogFeatureFlagsV3Test {
 
         val sut = getSut(host = url.toString())
 
-        assertTrue(sut.isFeatureEnabled("foo", defaultValue = false))
+        assertTrue(sut.getFeatureFlag("foo", defaultValue = false) as Boolean)
         assertTrue(sut.getFeatureFlagPayload("foo", defaultValue = false) as Boolean)
     }
 


### PR DESCRIPTION
Changes `isFeatureEnabled` to delegate to `getFeatureFlag` in order to get the result. This ensures that the `$feature_flag_called` event sends the correct `$feature_flag_response`.

## :bulb: Motivation and Context

This is the same change I made in https://github.com/PostHog/posthog-ios/pull/337.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
