### PR TITLE
fix: do not try to create a Canvas with a recycled bitmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: do not try to create a Canvas with a recycled bitmap
+- fix: do not try to create a Canvas with a recycled bitmap ([#277](https://github.com/PostHog/posthog-android/pull/277))
 
 ## 3.20.2 - 2025-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: do not try to create a Canvas with a recycled bitmap
+
 ## 3.20.2 - 2025-08-07
 
 - fix: missing session_id property for snapshot events ([#273](https://github.com/PostHog/posthog-android/pull/273))

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -45,6 +45,7 @@ public final class com/posthog/android/internal/PostHogAndroidUtilsKt {
 	public static final fun base64 (Landroid/graphics/Bitmap;Landroid/graphics/Bitmap$CompressFormat;I)Ljava/lang/String;
 	public static synthetic fun base64$default (Landroid/graphics/Bitmap;Landroid/graphics/Bitmap$CompressFormat;IILjava/lang/Object;)Ljava/lang/String;
 	public static final fun getApplicationInfo (Landroid/content/Context;)Landroid/content/pm/ApplicationInfo;
+	public static final fun isValid (Landroid/graphics/Bitmap;)Z
 	public static final fun webpBase64 (Landroid/graphics/Bitmap;I)Ljava/lang/String;
 	public static synthetic fun webpBase64$default (Landroid/graphics/Bitmap;IILjava/lang/Object;)Ljava/lang/String;
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -209,7 +209,8 @@ public fun getApplicationInfo(context: Context): ApplicationInfo =
             .getApplicationInfo(context.packageName, GET_META_DATA)
     }
 
-private fun Bitmap.isValid(): Boolean {
+@PostHogInternal
+public fun Bitmap.isValid(): Boolean {
     return !isRecycled &&
         width > 0 &&
         height > 0
@@ -218,6 +219,9 @@ private fun Bitmap.isValid(): Boolean {
 @PostHogInternal
 @Suppress("DEPRECATION")
 public fun Bitmap.webpBase64(quality: Int = 30): String? {
+    if (!isValid()) {
+        return null
+    }
     val format =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             Bitmap.CompressFormat.WEBP_LOSSY


### PR DESCRIPTION
## :bulb: Motivation and Context
Relates to https://posthoghelp.zendesk.com/agent/tickets/36336 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/37985)

> Fatal Exception: java.lang.RuntimeException: Canvas: trying to use a recycled bitmap android.graphics.Bitmap@88cbea3
>        at android.graphics.BaseCanvas.throwIfCannotDraw(BaseCanvas.java:83)
>        at android.graphics.Canvas.<init>(Canvas.java:116)
>        at com.posthog.android.replay.PostHogReplayIntegration.toScreenshotWireframe$lambda$24(PostHogReplayIntegration.java:786)
>        at android.view.PixelCopy$1.lambda$onCopyFinished$0(PixelCopy.java:193)
>        at android.view.PixelCopy$1$$ExternalSyntheticLambda0.run(:4)
>        at android.os.Handler.handleCallback(Handler.java:958)
>        at android.os.Handler.dispatchMessage(Handler.java:99)
>        at android.os.Looper.loopOnce(Looper.java:230)
>        at android.os.Looper.loop(Looper.java:319)
>        at android.os.HandlerThread.run(HandlerThread.java:67)


## :green_heart: How did you test it?
I cannot reproduce this but added extra checks

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
