### PR TITLE
fix: only log flush logging if queue not empty

### DIFF
--- a/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueue.kt
@@ -108,8 +108,10 @@ internal class PostHogQueue(
     private fun isAboveThreshold(flushAt: Int): Boolean {
         if (deque.size >= flushAt) {
             return true
+        } else if (deque.size > 0) {
+            // only log if there are events in the queue
+            config.logger.log("Cannot flush the Queue yet, below the threshold: $flushAt")
         }
-        config.logger.log("Cannot flush the Queue yet, below the threshold: $flushAt")
         return false
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context
_#skip-changelog_

> 2025-06-02 14:54:00.230  9231-9383  PostHog                 com.andreasjj.posthogandroidrepro    D  Cannot flush the Queue yet, below the threshold: 1
> 2025-06-02 14:54:30.230  9231-9383  PostHog                 com.andreasjj.posthogandroidrepro    D  Cannot flush the Queue yet, below the threshold: 1
> 2025-06-02 14:55:00.233  9231-9383  PostHog                 com.andreasjj.posthogandroidrepro    D  Cannot flush the Queue yet, below the threshold: 1
> 2025-06-02 14:55:30.232  9231-9383  PostHog                 com.andreasjj.posthogandroidrepro    D  Cannot flush the Queue yet, below the threshold: 1


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
