### PR TITLE
fix: do not try to use the view if it is in a dirty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: do not try to use the view if it is in a dirty state ([#278](https://github.com/PostHog/posthog-android/pull/278))
+
 ## 3.20.3 - 2025-08-22
 
 - fix: do not try to create a Canvas with a recycled bitmap ([#277](https://github.com/PostHog/posthog-android/pull/277))

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -532,16 +532,10 @@ public class PostHogReplayIntegration(
                     }
                     current = view.parent
                 }
-                // Check if the view is entirely covered by its predecessors.
-                val visibleRect = Rect()
-                val offset = Point()
 
+                val offset = Point()
                 // Check if view is in a stable state before accessing matrix-dependent operations
-                return if (isViewStateStableForMatrixOperations()) {
-                    getGlobalVisibleRect(visibleRect, offset)
-                } else {
-                    false
-                }
+                return globalVisibleRect(offset = offset) != null
 
                 // TODO: also check for getGlobalVisibleRect intersects the display
 //            if (boundInView != null) {
@@ -566,10 +560,10 @@ public class PostHogReplayIntegration(
         }
     }
 
-    private fun View.globalVisibleRect(): Rect? {
+    private fun View.globalVisibleRect(offset: Point? = null): Rect? {
         return if (isViewStateStableForMatrixOperations()) {
             val rect = Rect()
-            getGlobalVisibleRect(rect)
+            getGlobalVisibleRect(rect, offset)
             return rect
         } else {
             null
@@ -600,20 +594,12 @@ public class PostHogReplayIntegration(
     }
 
     private fun View.isAnimationRunning(): Boolean {
-        return try {
-            animation?.hasStarted() == true && animation?.hasEnded() != true
-        } catch (e: Throwable) {
-            false
-        }
+        return animation?.hasStarted() == true && animation?.hasEnded() != true
     }
 
     private fun View.isComputingLayout(): Boolean {
-        return try {
-            // Check if direct parent ViewGroup is in layout
-            (parent as? ViewGroup)?.isInLayout == true
-        } catch (e: Throwable) {
-            true // Assume unsafe if check fails
-        }
+        // Check if direct parent ViewGroup is in layout
+        return (parent as? ViewGroup)?.isInLayout == true
     }
 
     private fun View.isTextInputSensitive(): Boolean {


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-js/issues/2233
I cannot reproduce this issue, but I added a few checks to check the state of the view, this should at least avoid most of the crashes.
Side effect is that if the view is in any of that state, the snapshot will be missed, but it should capture the next if all is fine.


## :green_heart: How did you test it?
Running and checking that everything works as it should, but I cannot reproduce the issue.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
