### PR TITLE
fix: prevent circular reference in the view hierarchy where a child view somehow references back to a parent, creating an infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- fix: prevent circular reference in the view hierarchy where a child view somehow references back to a parent, creating an infinite loop ([#280](https://github.com/PostHog/posthog-android/pull/280))
+- fix: prevent circular reference in the view hierarchy where a child view somehow references back to a parent, creating an infinite loop ([#281](https://github.com/PostHog/posthog-android/pull/281))
 
 ## 3.21.1 - 2025-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: prevent circular reference in the view hierarchy where a child view somehow references back to a parent, creating an infinite loop ([#280](https://github.com/PostHog/posthog-android/pull/280))
+
 ## 3.21.1 - 2025-09-04
 
 - fix: do not throw if Canvas creation failed ([#280](https://github.com/PostHog/posthog-android/pull/280))

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -618,7 +618,16 @@ public class PostHogReplayIntegration(
     private fun findMaskableWidgets(
         view: View,
         maskableWidgets: MutableList<Rect>,
+        visitedViews: MutableSet<Int> = mutableSetOf(),
     ): Boolean {
+        val viewId = System.identityHashCode(view)
+
+        // Check for cycles to prevent stack overflow
+        if (viewId in visitedViews) {
+            return true
+        }
+        visitedViews.add(viewId)
+
         when {
             view.isComposeView() -> {
                 findMaskableComposeWidgets(view, maskableWidgets)
@@ -688,7 +697,7 @@ public class PostHogReplayIntegration(
                         continue
                     }
 
-                    if (!findMaskableWidgets(viewChild, maskableWidgets)) {
+                    if (!findMaskableWidgets(viewChild, maskableWidgets, visitedViews)) {
                         // do not continue if the screen has changed
                         return false
                     }


### PR DESCRIPTION
## :bulb: Motivation and Context
Closes https://github.com/PostHog/posthog-js/issues/2298


## :green_heart: How did you test it?
Just running the app but I cant reproduce the issue anyway

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [X] No breaking change or entry added to the changelog.
