### PR TITLE
feat: Core configuration factories for queue and feature flags

### DIFF
--- a/posthog/CHANGELOG.md
+++ b/posthog/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: `PostHogConfig` now accepts queue and remote config constructors ([#287])
+
 ## 3.22.0 - 2025-09-25
 
 - feat: Add a server-side stateless interface([#284](https://github.com/PostHog/posthog-android/pull/284))

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -83,8 +83,8 @@ public class com/posthog/PostHogConfig {
 	public static final field DEFAULT_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_ASSETS_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_HOST Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun getApiKey ()Ljava/lang/String;
@@ -110,7 +110,9 @@ public class com/posthog/PostHogConfig {
 	public final fun getPreloadFeatureFlags ()Z
 	public final fun getPropertiesSanitizer ()Lcom/posthog/PostHogPropertiesSanitizer;
 	public final fun getProxy ()Ljava/net/Proxy;
+	public final fun getQueueProvider ()Lkotlin/jvm/functions/Function5;
 	public final fun getRemoteConfig ()Z
+	public final fun getRemoteConfigProvider ()Lkotlin/jvm/functions/Function3;
 	public final fun getReplayStoragePrefix ()Ljava/lang/String;
 	public final fun getReuseAnonymousId ()Z
 	public final fun getSdkName ()Ljava/lang/String;
@@ -371,6 +373,79 @@ public final class com/posthog/PostHogStatelessInterface$DefaultImpls {
 public abstract interface annotation class com/posthog/PostHogVisibleForTesting : java/lang/annotation/Annotation {
 }
 
+public final class com/posthog/internal/EvaluationReason {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/posthog/internal/EvaluationReason;
+	public static synthetic fun copy$default (Lcom/posthog/internal/EvaluationReason;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/posthog/internal/EvaluationReason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getCondition_index ()Ljava/lang/Integer;
+	public final fun getDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/FeatureFlag {
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Lcom/posthog/internal/FeatureFlagMetadata;Lcom/posthog/internal/EvaluationReason;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/posthog/internal/FeatureFlagMetadata;
+	public final fun component5 ()Lcom/posthog/internal/EvaluationReason;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Lcom/posthog/internal/FeatureFlagMetadata;Lcom/posthog/internal/EvaluationReason;)Lcom/posthog/internal/FeatureFlag;
+	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlag;Ljava/lang/String;ZLjava/lang/String;Lcom/posthog/internal/FeatureFlagMetadata;Lcom/posthog/internal/EvaluationReason;ILjava/lang/Object;)Lcom/posthog/internal/FeatureFlag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getMetadata ()Lcom/posthog/internal/FeatureFlagMetadata;
+	public final fun getReason ()Lcom/posthog/internal/EvaluationReason;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/FeatureFlagMetadata {
+	public fun <init> (ILjava/lang/String;I)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (ILjava/lang/String;I)Lcom/posthog/internal/FeatureFlagMetadata;
+	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlagMetadata;ILjava/lang/String;IILjava/lang/Object;)Lcom/posthog/internal/FeatureFlagMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()I
+	public final fun getPayload ()Ljava/lang/String;
+	public final fun getVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/PostHogApi {
+	public fun <init> (Lcom/posthog/PostHogConfig;)V
+	public final fun batch (Ljava/util/List;)V
+	public final fun flags (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public static synthetic fun flags$default (Lcom/posthog/internal/PostHogApi;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public final fun remoteConfig ()Lcom/posthog/internal/PostHogRemoteConfigResponse;
+	public final fun snapshot (Ljava/util/List;)V
+}
+
+public final class com/posthog/internal/PostHogApiEndpoint : java/lang/Enum {
+	public static final field BATCH Lcom/posthog/internal/PostHogApiEndpoint;
+	public static final field SNAPSHOT Lcom/posthog/internal/PostHogApiEndpoint;
+	public static fun valueOf (Ljava/lang/String;)Lcom/posthog/internal/PostHogApiEndpoint;
+	public static fun values ()[Lcom/posthog/internal/PostHogApiEndpoint;
+}
+
+public final class com/posthog/internal/PostHogApiError : java/lang/RuntimeException {
+	public fun <init> (ILjava/lang/String;Lokhttp3/ResponseBody;)V
+	public final fun getBody ()Lokhttp3/ResponseBody;
+	public fun getMessage ()Ljava/lang/String;
+	public final fun getStatusCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/posthog/internal/PostHogContext {
 	public abstract fun getDynamicContext ()Ljava/util/Map;
 	public abstract fun getSdkInfo ()Ljava/util/Map;
@@ -394,15 +469,37 @@ public final class com/posthog/internal/PostHogDeviceDateProvider : com/posthog/
 
 public abstract interface class com/posthog/internal/PostHogFeatureFlagsInterface {
 	public abstract fun clear ()V
-	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun getFeatureFlags ()Ljava/util/Map;
-	public abstract fun isSessionReplayFlagActive ()Z
-	public abstract fun loadRemoteConfig (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
+	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public abstract fun getFeatureFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
 }
 
 public final class com/posthog/internal/PostHogFeatureFlagsInterface$DefaultImpls {
-	public static synthetic fun loadRemoteConfig$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
+	public static synthetic fun getFeatureFlag$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getFeatureFlagPayload$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getFeatureFlags$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/util/Map;
+}
+
+public final class com/posthog/internal/PostHogFlagsResponse : com/posthog/internal/PostHogRemoteConfigResponse {
+	public fun <init> (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public static synthetic fun copy$default (Lcom/posthog/internal/PostHogFlagsResponse;ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorsWhileComputingFlags ()Z
+	public final fun getFeatureFlagPayloads ()Ljava/util/Map;
+	public final fun getFeatureFlags ()Ljava/util/Map;
+	public final fun getFlags ()Ljava/util/Map;
+	public final fun getQuotaLimited ()Ljava/util/List;
+	public final fun getRequestId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/posthog/internal/PostHogLogger {
@@ -475,6 +572,33 @@ public abstract interface class com/posthog/internal/PostHogQueueInterface {
 	public abstract fun stop ()V
 }
 
+public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/internal/PostHogFeatureFlagsInterface {
+	public fun <init> (Lcom/posthog/PostHogConfig;Lcom/posthog/internal/PostHogApi;Ljava/util/concurrent/ExecutorService;)V
+	public fun clear ()V
+	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public fun getFeatureFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
+	public final fun getFlagDetails (Ljava/lang/String;)Lcom/posthog/internal/FeatureFlag;
+	public final fun getOnRemoteConfigLoaded ()Lkotlin/jvm/functions/Function0;
+	public final fun getRequestId ()Ljava/lang/String;
+	public final fun getSurveys ()Ljava/util/List;
+	public final fun isSessionReplayFlagActive ()Z
+	public final fun loadFeatureFlags (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
+	public static synthetic fun loadFeatureFlags$default (Lcom/posthog/internal/PostHogRemoteConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
+	public final fun loadRemoteConfig (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
+	public static synthetic fun loadRemoteConfig$default (Lcom/posthog/internal/PostHogRemoteConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
+	public final fun setOnRemoteConfigLoaded (Lkotlin/jvm/functions/Function0;)V
+}
+
+public class com/posthog/internal/PostHogRemoteConfigResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHasFeatureFlags ()Ljava/lang/Boolean;
+	public final fun getSessionRecording ()Ljava/lang/Object;
+	public final fun getSurveys ()Ljava/lang/Object;
+}
+
 public final class com/posthog/internal/PostHogSerializer {
 	public fun <init> (Lcom/posthog/PostHogConfig;)V
 	public final fun deserializeString (Ljava/lang/String;)Ljava/lang/Object;
@@ -497,7 +621,9 @@ public final class com/posthog/internal/PostHogThreadFactory : java/util/concurr
 }
 
 public final class com/posthog/internal/PostHogUtilsKt {
+	public static final fun executeSafely (Ljava/util/concurrent/Executor;Ljava/lang/Runnable;)V
 	public static final fun interruptSafely (Ljava/lang/Thread;)V
+	public static final fun isNetworkingError (Ljava/lang/Throwable;)Z
 }
 
 public abstract interface class com/posthog/internal/replay/PostHogSessionReplayHandler {

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -1,16 +1,23 @@
 package com.posthog
 
+import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogApiEndpoint
 import com.posthog.internal.PostHogContext
 import com.posthog.internal.PostHogDateProvider
 import com.posthog.internal.PostHogDeviceDateProvider
+import com.posthog.internal.PostHogFeatureFlagsInterface
 import com.posthog.internal.PostHogLogger
 import com.posthog.internal.PostHogNetworkStatus
 import com.posthog.internal.PostHogNoOpLogger
 import com.posthog.internal.PostHogPreferences
+import com.posthog.internal.PostHogQueue
+import com.posthog.internal.PostHogQueueInterface
+import com.posthog.internal.PostHogRemoteConfig
 import com.posthog.internal.PostHogSerializer
 import com.posthog.surveys.PostHogSurveysConfig
 import java.net.Proxy
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 
 /**
  * The SDK Config
@@ -167,6 +174,16 @@ public open class PostHogConfig(
      * Configuration for PostHog Surveys feature.
      */
     public var surveysConfig: PostHogSurveysConfig = PostHogSurveysConfig(),
+    /**
+     * Factory to instantiate a custom [com.posthog.internal.PostHogRemoteConfigInterface] implementation.
+     */
+    public val remoteConfigProvider: (PostHogConfig, PostHogApi, ExecutorService) -> PostHogFeatureFlagsInterface =
+        { config, api, executor -> PostHogRemoteConfig(config, api, executor) },
+    /**
+     * Factory to instantiate a custom queue implementation.
+     */
+    public val queueProvider: (PostHogConfig, PostHogApi, PostHogApiEndpoint, String?, ExecutorService) -> PostHogQueueInterface =
+        { config, api, endpoint, storagePrefix, executor -> PostHogQueue(config, api, endpoint, storagePrefix, executor) },
 ) {
     @PostHogInternal
     public var logger: PostHogLogger = PostHogNoOpLogger()

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -411,7 +411,7 @@ public open class PostHogStateless protected constructor(
         if (!isEnabled()) {
             return defaultValue
         }
-        val value = featureFlags?.getFeatureFlag(key, defaultValue) ?: defaultValue
+        val value = featureFlags?.getFeatureFlag(key, defaultValue, distinctId) ?: defaultValue
 
         sendFeatureFlagCalled(distinctId, key, value)
 
@@ -426,7 +426,7 @@ public open class PostHogStateless protected constructor(
         if (!isEnabled()) {
             return defaultValue
         }
-        return featureFlags?.getFeatureFlagPayload(key, defaultValue) ?: defaultValue
+        return featureFlags?.getFeatureFlagPayload(key, defaultValue, distinctId) ?: defaultValue
     }
 
     public override fun flush() {

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -9,9 +9,7 @@ import com.posthog.internal.PostHogPreferences
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPrintLogger
-import com.posthog.internal.PostHogQueue
 import com.posthog.internal.PostHogQueueInterface
-import com.posthog.internal.PostHogRemoteConfig
 import com.posthog.internal.PostHogThreadFactory
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -54,8 +52,15 @@ public open class PostHogStateless protected constructor(
 
                 config.cachePreferences = memoryPreferences
                 val api = PostHogApi(config)
-                val queue = PostHogQueue(config, api, PostHogApiEndpoint.BATCH, config.storagePrefix, queueExecutor)
-                val remoteConfig = PostHogRemoteConfig(config, api, featureFlagsExecutor)
+                val queue =
+                    config.queueProvider(
+                        config,
+                        api,
+                        PostHogApiEndpoint.BATCH,
+                        config.storagePrefix,
+                        queueExecutor,
+                    )
+                val remoteConfig = config.remoteConfigProvider(config, api, featureFlagsExecutor)
 
                 // no need to lock optOut here since the setup is locked already
                 val optOut =

--- a/posthog/src/main/java/com/posthog/internal/EvaluationReason.kt
+++ b/posthog/src/main/java/com/posthog/internal/EvaluationReason.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -9,7 +10,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property condition_index the condition index of the reason
  */
 @IgnoreJRERequirement
-internal data class EvaluationReason(
+@PostHogInternal
+public data class EvaluationReason(
     val code: String?,
     val description: String?,
     val condition_index: Int?,

--- a/posthog/src/main/java/com/posthog/internal/FeatureFlag.kt
+++ b/posthog/src/main/java/com/posthog/internal/FeatureFlag.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -11,7 +12,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property reason the reason the feature flag was evaluated
  */
 @IgnoreJRERequirement
-internal data class FeatureFlag(
+@PostHogInternal
+public data class FeatureFlag(
     val key: String,
     val enabled: Boolean,
     val variant: String?,

--- a/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
+++ b/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -9,7 +10,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property version the version of the feature flag
  */
 @IgnoreJRERequirement
-internal data class FeatureFlagMetadata(
+@PostHogInternal
+public data class FeatureFlagMetadata(
     val id: Int,
     val payload: String?,
     val version: Int,

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -113,12 +113,22 @@ internal class PostHogApi(
     }
 
     @Throws(PostHogApiError::class, IOException::class)
-    fun flags(
+    public fun flags(
         distinctId: String,
-        anonymousId: String?,
-        groups: Map<String, String>?,
+        anonymousId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
     ): PostHogFlagsResponse? {
-        val flagsRequest = PostHogFlagsRequest(config.apiKey, distinctId, anonymousId = anonymousId, groups)
+        val flagsRequest =
+            PostHogFlagsRequest(
+                config.apiKey,
+                distinctId,
+                anonymousId = anonymousId,
+                groups,
+                personProperties,
+                groupProperties,
+            )
 
         val url = "$theHost/flags/?v=2&config=true"
         logRequest(flagsRequest, url)

--- a/posthog/src/main/java/com/posthog/internal/PostHogApiEndpoint.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApiEndpoint.kt
@@ -1,6 +1,9 @@
 package com.posthog.internal
 
-internal enum class PostHogApiEndpoint {
+import com.posthog.PostHogInternal
+
+@PostHogInternal
+public enum class PostHogApiEndpoint {
     BATCH,
     SNAPSHOT,
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogApiError.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApiError.kt
@@ -1,7 +1,7 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import okhttp3.ResponseBody
-import java.lang.RuntimeException
 
 /**
  * The API exception if not within the successful range (2xx - 3xx)
@@ -9,10 +9,11 @@ import java.lang.RuntimeException
  * @property message the exception message
  * @property message the OkHttp response body, the source might be closed already
  */
-internal class PostHogApiError(
-    val statusCode: Int,
+@PostHogInternal
+public class PostHogApiError(
+    public val statusCode: Int,
     override val message: String,
-    val body: ResponseBody?,
+    public val body: ResponseBody?,
 ) : RuntimeException(message) {
     override fun toString(): String {
         return "PostHogApiError(statusCode=$statusCode, message='$message')"

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagsInterface.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagsInterface.kt
@@ -1,29 +1,33 @@
 package com.posthog.internal
 
-import com.posthog.PostHogOnFeatureFlags
+import com.posthog.PostHogInternal
 
+@PostHogInternal
 public interface PostHogFeatureFlagsInterface {
-    public fun loadRemoteConfig(
-        distinctId: String,
-        anonymousId: String?,
-        groups: Map<String, String>?,
-        internalOnFeatureFlags: PostHogOnFeatureFlags? = null,
-        onFeatureFlags: PostHogOnFeatureFlags? = null,
-    )
-
     public fun getFeatureFlag(
         key: String,
         defaultValue: Any?,
+        distinctId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
     ): Any?
 
     public fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,
+        distinctId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
     ): Any?
 
-    public fun getFeatureFlags(): Map<String, Any>?
-
-    public fun isSessionReplayFlagActive(): Boolean
+    public fun getFeatureFlags(
+        distinctId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
+    ): Map<String, Any>?
 
     public fun clear()
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
@@ -6,9 +6,10 @@ package com.posthog.internal
 internal class PostHogFlagsRequest(
     apiKey: String,
     distinctId: String,
-    anonymousId: String?,
-    groups: Map<String, String>?,
-    // add person_properties, group_properties
+    anonymousId: String? = null,
+    groups: Map<String, String>? = null,
+    personProperties: Map<String, String>? = null,
+    groupProperties: Map<String, String>? = null,
 ) : HashMap<String, Any>() {
     init {
         this["api_key"] = apiKey
@@ -18,6 +19,12 @@ internal class PostHogFlagsRequest(
         }
         if (groups?.isNotEmpty() == true) {
             this["\$groups"] = groups
+        }
+        if (personProperties?.isNotEmpty() == true) {
+            this["\$properties"] = personProperties
+        }
+        if (groupProperties?.isNotEmpty() == true) {
+            this["\$group_properties"] = groupProperties
         }
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFlagsResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFlagsResponse.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -11,7 +12,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property quotaLimited array of quota limited features
  */
 @IgnoreJRERequirement
-internal data class PostHogFlagsResponse(
+@PostHogInternal
+public data class PostHogFlagsResponse(
     // assuming theres no errors if not present
     val errorsWhileComputingFlags: Boolean = false,
     val featureFlags: Map<String, Any>?,

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -1,6 +1,7 @@
 package com.posthog.internal
 
 import com.posthog.PostHogConfig
+import com.posthog.PostHogInternal
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAGS_PAYLOAD
@@ -18,7 +19,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @property api the API
  * @property executor the Executor
  */
-internal class PostHogRemoteConfig(
+@PostHogInternal
+public class PostHogRemoteConfig(
     private val config: PostHogConfig,
     private val api: PostHogApi,
     private val executor: ExecutorService,
@@ -53,7 +55,7 @@ internal class PostHogRemoteConfig(
      * Use this to notify listeners that cached surveys may have changed.
      */
     @Volatile
-    var onRemoteConfigLoaded: (() -> Unit)? = null
+    public var onRemoteConfigLoaded: (() -> Unit)? = null
 
     init {
         preloadSessionReplayFlag()
@@ -392,7 +394,7 @@ internal class PostHogRemoteConfig(
         }
     }
 
-    fun loadFeatureFlags(
+    public fun loadFeatureFlags(
         distinctId: String,
         anonymousId: String?,
         groups: Map<String, String>?,
@@ -600,14 +602,14 @@ internal class PostHogRemoteConfig(
 
     public fun isSessionReplayFlagActive(): Boolean = sessionReplayFlagActive
 
-    fun getRequestId(): String? {
+    public fun getRequestId(): String? {
         loadFeatureFlagsFromCacheIfNeeded()
         synchronized(featureFlagsLock) {
             return requestId
         }
     }
 
-    fun getFlagDetails(key: String): FeatureFlag? {
+    public fun getFlagDetails(key: String): FeatureFlag? {
         loadFeatureFlagsFromCacheIfNeeded()
 
         synchronized(featureFlagsLock) {
@@ -615,7 +617,7 @@ internal class PostHogRemoteConfig(
         }
     }
 
-    fun getSurveys(): List<Survey>? {
+    public fun getSurveys(): List<Survey>? {
         synchronized(remoteConfigLock) {
             return surveys
         }

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -119,12 +119,12 @@ internal class PostHogRemoteConfig(
         }
     }
 
-    override fun loadRemoteConfig(
+    public fun loadRemoteConfig(
         distinctId: String,
         anonymousId: String?,
         groups: Map<String, String>?,
-        internalOnFeatureFlags: PostHogOnFeatureFlags?,
-        onFeatureFlags: PostHogOnFeatureFlags?,
+        internalOnFeatureFlags: PostHogOnFeatureFlags? = null,
+        onFeatureFlags: PostHogOnFeatureFlags? = null,
     ) {
         executor.executeSafely {
             if (config.networkStatus?.isConnected() == false) {
@@ -560,6 +560,10 @@ internal class PostHogRemoteConfig(
     override fun getFeatureFlag(
         key: String,
         defaultValue: Any?,
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
     ): Any? {
         // since we pass featureFlags as a value, we need to load it from cache if needed
         loadFeatureFlagsFromCacheIfNeeded()
@@ -570,6 +574,10 @@ internal class PostHogRemoteConfig(
     override fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
     ): Any? {
         // since we pass featureFlags as a value, we need to load it from cache if needed
         loadFeatureFlagsFromCacheIfNeeded()
@@ -577,7 +585,12 @@ internal class PostHogRemoteConfig(
         return readFeatureFlag(key, defaultValue, featureFlagPayloads)
     }
 
-    override fun getFeatureFlags(): Map<String, Any>? {
+    override fun getFeatureFlags(
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
+    ): Map<String, Any>? {
         val flags: Map<String, Any>?
         synchronized(featureFlagsLock) {
             flags = featureFlags?.toMap()
@@ -585,7 +598,7 @@ internal class PostHogRemoteConfig(
         return flags
     }
 
-    override fun isSessionReplayFlagActive(): Boolean = sessionReplayFlagActive
+    public fun isSessionReplayFlagActive(): Boolean = sessionReplayFlagActive
 
     fun getRequestId(): String? {
         loadFeatureFlagsFromCacheIfNeeded()

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfigResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfigResponse.kt
@@ -1,13 +1,15 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 @IgnoreJRERequirement
-internal open class PostHogRemoteConfigResponse(
+@PostHogInternal
+public open class PostHogRemoteConfigResponse(
     // its either a boolean or a map, see https://github.com/PostHog/posthog-js/blob/10fd7f4fa083f997d31a4a4c7be7d311d0a95e74/src/types.ts#L235-L243
-    val sessionRecording: Any? = false,
+    public val sessionRecording: Any? = false,
     // its either a boolean or a map
-    val surveys: Any? = false,
+    public val surveys: Any? = false,
     // Indicates if the team has any flags enabled (if not we don't need to load them)
-    val hasFeatureFlags: Boolean? = false,
+    public val hasFeatureFlags: Boolean? = false,
 )

--- a/posthog/src/main/java/com/posthog/internal/PostHogUtils.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogUtils.kt
@@ -22,7 +22,8 @@ private fun isConnectionTimeout(throwable: Throwable): Boolean {
     return throwable is SocketTimeoutException
 }
 
-internal fun Throwable.isNetworkingError(): Boolean {
+@PostHogInternal
+public fun Throwable.isNetworkingError(): Boolean {
     return isConnectionTimeout(this) ||
         noInternetAvailable(this) ||
         isRequestCanceled(this)
@@ -45,7 +46,8 @@ internal fun File.existsSafely(config: PostHogConfig): Boolean {
     }
 }
 
-internal fun Executor.executeSafely(run: Runnable) {
+@PostHogInternal
+public fun Executor.executeSafely(run: Runnable) {
     try {
         // can throw RejectedExecutionException
         execute(run)

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -93,19 +93,13 @@ internal class PostHogStatelessTest {
             flags[key] = value
         }
 
-        override fun loadRemoteConfig(
-            distinctId: String,
-            anonymousId: String?,
-            groups: Map<String, String>?,
-            internalOnFeatureFlags: PostHogOnFeatureFlags?,
-            onFeatureFlags: PostHogOnFeatureFlags?,
-        ) {
-            // Mock implementation
-        }
-
         override fun getFeatureFlag(
             key: String,
             defaultValue: Any?,
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, String>?,
+            groupProperties: Map<String, String>?,
         ): Any? {
             return flags[key] ?: defaultValue
         }
@@ -113,16 +107,21 @@ internal class PostHogStatelessTest {
         override fun getFeatureFlagPayload(
             key: String,
             defaultValue: Any?,
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, String>?,
+            groupProperties: Map<String, String>?,
         ): Any? {
             return flags[key] ?: defaultValue
         }
 
-        override fun getFeatureFlags(): Map<String, Any> {
+        override fun getFeatureFlags(
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, String>?,
+            groupProperties: Map<String, String>?,
+        ): Map<String, Any> {
             return flags.toMap()
-        }
-
-        override fun isSessionReplayFlagActive(): Boolean {
-            return false
         }
 
         override fun clear() {


### PR DESCRIPTION
## :bulb: Motivation and Context

This change allows core configuration to be extended via composition, hiding configuration that is not needed in a specific environment (e.g., server-side applications do not need survey configuration).

`PostHogConfig` now has two factory methods from which it will construct the event queue and remote config. By default, `PostHogQueue` and `PostHogRemoteConfig` will be used for backwards compatibility. This change will not affect any existing behavior.

As a result of this change, a whole bunch of things that were marked `internal` are now public (but typically annotated `@PostHogInternal`). This allows the server-side module to define it's own feature flags logic without adding an alternate implementation to the core module.

## :green_heart: How did you test it?

Existing tests are passing. This change does not affect behavior. I haven't yet compiled against Flutter or React Native, but I want to get this out first.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
