### PR TITLE
fix: call PostHogOnFeatureFlags if remote config fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Next
 
-## 3.20.0 - 2025-07-33
+## 3.20.1 - 2025-07-25
+
+- fix: call PostHogOnFeatureFlags if remote config fails ([#268](https://github.com/PostHog/posthog-android/pull/245)) 
+
+## 3.20.0 - 2025-07-23
 
 - feat: add support for beforeSend function to edit or drop events ([#266](https://github.com/PostHog/posthog-android/pull/266))
     - Thanks @KopeikinaDarya 


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-android/issues/269


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
