### PR TITLE
feat: Initial release of `posthog-server`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,12 @@ jobs:
             echo "dry_target=dryReleaseAndroid" >> $GITHUB_OUTPUT
             echo "release_target=releaseAndroid" >> $GITHUB_OUTPUT
             echo "module=android" >> $GITHUB_OUTPUT
+          elif [[ "$TAG" == server-v* ]]; then
+            echo "dry_target=dryReleaseServer" >> $GITHUB_OUTPUT
+            echo "release_target=releaseServer" >> $GITHUB_OUTPUT
+            echo "module=server" >> $GITHUB_OUTPUT
           else
-            echo "ERROR: Unknown tag format '$TAG'. Expected 'core-v*' or 'android-v*'"
+            echo "ERROR: Unknown tag format '$TAG'. Expected 'core-v*', 'android-v*', or 'server-v*'"
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ dryReleaseCore:
 dryReleaseAndroid:
 	./gradlew :posthog-android:publishToMavenLocal
 
+dryReleaseServer:
+	./gradlew :posthog-server:publishToMavenLocal
+
 release:
 	./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
 
@@ -37,6 +40,9 @@ releaseCore:
 
 releaseAndroid:
 	./gradlew :posthog-android:publishToSonatype closeAndReleaseSonatypeStagingRepository
+
+releaseServer:
+	./gradlew :posthog-server:publishToSonatype closeAndReleaseSonatypeStagingRepository
 
 testReport:
 	./gradlew koverHtmlReport

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,9 +6,12 @@
 2. Commit the changes
 3. Run: `./scripts/bump-version.sh core 3.23.0`
    - This bumps version, commits, and pushes with tag `core-v3.23.0`
-4. Go to [GH Releases](https://github.com/PostHog/posthog-android/releases)
-5. Create release with tag `core-v3.23.0`
-6. A GitHub action triggers `make releaseCore` automatically
+4. Go to [GH Releases](https://github.com/PostHog/posthog-android/releases) and draft a new release
+5. Choose a release name (e.g. `core-v3.23.0`), and the tag you just created, ideally the same.
+6. Write a description of the release.
+7. Publish the release.
+8. A GitHub action triggers `make releaseAndroid` automatically
+9. Done.
 
 ### Android module (posthog-android):
 
@@ -16,13 +19,30 @@
 2. Commit the changes
 3. Run: `./scripts/bump-version.sh android 3.23.0`
    - This bumps version, commits, and pushes with tag `android-v3.23.0`
-4. Go to [GH Releases](https://github.com/PostHog/posthog-android/releases)
-5. Create release with tag `android-v3.23.0`
-6. A GitHub action triggers `make releaseAndroid` automatically
+4. Go to [GH Releases](https://github.com/PostHog/posthog-android/releases) and draft a new release
+5. Choose a release name (e.g. `android-v3.23.0`), and the tag you just created, ideally the same.
+6. Write a description of the release.
+7. Publish the release.
+8. A GitHub action triggers `make releaseAndroid` automatically
+9. Done.
+
+### Server module (posthog-server):
+
+1. Update `posthog-server/CHANGELOG.md` with the version and date
+2. Commit the changes
+3. Run: `./scripts/bump-version.sh server 1.0.1`
+   - This bumps version, commits, and pushes with tag `server-v1.0.1`
+4. Go to [GH Releases](https://github.com/PostHog/posthog-android/releases) and draft a new release
+5. Choose a release name (e.g. `server-v1.0.1`), and the tag you just created, ideally the same.
+6. Write a description of the release.
+7. Publish the release.
+8. A GitHub action triggers `make releaseServer` automatically
+9. Done.
 
 ## Tag Naming Convention
 
 - `core-v3.23.0` → releases only posthog core module
 - `android-v3.23.0` → releases only posthog-android module
+- `server-v1.0.1` → releases only posthog-server module
 
-Preview releases follow the pattern `core-v3.0.0-alpha.1`, `android-v3.0.0-beta.1`, etc.
+Preview releases follow the pattern `core-v3.0.0-alpha.1`, `android-v3.0.0-beta.1`, `server-v1.0.0-alpha.1`, etc.

--- a/buildSrc/src/main/java/PostHogPublishConfig.kt
+++ b/buildSrc/src/main/java/PostHogPublishConfig.kt
@@ -108,6 +108,7 @@ fun MavenPublication.postHogConfig(
         when (projectName) {
             "posthog" -> properties["coreVersion"].toString()
             "posthog-android" -> properties["androidVersion"].toString()
+            "posthog-server" -> properties["serverVersion"].toString()
             else -> throw IllegalArgumentException(
                 "Unknown project name '$projectName'. Please add version mapping in PostHogPublishConfig.kt",
             )

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -8,7 +8,7 @@ async function checkChangelog() {
   }
 
   // Check if current PR has an entry in any changelog
-  const changelogFiles = ["posthog/CHANGELOG.md", "posthog-android/CHANGELOG.md"];
+  const changelogFiles = ["posthog/CHANGELOG.md", "posthog-android/CHANGELOG.md", "posthog-server/CHANGELOG.md"];
   let hasChangelogEntry = false;
 
   for (const file of changelogFiles) {
@@ -44,6 +44,7 @@ async function checkChangelog() {
 Please add an entry to the appropriate changelog:
 - \`posthog/CHANGELOG.md\` (core module)
 - \`posthog-android/CHANGELOG.md\` (android module)
+- \`posthog-server/CHANGELOG.md\` (server module)
 
 Make sure the entry includes this PR's number.
 Example:

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,4 @@ android.defaults.buildfeatures.resvalues=false
 # Release - Module-specific versions
 coreVersion=3.22.0
 androidVersion=3.22.0
+serverVersion=1.0.0

--- a/posthog-samples/posthog-java-sample/README.md
+++ b/posthog-samples/posthog-java-sample/README.md
@@ -1,0 +1,68 @@
+# PostHog Java Sample
+
+This is a simple Java 1.8 example demonstrating how to use the PostHog Server library.
+
+## Overview
+
+This sample shows:
+- Basic PostHog configuration
+- Event capture
+- Event capture with properties
+- User identification
+- User properties
+- Feature flags
+- Group analytics
+
+## Running the Example
+
+1. Update the API key in `PostHogJavaExample.java`:
+   ```java
+   PostHogConfig config = new PostHogConfig("your_actual_api_key_here")
+   ```
+
+2. Run the example:
+   ```bash
+   ./gradlew :posthog-samples:posthog-java-sample:run
+   ```
+
+## Key Features Demonstrated
+
+### Event Tracking
+```java
+// Simple event
+postHog.capture("button_clicked");
+
+// Event with properties
+Map<String, Object> properties = new HashMap<>();
+properties.put("button_name", "signup");
+postHog.capture("button_clicked", properties);
+```
+
+### User Management
+```java
+// Identify user
+postHog.identify("user123");
+
+// Set user properties
+Map<String, Object> userProperties = new HashMap<>();
+userProperties.put("email", "user@example.com");
+postHog.capture("$set", userProperties);
+```
+
+### Feature Flags
+```java
+boolean isEnabled = postHog.isFeatureEnabled("new_feature", false);
+Object flagValue = postHog.getFeatureFlag("new_feature");
+```
+
+### Groups
+```java
+Map<String, Object> groupProperties = new HashMap<>();
+groupProperties.put("name", "Acme Corp");
+postHog.group("company", "company_123", groupProperties);
+```
+
+## Requirements
+
+- Java 1.8 or higher
+- PostHog API key

--- a/posthog-samples/posthog-java-sample/build.gradle.kts
+++ b/posthog-samples/posthog-java-sample/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("java-library")
+    id("application")
+}
+
+java {
+    sourceCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
+    targetCompatibility = PosthogBuildConfig.Build.JAVA_VERSION
+}
+
+application {
+    mainClass.set("com.posthog.java.sample.PostHogJavaExample")
+}
+
+dependencies {
+    implementation(project(":posthog-server"))
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:${PosthogBuildConfig.Dependencies.OKHTTP}"))
+    implementation("com.squareup.okhttp3:okhttp")
+    implementation("com.google.code.gson:gson:${PosthogBuildConfig.Dependencies.GSON}")
+
+    // Example logging
+    implementation("org.slf4j:slf4j-simple:1.7.36")
+}

--- a/posthog-samples/posthog-java-sample/src/main/java/com/posthog/java/sample/PostHogJavaExample.java
+++ b/posthog-samples/posthog-java-sample/src/main/java/com/posthog/java/sample/PostHogJavaExample.java
@@ -1,0 +1,59 @@
+package com.posthog.java.sample;
+
+import com.posthog.server.PostHogCaptureOptions;
+import com.posthog.server.PostHogConfig;
+import com.posthog.server.PostHog;
+import com.posthog.server.PostHogInterface;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple Java 1.8 example demonstrating PostHog usage
+ */
+public class PostHogJavaExample {
+    public static void main(String[] args) {
+        PostHogConfig config = PostHogConfig
+                .builder("phc_wz4KZkikEluCCdfY2B2h7MXYygNGdTqFgjbU7I1ZdVR")
+                .build();
+
+        PostHogInterface postHog = PostHog.with(config);
+
+        postHog.group("distinct-id", "company", "some-company-id");
+        postHog.capture(
+                "distinct-id",
+                "new-purchase",
+                PostHogCaptureOptions
+                        .builder()
+                        .property("item", "SKU-0000")
+                        .property("sale", false)
+                        .build());
+
+        HashMap<String, Object> userProperties = new HashMap<>();
+        userProperties.put("email", "user@example.com");
+        postHog.identify("distinct-id", userProperties);
+
+        // AVOID - Anonymous inner class holds reference to outer class.
+        // The following won't serialize properly.
+        // postHog.identify("user-123", new HashMap<String, Object>() {{
+        //      put("key", "value");
+        // }});
+
+        postHog.alias("distinct-id", "alias-id");
+
+
+        if (postHog.isFeatureEnabled("distinct-id", "beta-feature", false)) {
+            System.out.println("The feature is enabled.");
+        }
+
+        Object flagValue = postHog.getFeatureFlag("distinct-id", "multi-variate-flag", "default");
+        String flagVariate = flagValue instanceof String ? (String) flagValue : "default";
+        Object flagPayload = postHog.getFeatureFlagPayload("distinct-id", "multi-variate-flag");
+
+        System.out.println("The flag variant was: " + flagVariate);
+        System.out.println("Received flag payload: " + flagPayload);
+
+        postHog.flush();
+        postHog.close();
+    }
+}

--- a/posthog-server/CHANGELOG.md
+++ b/posthog-server/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Next
+
+- Initial release ([#288](https://github.com/PostHog/posthog-android/pull/288))

--- a/posthog-server/USAGE.md
+++ b/posthog-server/USAGE.md
@@ -1,0 +1,340 @@
+# How to use the PostHog Server SDK
+
+The PostHog Server SDK is designed for server-side applications and provides a simple, stateless interface for sending events and managing feature flags.
+
+Java examples given in this document aim to work on any Java versions 8 and up.
+
+## Setup
+
+### Gradle
+
+```kotlin
+// build.gradle.kts
+implementation("com.posthog:posthog-server:$latestVersion")
+```
+
+```groovy
+// build.gradle
+implementation 'com.posthog:posthog-server:$latestVersion'
+```
+
+### Kotlin
+
+```kotlin
+import com.posthog.server.PostHog
+import com.posthog.server.PostHogConfig
+
+val config = PostHogConfig(apiKey = "phc_your_api_key_here")
+val postHog = PostHog.with(config)
+```
+
+### Java
+
+```java
+import com.posthog.server.PostHog;
+import com.posthog.server.PostHogConfig;
+import com.posthog.server.PostHogInterface;
+
+PostHogConfig config = new PostHogConfig("phc_your_api_key_here");
+PostHogInterface postHog = PostHog.with(config);
+```
+
+## Configuration
+
+### Set a custom host (Self-Hosted)
+
+#### Kotlin
+
+```kotlin
+val config = PostHogConfig(
+    apiKey = "phc_your_api_key_here",
+    host = "https://your-posthog-instance.com"
+)
+```
+
+#### Java
+
+```java
+PostHogConfig config = new PostHogConfig(
+    "phc_your_api_key_here",
+    "https://your-posthog-instance.com"
+);
+```
+
+#### Builder Pattern Configuration (Java)
+
+```java
+PostHogConfig config = PostHogConfig.builder("phc_your_api_key_here")
+    .host("https://your-posthog-instance.com")
+    .debug(true)
+    .sendFeatureFlagEvent(false)
+    .preloadFeatureFlags(true)
+    .flushAt(50)
+    .maxQueueSize(2000)
+    .maxBatchSize(100)
+    .flushIntervalSeconds(60)
+    .featureFlagCacheSize(1000)
+    .featureFlagCacheMaxAgeMs(5 * 60 * 1000)
+    .build();
+```
+
+### Available Configuration Options
+
+- `apiKey`: Your PostHog API key (required)
+- `host`: PostHog host URL (default: `https://us.i.posthog.com`)
+- `debug`: Enable debug logging (default: `false`)
+- `sendFeatureFlagEvent`: Send feature flag events automatically (default: `true`)
+- `preloadFeatureFlags`: Preload feature flags on startup (default: `true`)
+- `remoteConfig`: Enable remote configuration (default: `true`)
+- `flushAt`: Number of events to batch before sending (default: `20`)
+- `maxQueueSize`: Maximum events in memory/disk (default: `1000`)
+- `maxBatchSize`: Maximum events per batch (default: `50`)
+- `flushIntervalSeconds`: Interval between automatic flushes (default: `30`)
+- `featureFlagCacheSize`: The maximum number of feature flags results to cache (default: `1000`)
+- `featureFlagCacheMaxAgeMs`: The maximum age of a feature flag cache record in memory in milliseconds (default: `300000` or five minutes)
+
+## Capturing Events
+
+### Simple Event Capture
+
+#### Kotlin & Java
+
+```kotlin
+postHog.capture("user123", "button_clicked")
+```
+
+### Event with Properties
+
+#### Kotlin
+
+```kotlin
+postHog.capture(
+    distinctId = "user123",
+    event = "purchase_completed",
+    properties = mapOf("product" to "premium_plan", "price" to 99.99),
+    userProperties = mapOf("plan" to "premium"),
+    userPropertiesSetOnce = mapOf("first_purchase_date" to "2023-01-15"),
+    groups = mapOf("company" to "acme_corp")
+)
+```
+
+#### Java
+
+> [!WARNING]
+> Avoid using anonymous inner classes (double braces) to initialize your HashMaps. These hold references to the outer class and will not serialize properly.
+
+```java
+Map<String, Object> properties = new HashMap<>();
+properties.put("button_name", "signup");
+properties.put("page", "landing");
+properties.put("experiment_variant", "blue_button");
+postHog.capture("user123", "button_clicked", properties);
+```
+
+#### Builder Pattern (Java)
+
+```java
+postHog.capture(
+    "distinct-id",
+    "new-purchase",
+    PostHogCaptureOptions
+        .builder()
+        .property("item", "SKU-0000")
+        .property("sale", false)
+        .userProperty("plan", "premium")
+        .userPropertySetOnce("signup_date", "2023-01-01")
+        .build()
+);
+```
+
+## User Identification
+
+#### Kotlin
+
+```kotlin
+postHog.identify(
+    "user123",
+    userProperties = mapOf("current_plan" to "premium"),
+    userPropertiesSetOnce = mapOf(
+        "signup_date" to "2023-01-01",
+        "initial_referrer" to "google"
+    )
+)
+```
+
+#### Java
+
+```java
+Map<String, Object> userProperties = new HashMap<>();
+userProperties.put("current_plan", "premium");
+
+Map<String, Object> userPropertiesSetOnce = new HashMap<>();
+userPropertiesSetOnce.put("signup_date", "2023-01-01");
+userPropertiesSetOnce.put("initial_referrer", "google");
+
+postHog.identify("user123", userProperties, userPropertiesSetOnce);
+```
+
+## Feature Flags
+
+### Check if Feature is Enabled
+
+#### Kotlin
+
+```kotlin
+val isEnabled = postHog.isFeatureEnabled("user123", "beta_feature", false)
+if (isEnabled) {
+    // Show beta feature
+}
+```
+
+#### Java
+
+```java
+boolean isEnabled = postHog.isFeatureEnabled("user123", "beta_feature", false);
+if (isEnabled) {
+    // Show beta feature
+}
+```
+
+### Get Feature Flag Value
+
+#### Kotlin
+
+```kotlin
+val flagValue = postHog.getFeatureFlag("user123", "theme_variant", "light")
+when (flagValue) {
+    "dark" -> applyDarkTheme()
+    "light" -> applyLightTheme()
+    else -> applyDefaultTheme()
+}
+```
+
+#### Java
+
+```java
+Object flagValue = postHog.getFeatureFlag("user123", "theme_variant", "light");
+String theme = flagValue instanceof String ? (String) flagValue : "light";
+switch (theme) {
+    case "dark":
+        applyDarkTheme();
+        break;
+    case "light":
+        applyLightTheme();
+        break;
+    default:
+        applyDefaultTheme();
+}
+```
+
+### Get Feature Flag Payload
+
+#### Kotlin
+
+```kotlin
+val payload = postHog.getFeatureFlagPayload("user123", "experiment_config")
+if (payload is Map<*, *>) {
+    val config = payload as Map<String, Any>
+    val buttonColor = config["button_color"] as? String ?: "blue"
+    val showBanner = config["show_banner"] as? Boolean ?: false
+}
+```
+
+#### Java
+
+```java
+Object payload = postHog.getFeatureFlagPayload("user123", "experiment_config");
+if (payload instanceof Map) {
+    Map<String, Object> config = (Map<String, Object>) payload;
+    String buttonColor = config.get("button_color") instanceof String
+        ? (String) config.get("button_color") : "blue";
+    boolean showBanner = config.get("show_banner") instanceof Boolean
+        ? (Boolean) config.get("show_banner") : false;
+}
+```
+
+## Groups
+
+### Create a Group
+
+#### Kotlin
+
+```kotlin
+val groupProperties = mapOf(
+    "name" to "Acme Corporation",
+    "industry" to "Technology",
+    "employee_count" to 500
+)
+postHog.group("user123", "company", "acme_corp", groupProperties)
+```
+
+#### Java
+
+```java
+Map<String, Object> groupProperties = new HashMap<>();
+groupProperties.put("name", "Acme Corporation");
+groupProperties.put("industry", "Technology");
+groupProperties.put("employee_count", 500);
+postHog.group("user123", "company", "acme_corp", groupProperties);
+```
+
+### Simple Group Creation
+
+#### Kotlin & Java
+
+```kotlin
+postHog.group("user123", "organization", "org_123")
+```
+
+## User Aliases
+
+### Create an Alias
+
+#### Kotlin & Java
+
+```kotlin
+postHog.alias("user123", "john_doe_alias")
+```
+
+## SDK Management
+
+### Flush Events
+
+Force send all queued events immediately:
+
+#### Kotlin & Java
+
+```kotlin
+postHog.flush()
+```
+
+### Enable Debug Mode
+
+#### Kotlin & Java
+
+```kotlin
+postHog.debug(true)  // Enable debug logging
+postHog.debug(false) // Disable debug logging
+```
+
+### Close the SDK
+
+#### Kotlin & Java
+
+```kotlin
+postHog.close()
+```
+
+## Error Handling
+
+The PostHog Server SDK is designed to be resilient and won't throw exceptions for normal operations. Network errors and API failures are handled gracefully with automatic retries and fallback behaviors.
+
+## Thread Safety
+
+The PostHog Server SDK is thread-safe and can be used safely from multiple threads concurrently.
+
+## Requirements
+
+- Java 8 or higher
+- Kotlin 1.6 or higher (if using Kotlin)
+- Internet connection for sending events to PostHog

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -1,0 +1,175 @@
+public final class com/posthog/server/PostHog : com/posthog/server/PostHogInterface {
+	public static final field Companion Lcom/posthog/server/PostHog$Companion;
+	public fun <init> ()V
+	public fun alias (Ljava/lang/String;Ljava/lang/String;)V
+	public fun capture (Ljava/lang/String;Ljava/lang/String;)V
+	public fun capture (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
+	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public fun close ()V
+	public fun debug (Z)V
+	public fun flush ()V
+	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun group (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun identify (Ljava/lang/String;)V
+	public fun identify (Ljava/lang/String;Ljava/util/Map;)V
+	public fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public fun isFeatureEnabled (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun isFeatureEnabled (Ljava/lang/String;Ljava/lang/String;Z)Z
+	public fun setup (Lcom/posthog/server/PostHogConfig;)V
+	public static final fun with (Lcom/posthog/server/PostHogConfig;)Lcom/posthog/server/PostHogInterface;
+}
+
+public final class com/posthog/server/PostHog$Companion {
+	public final fun with (Lcom/posthog/server/PostHogConfig;)Lcom/posthog/server/PostHogInterface;
+}
+
+public final class com/posthog/server/PostHogCaptureOptions {
+	public static final field Companion Lcom/posthog/server/PostHogCaptureOptions$Companion;
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun builder ()Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun getGroups ()Ljava/util/Map;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getUserProperties ()Ljava/util/Map;
+	public final fun getUserPropertiesSetOnce ()Ljava/util/Map;
+}
+
+public final class com/posthog/server/PostHogCaptureOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/posthog/server/PostHogCaptureOptions;
+	public final fun getGroups ()Ljava/util/Map;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getUserProperties ()Ljava/util/Map;
+	public final fun getUserPropertiesSetOnce ()Ljava/util/Map;
+	public final fun group (Ljava/lang/String;Ljava/lang/String;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun groups (Ljava/util/Map;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun properties (Ljava/util/Map;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun property (Ljava/lang/String;Ljava/lang/Object;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun setGroups (Ljava/util/Map;)V
+	public final fun setProperties (Ljava/util/Map;)V
+	public final fun setUserProperties (Ljava/util/Map;)V
+	public final fun setUserPropertiesSetOnce (Ljava/util/Map;)V
+	public final fun userProperties (Ljava/util/Map;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun userPropertiesSetOnce (Ljava/util/Map;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun userProperty (Ljava/lang/String;Ljava/lang/Object;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun userPropertySetOnce (Ljava/lang/String;Ljava/lang/Object;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+}
+
+public final class com/posthog/server/PostHogCaptureOptions$Companion {
+	public final fun builder ()Lcom/posthog/server/PostHogCaptureOptions$Builder;
+}
+
+public class com/posthog/server/PostHogConfig {
+	public static final field Companion Lcom/posthog/server/PostHogConfig$Companion;
+	public static final field DEFAULT_EU_ASSETS_HOST Ljava/lang/String;
+	public static final field DEFAULT_EU_HOST Ljava/lang/String;
+	public static final field DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS I
+	public static final field DEFAULT_FEATURE_FLAG_CACHE_SIZE I
+	public static final field DEFAULT_FLUSH_AT I
+	public static final field DEFAULT_FLUSH_INTERVAL_SECONDS I
+	public static final field DEFAULT_HOST Ljava/lang/String;
+	public static final field DEFAULT_MAX_BATCH_SIZE I
+	public static final field DEFAULT_MAX_QUEUE_SIZE I
+	public static final field DEFAULT_US_ASSETS_HOST Ljava/lang/String;
+	public static final field DEFAULT_US_HOST Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Ljava/net/Proxy;II)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Ljava/net/Proxy;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
+	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
+	public static final fun builder (Ljava/lang/String;)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun getApiKey ()Ljava/lang/String;
+	public final fun getDebug ()Z
+	public final fun getEncryption ()Lcom/posthog/PostHogEncryption;
+	public final fun getFeatureFlagCacheMaxAgeMs ()I
+	public final fun getFeatureFlagCacheSize ()I
+	public final fun getFlushAt ()I
+	public final fun getFlushIntervalSeconds ()I
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getMaxBatchSize ()I
+	public final fun getMaxQueueSize ()I
+	public final fun getOnFeatureFlags ()Lcom/posthog/PostHogOnFeatureFlags;
+	public final fun getPreloadFeatureFlags ()Z
+	public final fun getProxy ()Ljava/net/Proxy;
+	public final fun getRemoteConfig ()Z
+	public final fun getSendFeatureFlagEvent ()Z
+	public final fun removeBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
+	public final fun setDebug (Z)V
+	public final fun setEncryption (Lcom/posthog/PostHogEncryption;)V
+	public final fun setFeatureFlagCacheMaxAgeMs (I)V
+	public final fun setFeatureFlagCacheSize (I)V
+	public final fun setFlushAt (I)V
+	public final fun setFlushIntervalSeconds (I)V
+	public final fun setMaxBatchSize (I)V
+	public final fun setMaxQueueSize (I)V
+	public final fun setOnFeatureFlags (Lcom/posthog/PostHogOnFeatureFlags;)V
+	public final fun setPreloadFeatureFlags (Z)V
+	public final fun setProxy (Ljava/net/Proxy;)V
+	public final fun setRemoteConfig (Z)V
+	public final fun setSendFeatureFlagEvent (Z)V
+}
+
+public final class com/posthog/server/PostHogConfig$Builder {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun build ()Lcom/posthog/server/PostHogConfig;
+	public final fun debug (Z)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun encryption (Lcom/posthog/PostHogEncryption;)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun flushAt (I)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun flushIntervalSeconds (I)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun host (Ljava/lang/String;)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun maxBatchSize (I)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun maxQueueSize (I)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun onFeatureFlags (Lcom/posthog/PostHogOnFeatureFlags;)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun preloadFeatureFlags (Z)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun proxy (Ljava/net/Proxy;)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun remoteConfig (Z)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun sendFeatureFlagEvent (Z)Lcom/posthog/server/PostHogConfig$Builder;
+}
+
+public final class com/posthog/server/PostHogConfig$Companion {
+	public final fun builder (Ljava/lang/String;)Lcom/posthog/server/PostHogConfig$Builder;
+}
+
+public abstract interface class com/posthog/server/PostHogInterface {
+	public abstract fun alias (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
+	public abstract synthetic fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public abstract fun close ()V
+	public abstract fun debug (Z)V
+	public abstract fun flush ()V
+	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun group (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun group (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun identify (Ljava/lang/String;)V
+	public abstract fun identify (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun identify (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public abstract fun isFeatureEnabled (Ljava/lang/String;Ljava/lang/String;)Z
+	public abstract fun isFeatureEnabled (Ljava/lang/String;Ljava/lang/String;Z)Z
+	public abstract fun setup (Lcom/posthog/server/PostHogConfig;)V
+}
+
+public final class com/posthog/server/PostHogInterface$DefaultImpls {
+	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)V
+	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
+	public static synthetic fun capture$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun debug$default (Lcom/posthog/server/PostHogInterface;ZILjava/lang/Object;)V
+	public static fun getFeatureFlag (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public static synthetic fun getFeatureFlag$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun getFeatureFlagPayload (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public static synthetic fun getFeatureFlagPayload$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun group (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun group$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static fun identify (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;)V
+	public static fun identify (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/util/Map;)V
+	public static synthetic fun identify$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun identify$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
+	public static fun isFeatureEnabled (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)Z
+	public static synthetic fun isFeatureEnabled$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Z
+}
+

--- a/posthog-server/build.gradle.kts
+++ b/posthog-server/build.gradle.kts
@@ -1,0 +1,114 @@
+@file:Suppress("ktlint:standard:max-line-length")
+
+import org.jetbrains.kotlin.config.KotlinCompilerVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `java-library`
+    kotlin("jvm")
+    id("com.android.lint")
+
+    // publish
+    `maven-publish`
+    signing
+    id("org.jetbrains.dokka")
+
+    // plugins
+    id("com.github.gmazzo.buildconfig")
+
+    // tests
+    id("org.jetbrains.kotlinx.kover")
+
+    // compatibility
+    id("ru.vyarus.animalsniffer")
+}
+
+buildConfig {
+    useKotlinOutput()
+    packageName("com.posthog")
+    buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
+}
+
+java {
+    withSourcesJar()
+}
+
+val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
+    dependsOn(tasks.dokkaJavadoc)
+    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+    archiveClassifier.set("javadoc")
+}
+
+val dokkaHtmlJar by tasks.register<Jar>("dokkaHtmlJar") {
+    dependsOn(tasks.dokkaHtml)
+    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
+    archiveClassifier.set("html-doc")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            artifact(dokkaJavadocJar)
+            artifact(dokkaHtmlJar)
+
+            postHogConfig(project.name, properties)
+
+            pom.postHogConfig(project.name)
+        }
+    }
+    signing.postHogConfig("maven", this)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.postHogConfig()
+}
+
+kotlin {
+    explicitApi()
+    jvmToolchain(PosthogBuildConfig.Build.JAVA_VERSION.majorVersion.toInt())
+}
+
+configure<SourceSetContainer> {
+    test {
+        java.srcDir("src/test/java")
+    }
+}
+
+animalsniffer {
+    ignore("java.util.HashMap")
+}
+
+dependencies {
+    // Depend on posthog-core module (not posthog-android)
+    api(project(":posthog"))
+
+    implementation(kotlin("stdlib-jdk8", KotlinCompilerVersion.VERSION))
+
+    implementation("com.google.code.gson:gson:${PosthogBuildConfig.Dependencies.GSON}")
+
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:${PosthogBuildConfig.Dependencies.OKHTTP}"))
+    implementation("com.squareup.okhttp3:okhttp")
+    compileOnly("org.codehaus.mojo:animal-sniffer-annotations:${PosthogBuildConfig.Plugins.ANIMAL_SNIFFER_SDK_ANNOTATION}")
+
+    // compatibility
+    signature("org.codehaus.mojo.signature:java18:${PosthogBuildConfig.Plugins.SIGNATURE_JAVA18}@signature")
+    signature(
+        "net.sf.androidscents.signature:android-api-level-${PosthogBuildConfig.Android.MIN_SDK}:${PosthogBuildConfig.Plugins.ANIMAL_SNIFFER_SDK_VERSION}@signature",
+    )
+    signature(
+        "com.toasttab.android:gummy-bears-api-${PosthogBuildConfig.Android.MIN_SDK}:${PosthogBuildConfig.Plugins.GUMMY_BEARS_API}@signature",
+    )
+
+    // tests
+    testImplementation("org.mockito.kotlin:mockito-kotlin:${PosthogBuildConfig.Dependencies.MOCKITO}")
+    testImplementation("org.mockito:mockito-inline:${PosthogBuildConfig.Dependencies.MOCKITO_INLINE}")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:${PosthogBuildConfig.Kotlin.KOTLIN}")
+    testImplementation("com.squareup.okhttp3:mockwebserver:${PosthogBuildConfig.Dependencies.OKHTTP}")
+}
+
+tasks.javadoc {
+    if (JavaVersion.current().isJava9Compatible) {
+        (options as StandardJavadocDocletOptions).addBooleanOption("html5", true)
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/PostHog.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHog.kt
@@ -1,0 +1,116 @@
+package com.posthog.server
+
+import com.posthog.PostHogStateless
+import com.posthog.PostHogStatelessInterface
+
+public class PostHog : PostHogInterface {
+    private var instance: PostHogStatelessInterface? = null
+
+    override fun <T : PostHogConfig> setup(config: T) {
+        instance = PostHogStateless.with(config.asCoreConfig())
+    }
+
+    override fun close() {
+        instance?.close()
+    }
+
+    override fun identify(
+        distinctId: String,
+        userProperties: Map<String, Any>?,
+        userPropertiesSetOnce: Map<String, Any>?,
+    ) {
+        instance?.identify(
+            distinctId,
+            userProperties,
+            userPropertiesSetOnce,
+        )
+    }
+
+    override fun flush() {
+        instance?.flush()
+    }
+
+    override fun debug(enable: Boolean) {
+        instance?.debug(enable)
+    }
+
+    override fun capture(
+        distinctId: String,
+        event: String,
+        properties: Map<String, Any>?,
+        userProperties: Map<String, Any>?,
+        userPropertiesSetOnce: Map<String, Any>?,
+        groups: Map<String, String>?,
+    ) {
+        instance?.captureStateless(
+            event,
+            distinctId,
+            properties,
+            userProperties,
+            userPropertiesSetOnce,
+            groups,
+        )
+    }
+
+    override fun isFeatureEnabled(
+        distinctId: String,
+        key: String,
+        defaultValue: Boolean,
+    ): Boolean {
+        return instance?.isFeatureEnabledStateless(distinctId, key, defaultValue) ?: false
+    }
+
+    override fun getFeatureFlag(
+        distinctId: String,
+        key: String,
+        defaultValue: Any?,
+    ): Any? {
+        return instance?.getFeatureFlagStateless(distinctId, key, defaultValue)
+    }
+
+    override fun getFeatureFlagPayload(
+        distinctId: String,
+        key: String,
+        defaultValue: Any?,
+    ): Any? {
+        return instance?.getFeatureFlagPayloadStateless(distinctId, key, defaultValue)
+    }
+
+    override fun group(
+        distinctId: String,
+        type: String,
+        key: String,
+        groupProperties: Map<String, Any>?,
+    ) {
+        instance?.groupStateless(
+            distinctId,
+            type,
+            key,
+            groupProperties,
+        )
+    }
+
+    override fun alias(
+        distinctId: String,
+        alias: String,
+    ) {
+        instance?.aliasStateless(
+            distinctId,
+            alias,
+        )
+    }
+
+    public companion object {
+        /**
+         * Set up the SDK and returns an instance that you can hold and pass it around
+         * @param T the type of the Config
+         * @property config the Config
+         */
+        @JvmStatic
+        public fun <T : PostHogConfig> with(config: T): PostHogInterface {
+            val instance = PostHog()
+            instance.setup(config)
+            return instance
+        }
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/PostHogCaptureOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogCaptureOptions.kt
@@ -1,0 +1,132 @@
+package com.posthog.server
+
+/**
+ * Provides an ergonomic interface when providing options for capturing events
+ * This is mainly meant to be used from Java, as Kotlin can use named parameters.
+ * @see <a href="https://posthog.com/docs/product-analytics/capture-events">Documentation: Capturing events</a>
+ */
+public class PostHogCaptureOptions private constructor(
+    public val properties: Map<String, Any>?,
+    public val userProperties: Map<String, Any>?,
+    public val userPropertiesSetOnce: Map<String, Any>?,
+    public val groups: Map<String, String>?,
+) {
+    public class Builder {
+        public var properties: MutableMap<String, Any>? = null
+        public var userProperties: MutableMap<String, Any>? = null
+        public var userPropertiesSetOnce: MutableMap<String, Any>? = null
+        public var groups: MutableMap<String, String>? = null
+
+        /**
+         * Add a single custom property to the capture options
+         */
+        public fun property(
+            key: String,
+            value: Any,
+        ): Builder {
+            if (properties == null) {
+                properties = mutableMapOf()
+            }
+            properties!![key] = value
+            return this
+        }
+
+        /**
+         * Appends multiple custom properties to the capture options
+         */
+        public fun properties(properties: Map<String, Any>): Builder {
+            if (this.properties == null) {
+                this.properties = mutableMapOf()
+            }
+            this.properties!!.putAll(properties)
+            return this
+        }
+
+        /**
+         * Adds a single user property to the capture options
+         * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
+         */
+        public fun userProperty(
+            key: String,
+            value: Any,
+        ): Builder {
+            if (userProperties == null) {
+                userProperties = mutableMapOf()
+            }
+            userProperties!![key] = value
+            return this
+        }
+
+        /**
+         * Appends multiple user properties to the capture options.
+         * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
+         */
+        public fun userProperties(userProperties: Map<String, Any>): Builder {
+            if (this.userProperties == null) {
+                this.userProperties = mutableMapOf()
+            }
+            this.userProperties!!.putAll(userProperties)
+            return this
+        }
+
+        /**
+         * Adds a single user property (set once) to the capture options.
+         * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
+         */
+        public fun userPropertySetOnce(
+            key: String,
+            value: Any,
+        ): Builder {
+            if (userPropertiesSetOnce == null) {
+                userPropertiesSetOnce = mutableMapOf()
+            }
+            userPropertiesSetOnce!![key] = value
+            return this
+        }
+
+        /**
+         * Appends multiple user properties (set once) to the capture options.
+         * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
+         */
+        public fun userPropertiesSetOnce(userPropertiesSetOnce: Map<String, Any>): Builder {
+            if (this.userPropertiesSetOnce == null) {
+                this.userPropertiesSetOnce = mutableMapOf()
+            }
+            this.userPropertiesSetOnce!!.putAll(userPropertiesSetOnce)
+            return this
+        }
+
+        /**
+         * Adds a single group to the capture options.
+         * @see <a href="https://posthog.com/docs/product-analytics/group-analytics">Documentation: Group Analytics</a>
+         */
+        public fun group(
+            type: String,
+            key: String,
+        ): Builder {
+            if (groups == null) {
+                groups = mutableMapOf()
+            }
+            groups!![type] = key
+            return this
+        }
+
+        /**
+         * Appends multiple groups to the capture options.
+         * @see <a href="https://posthog.com/docs/product-analytics/group-analytics">Documentation: Group Analytics</a>
+         */
+        public fun groups(groups: Map<String, String>): Builder {
+            if (this.groups == null) {
+                this.groups = mutableMapOf()
+            }
+            this.groups!!.putAll(groups)
+            return this
+        }
+
+        public fun build(): PostHogCaptureOptions = PostHogCaptureOptions(properties, userProperties, userPropertiesSetOnce, groups)
+    }
+
+    public companion object {
+        @JvmStatic public fun builder(): Builder = Builder()
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -1,0 +1,229 @@
+package com.posthog.server
+
+import com.posthog.PostHogBeforeSend
+import com.posthog.PostHogEncryption
+import com.posthog.PostHogExperimental
+import com.posthog.PostHogIntegration
+import com.posthog.PostHogOnFeatureFlags
+import com.posthog.server.internal.PostHogFeatureFlags
+import com.posthog.server.internal.PostHogMemoryQueue
+import java.net.Proxy
+
+/**
+ * The SDK Config
+ */
+public open class PostHogConfig constructor(
+    /**
+     * The PostHog API Key
+     */
+    public val apiKey: String,
+    /**
+     * The PostHog Host
+     * Defaults to https://us.i.posthog.com
+     * EU Host: https://eu.i.posthog.com
+     *
+     */
+    public val host: String = DEFAULT_HOST,
+    /**
+     * Logs the debug logs to the [logger] if enabled
+     * Defaults to false
+     */
+    public var debug: Boolean = false,
+    /**
+     * Send a $feature_flag_called event when a feature flag is used automatically
+     * Used by experiments
+     *
+     * Defaults to true
+     */
+    public var sendFeatureFlagEvent: Boolean = true,
+    /**
+     * Preload feature flags automatically
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * Defaults to true
+     */
+    public var preloadFeatureFlags: Boolean = true,
+    /**
+     * Preload PostHog remote config automatically
+     * Defaults to true
+     */
+    public var remoteConfig: Boolean = true,
+    /**
+     * Number of minimum events before they are sent over the wire
+     * Defaults to 20
+     */
+    public var flushAt: Int = DEFAULT_FLUSH_AT,
+    /**
+     * Number of maximum events in memory and disk, when the maximum is exceed, the oldest
+     * event is deleted and the new one takes place
+     * Defaults to 1000
+     */
+    public var maxQueueSize: Int = DEFAULT_MAX_QUEUE_SIZE,
+    /**
+     * Number of maximum events in a batch call
+     * Defaults to 50
+     */
+    public var maxBatchSize: Int = DEFAULT_MAX_BATCH_SIZE,
+    /**
+     * Interval in seconds for sending events over the wire
+     * The lower the number, most likely more battery is used
+     * Defaults to 30s
+     */
+    public var flushIntervalSeconds: Int = DEFAULT_FLUSH_INTERVAL_SECONDS,
+    /**
+     * Hook for encrypt and decrypt events
+     * Devices are sandbox so likely not needed
+     * Defaults to no encryption
+     */
+    public var encryption: PostHogEncryption? = null,
+    /**
+     * Hook that is called when feature flags are loaded
+     * Defaults to no callback
+     */
+    public var onFeatureFlags: PostHogOnFeatureFlags? = null,
+    /**
+     * Hook that allows to sanitize the event properties
+     * The hook is called before the event is cached or sent over the wire
+     */
+    public var proxy: Proxy? = null,
+    /**
+     * The maximum size of the feature flag cache in memory
+     * Defaults to 1000
+     */
+    @PostHogExperimental
+    public var featureFlagCacheSize: Int = DEFAULT_FEATURE_FLAG_CACHE_SIZE,
+    /**
+     * The maximum age of a feature flag cache record in memory in milliseconds
+     * Defaults to 5 minutes
+     */
+    @PostHogExperimental
+    public var featureFlagCacheMaxAgeMs: Int = DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS,
+) {
+    private val beforeSendCallbacks = mutableListOf<PostHogBeforeSend>()
+    private val integrations = mutableListOf<PostHogIntegration>()
+
+    public fun addBeforeSend(beforeSend: PostHogBeforeSend) {
+        beforeSendCallbacks.add(beforeSend)
+    }
+
+    public fun removeBeforeSend(beforeSend: PostHogBeforeSend) {
+        beforeSendCallbacks.remove(beforeSend)
+    }
+
+    public fun addIntegration(integration: PostHogIntegration) {
+        integrations.add(integration)
+    }
+
+    @JvmSynthetic
+    internal fun asCoreConfig(): com.posthog.PostHogConfig {
+        val coreConfig =
+            com.posthog.PostHogConfig(
+                apiKey = apiKey,
+                host = host,
+                debug = debug,
+                sendFeatureFlagEvent = sendFeatureFlagEvent,
+                preloadFeatureFlags = preloadFeatureFlags,
+                remoteConfig = remoteConfig,
+                flushAt = flushAt,
+                maxQueueSize = maxQueueSize,
+                maxBatchSize = maxBatchSize,
+                flushIntervalSeconds = flushIntervalSeconds,
+                encryption = encryption,
+                onFeatureFlags = onFeatureFlags,
+                proxy = proxy,
+                remoteConfigProvider = { config, api, _ ->
+                    PostHogFeatureFlags(
+                        config,
+                        api,
+                        cacheMaxAgeMs = featureFlagCacheMaxAgeMs,
+                        cacheMaxSize = featureFlagCacheSize,
+                    )
+                },
+                queueProvider = { config, api, endpoint, _, executor ->
+                    PostHogMemoryQueue(config, api, endpoint, executor)
+                },
+            )
+
+        // Apply stored callbacks and integrations
+        beforeSendCallbacks.forEach { coreConfig.addBeforeSend(it) }
+        integrations.forEach { coreConfig.addIntegration(it) }
+
+        return coreConfig
+    }
+
+    public companion object {
+        public const val DEFAULT_US_HOST: String = "https://us.i.posthog.com"
+        public const val DEFAULT_US_ASSETS_HOST: String = "https://us-assets.i.posthog.com"
+
+        // flutter uses it
+        public const val DEFAULT_HOST: String = DEFAULT_US_HOST
+
+        public const val DEFAULT_EU_HOST: String = "https://eu.i.posthog.com"
+        public const val DEFAULT_EU_ASSETS_HOST: String = "https://eu-assets.i.posthog.com"
+
+        public const val DEFAULT_FLUSH_AT: Int = 20
+        public const val DEFAULT_MAX_QUEUE_SIZE: Int = 1000
+        public const val DEFAULT_MAX_BATCH_SIZE: Int = 50
+        public const val DEFAULT_FLUSH_INTERVAL_SECONDS: Int = 30
+        public const val DEFAULT_FEATURE_FLAG_CACHE_SIZE: Int = 1000
+        public const val DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS: Int = 5 * 60 * 1000 // 5 minutes
+
+        @JvmStatic
+        public fun builder(apiKey: String): Builder = Builder(apiKey)
+    }
+
+    public class Builder(private val apiKey: String) {
+        private var host: String = DEFAULT_HOST
+        private var debug: Boolean = false
+        private var sendFeatureFlagEvent: Boolean = true
+        private var preloadFeatureFlags: Boolean = true
+        private var remoteConfig: Boolean = true
+        private var flushAt: Int = DEFAULT_FLUSH_AT
+        private var maxQueueSize: Int = DEFAULT_MAX_QUEUE_SIZE
+        private var maxBatchSize: Int = DEFAULT_MAX_BATCH_SIZE
+        private var flushIntervalSeconds: Int = DEFAULT_FLUSH_INTERVAL_SECONDS
+        private var encryption: PostHogEncryption? = null
+        private var onFeatureFlags: PostHogOnFeatureFlags? = null
+        private var proxy: Proxy? = null
+
+        public fun host(host: String): Builder = apply { this.host = host }
+
+        public fun debug(debug: Boolean): Builder = apply { this.debug = debug }
+
+        public fun sendFeatureFlagEvent(sendFeatureFlagEvent: Boolean): Builder = apply { this.sendFeatureFlagEvent = sendFeatureFlagEvent }
+
+        public fun preloadFeatureFlags(preloadFeatureFlags: Boolean): Builder = apply { this.preloadFeatureFlags = preloadFeatureFlags }
+
+        public fun remoteConfig(remoteConfig: Boolean): Builder = apply { this.remoteConfig = remoteConfig }
+
+        public fun flushAt(flushAt: Int): Builder = apply { this.flushAt = flushAt }
+
+        public fun maxQueueSize(maxQueueSize: Int): Builder = apply { this.maxQueueSize = maxQueueSize }
+
+        public fun maxBatchSize(maxBatchSize: Int): Builder = apply { this.maxBatchSize = maxBatchSize }
+
+        public fun flushIntervalSeconds(flushIntervalSeconds: Int): Builder = apply { this.flushIntervalSeconds = flushIntervalSeconds }
+
+        public fun encryption(encryption: PostHogEncryption?): Builder = apply { this.encryption = encryption }
+
+        public fun onFeatureFlags(onFeatureFlags: PostHogOnFeatureFlags?): Builder = apply { this.onFeatureFlags = onFeatureFlags }
+
+        public fun proxy(proxy: Proxy?): Builder = apply { this.proxy = proxy }
+
+        public fun build(): PostHogConfig =
+            PostHogConfig(
+                apiKey = apiKey,
+                host = host,
+                debug = debug,
+                sendFeatureFlagEvent = sendFeatureFlagEvent,
+                preloadFeatureFlags = preloadFeatureFlags,
+                remoteConfig = remoteConfig,
+                flushAt = flushAt,
+                maxQueueSize = maxQueueSize,
+                maxBatchSize = maxBatchSize,
+                flushIntervalSeconds = flushIntervalSeconds,
+                encryption = encryption,
+                onFeatureFlags = onFeatureFlags,
+                proxy = proxy,
+            )
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
@@ -1,0 +1,246 @@
+package com.posthog.server
+
+public sealed interface PostHogInterface {
+    /**
+     * Setup the SDK
+     * @param config the SDK configuration
+     */
+    public fun <T : PostHogConfig> setup(config: T)
+
+    /**
+     * Closes the SDK
+     */
+    public fun close()
+
+    /**
+     * Identifies the user
+     * Docs https://posthog.com/docs/product-analytics/identify
+     * @param distinctId the distinctId
+     * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
+     * @param userPropertiesSetOnce the user properties to set only once, set as a "$set_once" property, Docs https://posthog.com/docs/product-analytics/user-properties
+     */
+    public fun identify(
+        distinctId: String,
+        userProperties: Map<String, Any>? = null,
+        userPropertiesSetOnce: Map<String, Any>? = null,
+    )
+
+    /**
+     * Identifies the user
+     * Docs https://posthog.com/docs/product-analytics/identify
+     * @param distinctId the distinctId
+     */
+    public fun identify(distinctId: String) {
+        identify(
+            distinctId,
+            null,
+            null,
+        )
+    }
+
+    /**
+     * Identifies the user
+     * Docs https://posthog.com/docs/product-analytics/identify
+     * @param distinctId the distinctId
+     * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
+     */
+    public fun identify(
+        distinctId: String,
+        userProperties: Map<String, Any>? = null,
+    ) {
+        identify(
+            distinctId,
+            userProperties,
+            null,
+        )
+    }
+
+    /**
+     * Flushes all the events in the Queue right away
+     */
+    public fun flush()
+
+    /**
+     * Enables or disables the debug mode
+     */
+    public fun debug(enable: Boolean = true)
+
+    /**
+     * Captures events
+     * @param distinctId the distinctId of the user performing the event
+     * @param properties the custom properties
+     * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
+     * @param userPropertiesSetOnce the user properties to set only once, set as a "$set_once" property, Docs https://posthog.com/docs/product-analytics/user-properties
+     * @param groups the groups, set as a "$groups" property, Docs https://posthog.com/docs/product-analytics/group-analytics
+     */
+    @JvmSynthetic
+    public fun capture(
+        distinctId: String,
+        event: String,
+        properties: Map<String, Any>? = null,
+        userProperties: Map<String, Any>? = null,
+        userPropertiesSetOnce: Map<String, Any>? = null,
+        groups: Map<String, String>? = null,
+    )
+
+    /**
+     * Captures events
+     * @param event the event name
+     * @param distinctId the distinctId
+     * @param options the capture options containing properties, userProperties, userPropertiesSetOnce, and groups
+     */
+    public fun capture(
+        distinctId: String,
+        event: String,
+        options: PostHogCaptureOptions,
+    ) {
+        capture(
+            distinctId,
+            event,
+            options.properties,
+            options.userProperties,
+            options.userPropertiesSetOnce,
+            options.groups,
+        )
+    }
+
+    /**
+     * Captures events
+     * @param event the event name
+     * @param distinctId the distinctId
+     */
+    public fun capture(
+        distinctId: String,
+        event: String,
+    ) {
+        capture(
+            distinctId,
+            event,
+            null,
+            null,
+            null,
+            null,
+        )
+    }
+
+    /**
+     * Returns if a feature flag is enabled, the feature flag must be a Boolean
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * @param distinctId the distinctId
+     * @param key the Key
+     * @param defaultValue the default value if not found, false if not given
+     */
+    public fun isFeatureEnabled(
+        distinctId: String,
+        key: String,
+        defaultValue: Boolean = false,
+    ): Boolean
+
+    /**
+     * Returns if a feature flag is enabled, the feature flag must be a Boolean
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * @param distinctId the distinctId
+     * @param key the Key
+     */
+    public fun isFeatureEnabled(
+        distinctId: String,
+        key: String,
+    ): Boolean {
+        return isFeatureEnabled(distinctId, key, false)
+    }
+
+    /**
+     * Returns the feature flag
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * @param distinctId the distinctId
+     * @param key the Key
+     * @param defaultValue the default value if not found
+     */
+    public fun getFeatureFlag(
+        distinctId: String,
+        key: String,
+        defaultValue: Any? = null,
+    ): Any?
+
+    /**
+     * Returns the feature flag
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * @param distinctId the distinctId
+     * @param key the Key
+     * @return the feature flag value or null if not found
+     */
+    public fun getFeatureFlag(
+        distinctId: String,
+        key: String,
+    ): Any? {
+        return getFeatureFlag(distinctId, key, null)
+    }
+
+    /**
+     * Returns the feature flag payload
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * @param distinctId the distinctId
+     * @param key the Key
+     * @param defaultValue the default value if not found
+     */
+    public fun getFeatureFlagPayload(
+        distinctId: String,
+        key: String,
+        defaultValue: Any? = null,
+    ): Any?
+
+    /**
+     * Returns the feature flag payload
+     * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
+     * @param distinctId the distinctId
+     * @param key the Key
+     * @return the feature flag payload or null if not found
+     */
+    public fun getFeatureFlagPayload(
+        distinctId: String,
+        key: String,
+    ): Any? {
+        return getFeatureFlagPayload(distinctId, key, null)
+    }
+
+    /**
+     * Creates a group
+     * Docs https://posthog.com/docs/product-analytics/group-analytics
+     * @param distinctId the distinctId
+     * @param type the Group type
+     * @param key the Group key
+     * @param groupProperties the Group properties, set as a "$group_set" property, Docs https://posthog.com/docs/product-analytics/group-analytics
+     */
+    public fun group(
+        distinctId: String,
+        type: String,
+        key: String,
+        groupProperties: Map<String, Any>? = null,
+    )
+
+    /**
+     * Creates a group
+     * Docs https://posthog.com/docs/product-analytics/group-analytics
+     * @param distinctId the distinctId
+     * @param type the Group type
+     * @param key the Group key
+     */
+    public fun group(
+        distinctId: String,
+        type: String,
+        key: String,
+    ) {
+        group(distinctId, type, key, null)
+    }
+
+    /**
+     * Creates an alias for the user
+     * Docs https://posthog.com/docs/product-analytics/identify#alias-assigning-multiple-distinct-ids-to-the-same-user
+     * @param distinctId the distinctId
+     * @param alias the alias
+     */
+    public fun alias(
+        distinctId: String,
+        alias: String,
+    )
+}

--- a/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheEntry.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheEntry.kt
@@ -1,0 +1,37 @@
+package com.posthog.server.internal
+
+import com.posthog.internal.FeatureFlag
+
+/**
+ * Cache entry containing feature flag data and expiry information
+ */
+internal data class FeatureFlagCacheEntry(
+    val flags: Map<String, FeatureFlag>?,
+    val timestamp: Long,
+    val expiresAt: Long,
+) {
+    /**
+     * Check if this cache entry has expired
+     */
+    fun isExpired(currentTime: Long = System.currentTimeMillis()): Boolean {
+        return currentTime >= expiresAt
+    }
+
+    override fun hashCode(): Int {
+        var result = flags?.hashCode() ?: 0
+        result = 31 * result + (timestamp xor (timestamp ushr 32)).toInt()
+        result = 31 * result + (expiresAt xor (expiresAt ushr 32)).toInt()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FeatureFlagCacheEntry) return false
+
+        if (flags != other.flags) return false
+        if (timestamp != other.timestamp) return false
+        if (expiresAt != other.expiresAt) return false
+
+        return true
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheKey.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheKey.kt
@@ -1,0 +1,31 @@
+package com.posthog.server.internal
+
+/**
+ * Cache key for feature flag requests based on the parameters used in the API call
+ */
+internal data class FeatureFlagCacheKey(
+    val distinctId: String?,
+    val groups: Map<String, String>?,
+    val personProperties: Map<String, String>?,
+    val groupProperties: Map<String, String>?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FeatureFlagCacheKey) return false
+
+        if (distinctId != other.distinctId) return false
+        if (groups != other.groups) return false
+        if (personProperties != other.personProperties) return false
+        if (groupProperties != other.groupProperties) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = distinctId?.hashCode() ?: 0
+        result = 31 * result + (groups?.hashCode() ?: 0)
+        result = 31 * result + (personProperties?.hashCode() ?: 0)
+        result = 31 * result + (groupProperties?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlagCache.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlagCache.kt
@@ -1,0 +1,110 @@
+package com.posthog.server.internal
+
+import com.posthog.internal.FeatureFlag
+
+/**
+ * LRU cache with TTL support for feature flag responses
+ */
+internal class PostHogFeatureFlagCache(
+    private val maxSize: Int,
+    private val maxAgeMs: Int,
+) {
+    private val cache = mutableMapOf<FeatureFlagCacheKey, FeatureFlagCacheEntry>()
+    private val accessOrder = mutableListOf<FeatureFlagCacheKey>()
+
+    /**
+     * Get feature flags from cache if present and not expired
+     */
+    @Synchronized
+    fun get(key: FeatureFlagCacheKey): Map<String, FeatureFlag>? {
+        cleanupExpiredEntries()
+
+        val entry = cache[key]
+        if (entry == null) {
+            return null
+        }
+
+        if (entry.isExpired()) {
+            removeFromCache(key)
+            return null
+        }
+
+        // Move to end (most recently used)
+        accessOrder.remove(key)
+        accessOrder.add(key)
+
+        return entry.flags
+    }
+
+    /**
+     * Put feature flags into cache with current timestamp
+     */
+    @Synchronized
+    fun put(
+        key: FeatureFlagCacheKey,
+        flags: Map<String, FeatureFlag>?,
+    ) {
+        val currentTime = System.currentTimeMillis()
+        val entry =
+            FeatureFlagCacheEntry(
+                flags = flags,
+                timestamp = currentTime,
+                expiresAt = currentTime + maxAgeMs,
+            )
+
+        // Remove if already exists to update access order
+        if (cache.containsKey(key)) {
+            accessOrder.remove(key)
+        }
+
+        cache[key] = entry
+        accessOrder.add(key)
+
+        // Remove eldest entries if over max size
+        while (accessOrder.size > maxSize) {
+            val eldestKey = accessOrder.removeAt(0)
+            cache.remove(eldestKey)
+        }
+    }
+
+    /**
+     * Clear all cached entries
+     */
+    @Synchronized
+    fun clear() {
+        cache.clear()
+        accessOrder.clear()
+    }
+
+    /**
+     * Get current cache size
+     */
+    @Synchronized
+    fun size(): Int = cache.size
+
+    /**
+     * Remove a key from cache and access order
+     */
+    private fun removeFromCache(key: FeatureFlagCacheKey) {
+        cache.remove(key)
+        accessOrder.remove(key)
+    }
+
+    /**
+     * Remove expired entries from cache
+     */
+    private fun cleanupExpiredEntries() {
+        val currentTime = System.currentTimeMillis()
+        val expiredKeys = mutableListOf<FeatureFlagCacheKey>()
+
+        for ((key, entry) in cache) {
+            if (entry.isExpired(currentTime)) {
+                expiredKeys.add(key)
+            }
+        }
+
+        for (key in expiredKeys) {
+            removeFromCache(key)
+        }
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -1,0 +1,99 @@
+package com.posthog.server.internal
+
+import com.posthog.PostHogConfig
+import com.posthog.internal.FeatureFlag
+import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogFeatureFlagsInterface
+
+internal class PostHogFeatureFlags(
+    private val config: PostHogConfig,
+    private val api: PostHogApi,
+    private val cacheMaxAgeMs: Int,
+    private val cacheMaxSize: Int,
+) : PostHogFeatureFlagsInterface {
+    private val cache =
+        PostHogFeatureFlagCache(
+            maxSize = cacheMaxSize,
+            maxAgeMs = cacheMaxAgeMs,
+        )
+
+    override fun getFeatureFlag(
+        key: String,
+        defaultValue: Any?,
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
+    ): Any? {
+        val flag =
+            getFeatureFlags(
+                distinctId,
+                groups,
+                personProperties,
+                groupProperties,
+            )?.get(key)
+        return flag?.variant ?: flag?.enabled ?: defaultValue
+    }
+
+    override fun getFeatureFlagPayload(
+        key: String,
+        defaultValue: Any?,
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
+    ): Any? {
+        return getFeatureFlags(
+            distinctId,
+            groups,
+            personProperties,
+            groupProperties,
+        )?.get(key)?.metadata?.payload
+            ?: defaultValue
+    }
+
+    override fun getFeatureFlags(
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
+    ): Map<String, FeatureFlag>? {
+        if (distinctId == null) {
+            config.logger.log("getFeatureFlags called but no distinctId available for API call")
+            return null
+        }
+
+        // Create cache key from parameters
+        val cacheKey =
+            FeatureFlagCacheKey(
+                distinctId = distinctId,
+                groups = groups,
+                personProperties = personProperties,
+                groupProperties = groupProperties,
+            )
+
+        // Check cache first
+        val cachedFlags = cache.get(cacheKey)
+        if (cachedFlags != null) {
+            config.logger.log("Feature flags cache hit for distinctId: $distinctId")
+            return cachedFlags
+        }
+
+        // Cache miss
+        config.logger.log("Feature flags cache miss for distinctId: $distinctId")
+        return try {
+            val response = api.flags(distinctId, null, groups, personProperties, groupProperties)
+            val flags = response?.flags
+            cache.put(cacheKey, flags)
+            flags
+        } catch (e: Throwable) {
+            config.logger.log("Loading feature flags failed: $e")
+            null
+        }
+    }
+
+    override fun clear() {
+        cache.clear()
+        config.logger.log("Feature flags cache cleared")
+    }
+}

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
@@ -1,0 +1,258 @@
+package com.posthog.server.internal
+
+import com.posthog.PostHogConfig
+import com.posthog.PostHogEvent
+import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogApiEndpoint
+import com.posthog.internal.PostHogApiError
+import com.posthog.internal.PostHogQueueInterface
+import com.posthog.internal.executeSafely
+import com.posthog.internal.isNetworkingError
+import java.io.IOException
+import java.util.Date
+import java.util.Timer
+import java.util.TimerTask
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.schedule
+import kotlin.math.min
+
+/**
+ * Memory-only implementation of PostHogQueueInterface that stores events in memory without persistence
+ * @property config the Config
+ * @property api the API
+ * @property endpoint the API endpoint to use
+ * @property executor the Executor
+ */
+internal class PostHogMemoryQueue(
+    private val config: PostHogConfig,
+    private val api: PostHogApi,
+    private val endpoint: PostHogApiEndpoint,
+    private val executor: ExecutorService,
+    private val retryDelaySeconds: Int = DEFAULT_RETRY_DELAY_SECONDS,
+    private val maxRetryDelaySeconds: Int = DEFAULT_MAX_RETRY_DELAY_SECONDS,
+) : PostHogQueueInterface {
+    private val events: ArrayDeque<PostHogEvent> = ArrayDeque()
+    private val eventsLock = Any()
+    private val timerLock = Any()
+    private var pausedUntil: Date? = null
+    private var retryCount = 0
+
+    @Volatile
+    private var timer: Timer? = null
+
+    @Volatile
+    private var timerTask: TimerTask? = null
+
+    private var isFlushing = AtomicBoolean(false)
+
+    private val delay: Long get() = (config.flushIntervalSeconds * 1000).toLong()
+
+    override fun add(event: PostHogEvent) {
+        executor.executeSafely {
+            var removedEvent: PostHogEvent? = null
+
+            synchronized(eventsLock) {
+                if (events.size >= config.maxQueueSize) {
+                    removedEvent = events.removeFirstOrNull()
+                }
+
+                events.addLast(event)
+            }
+
+            if (removedEvent != null) {
+                config.logger.log("Queue is full, the oldest event ${removedEvent?.event} was discarded.")
+            }
+
+            config.logger.log("Event: ${event.event} was added to the queue.")
+
+            flushIfOverThreshold()
+        }
+    }
+
+    override fun flush() {
+        // only flushes if the queue has events
+        if (!isAboveThreshold(1)) {
+            return
+        }
+
+        if (isFlushing.getAndSet(true)) {
+            config.logger.log("Queue is flushing.")
+            return
+        }
+
+        executeBatch()
+    }
+
+    override fun start() {
+        executor.executeSafely {
+            synchronized(timerLock) {
+                if (timer == null) {
+                    timer = Timer()
+                    startTimer(delay)
+                    config.logger.log("Queue timer started.")
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        executor.executeSafely {
+            synchronized(timerLock) {
+                timerTask?.cancel()
+                timerTask = null
+                timer?.cancel()
+                timer = null
+                config.logger.log("Queue timer stopped.")
+            }
+        }
+    }
+
+    override fun clear() {
+        executor.executeSafely {
+            synchronized(eventsLock) {
+                val eventsRemoved = events.size
+                events.clear()
+                config.logger.log("$eventsRemoved events cleared from Queue.")
+            }
+        }
+    }
+
+    private fun flushIfOverThreshold() {
+        if (isAboveThreshold(config.flushAt)) {
+            flushBatch()
+        }
+    }
+
+    private fun isAboveThreshold(flushAt: Int): Boolean {
+        val size = synchronized(eventsLock) { events.size }
+        if (size >= flushAt) {
+            return true
+        } else if (size > 0) {
+            // only log if there are events in the queue
+            config.logger.log("Cannot flush the Queue yet, below the threshold: $flushAt")
+        }
+        return false
+    }
+
+    private fun canFlushBatch(): Boolean {
+        if (pausedUntil?.after(config.dateProvider.currentDate()) == true) {
+            config.logger.log("Queue is paused until $pausedUntil")
+            return false
+        }
+
+        if (config.networkStatus?.isConnected() == false) {
+            config.logger.log("Device is offline.")
+            return false
+        }
+
+        return true
+    }
+
+    private fun takeEvents(): List<PostHogEvent> {
+        val eventsToProcess: MutableList<PostHogEvent> = mutableListOf()
+        synchronized(eventsLock) {
+            val maxToTake = min(config.maxBatchSize, events.size)
+            repeat(maxToTake) {
+                events.removeFirstOrNull()?.let { event ->
+                    eventsToProcess.add(event)
+                }
+            }
+        }
+        return eventsToProcess
+    }
+
+    private fun flushBatch() {
+        if (!canFlushBatch()) {
+            config.logger.log("Cannot flush the queue.")
+            return
+        }
+
+        if (isFlushing.getAndSet(true)) {
+            config.logger.log("Queue is flushing.")
+            return
+        }
+
+        executeBatch()
+    }
+
+    private fun executeBatch() {
+        var retry = false
+        try {
+            batchEvents()
+            retryCount = 0
+        } catch (e: Throwable) {
+            config.logger.log("Flushing failed: $e.")
+
+            retry = true
+            retryCount++
+        } finally {
+            calculateDelay(retry)
+
+            isFlushing.set(false)
+        }
+    }
+
+    @Throws(PostHogApiError::class, IOException::class)
+    private fun batchEvents() {
+        val eventsToProcess = takeEvents()
+
+        if (eventsToProcess.isEmpty()) {
+            return
+        }
+
+        try {
+            config.logger.log("Flushing ${eventsToProcess.size} events.")
+            when (endpoint) {
+                PostHogApiEndpoint.BATCH -> api.batch(eventsToProcess)
+                PostHogApiEndpoint.SNAPSHOT -> api.snapshot(eventsToProcess)
+            }
+            // Events successfully sent, no need to put them back
+        } catch (e: PostHogApiError) {
+            // Put events back at the front of the queue if an intermittent error occurs
+            if (e.isNetworkingError() || e.statusCode >= 500) {
+                synchronized(eventsLock) {
+                    // Add events back to the front of the queue in reverse order
+                    eventsToProcess.asReversed().forEach { event ->
+                        events.addFirst(event)
+                    }
+                }
+                config.logger.log("Flushing failed because of a network error, let's try again soon.")
+            } else {
+                // Don't put events back for non-network errors (they're likely bad data)
+                config.logger.log("Flushing failed: $e")
+            }
+            throw e
+        }
+    }
+
+    private fun startTimer(delay: Long) {
+        synchronized(timerLock) {
+            timerTask?.cancel()
+            timerTask =
+                timer?.schedule(delay) {
+                    flushBatch()
+                    startTimer(this@PostHogMemoryQueue.delay)
+                }
+        }
+    }
+
+    private fun calculateDelay(retry: Boolean) {
+        if (retry) {
+            val delayInSeconds = min(retryDelaySeconds * retryCount, maxRetryDelaySeconds)
+            pausedUntil =
+                config.dateProvider.currentDate().let {
+                    Date(it.time + (delayInSeconds * 1000))
+                }
+
+            config.logger.log("Retrying in $delayInSeconds seconds.")
+        } else {
+            pausedUntil = null
+        }
+    }
+
+    public companion object {
+        private const val DEFAULT_RETRY_DELAY_SECONDS = 5
+        private const val DEFAULT_MAX_RETRY_DELAY_SECONDS = 60
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/PostHogCaptureOptionsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogCaptureOptionsTest.kt
@@ -1,0 +1,476 @@
+package com.posthog.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class PostHogCaptureOptionsTest {
+    @Test
+    fun `builder creates instance with all null properties by default`() {
+        val options = PostHogCaptureOptions.builder().build()
+
+        assertNull(options.properties)
+        assertNull(options.userProperties)
+        assertNull(options.userPropertiesSetOnce)
+        assertNull(options.groups)
+    }
+
+    @Test
+    fun `property method adds single property`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .property("test_key", "test_value")
+                .build()
+
+        assertEquals(mapOf("test_key" to "test_value"), options.properties)
+    }
+
+    @Test
+    fun `property method creates properties map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.properties)
+
+        builder.property("test_key", "test_value")
+
+        assertEquals(mutableMapOf<String, Any>("test_key" to "test_value"), builder.properties)
+    }
+
+    @Test
+    fun `property method adds to existing properties map`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .property("key1", "value1")
+                .property("key2", "value2")
+                .build()
+
+        assertEquals(mapOf("key1" to "value1", "key2" to "value2"), options.properties)
+    }
+
+    @Test
+    fun `property method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.property("test_key", "test_value")
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `property method handles different value types`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .property("string_key", "string_value")
+                .property("int_key", 42)
+                .property("boolean_key", true)
+                .property("double_key", 3.14)
+                .build()
+
+        val expected =
+            mapOf(
+                "string_key" to "string_value",
+                "int_key" to 42,
+                "boolean_key" to true,
+                "double_key" to 3.14,
+            )
+        assertEquals(expected, options.properties)
+    }
+
+    @Test
+    fun `properties method adds multiple properties`() {
+        val propertiesToAdd = mapOf("key1" to "value1", "key2" to "value2")
+        val options =
+            PostHogCaptureOptions.builder()
+                .properties(propertiesToAdd)
+                .build()
+
+        assertEquals(propertiesToAdd, options.properties)
+    }
+
+    @Test
+    fun `properties method creates properties map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.properties)
+
+        val propertiesToAdd = mapOf("key1" to "value1")
+        builder.properties(propertiesToAdd)
+
+        assertEquals(mutableMapOf<String, Any>("key1" to "value1"), builder.properties)
+    }
+
+    @Test
+    fun `properties method appends to existing properties`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .property("existing_key", "existing_value")
+                .properties(mapOf("new_key1" to "new_value1", "new_key2" to "new_value2"))
+                .build()
+
+        val expected =
+            mapOf(
+                "existing_key" to "existing_value",
+                "new_key1" to "new_value1",
+                "new_key2" to "new_value2",
+            )
+        assertEquals(expected, options.properties)
+    }
+
+    @Test
+    fun `properties method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.properties(mapOf("key" to "value"))
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `userProperty method adds single user property`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userProperty("user_key", "user_value")
+                .build()
+
+        assertEquals(mapOf("user_key" to "user_value"), options.userProperties)
+    }
+
+    @Test
+    fun `userProperty method creates userProperties map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.userProperties)
+
+        builder.userProperty("user_key", "user_value")
+
+        assertEquals(mutableMapOf<String, Any>("user_key" to "user_value"), builder.userProperties)
+    }
+
+    @Test
+    fun `userProperty method adds to existing userProperties map`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userProperty("key1", "value1")
+                .userProperty("key2", "value2")
+                .build()
+
+        assertEquals(mapOf("key1" to "value1", "key2" to "value2"), options.userProperties)
+    }
+
+    @Test
+    fun `userProperty method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.userProperty("user_key", "user_value")
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `userProperties method adds multiple user properties`() {
+        val userPropertiesToAdd = mapOf("key1" to "value1", "key2" to "value2")
+        val options =
+            PostHogCaptureOptions.builder()
+                .userProperties(userPropertiesToAdd)
+                .build()
+
+        assertEquals(userPropertiesToAdd, options.userProperties)
+    }
+
+    @Test
+    fun `userProperties method creates userProperties map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.userProperties)
+
+        val userPropertiesToAdd = mapOf("key1" to "value1")
+        builder.userProperties(userPropertiesToAdd)
+
+        assertEquals(mutableMapOf<String, Any>("key1" to "value1"), builder.userProperties)
+    }
+
+    @Test
+    fun `userProperties method appends to existing userProperties`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userProperty("existing_key", "existing_value")
+                .userProperties(mapOf("new_key1" to "new_value1", "new_key2" to "new_value2"))
+                .build()
+
+        val expected =
+            mapOf(
+                "existing_key" to "existing_value",
+                "new_key1" to "new_value1",
+                "new_key2" to "new_value2",
+            )
+        assertEquals(expected, options.userProperties)
+    }
+
+    @Test
+    fun `userProperties method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.userProperties(mapOf("key" to "value"))
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `userPropertySetOnce method adds single user property set once`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userPropertySetOnce("once_key", "once_value")
+                .build()
+
+        assertEquals(mapOf("once_key" to "once_value"), options.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `userPropertySetOnce method creates userPropertiesSetOnce map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.userPropertiesSetOnce)
+
+        builder.userPropertySetOnce("once_key", "once_value")
+
+        assertEquals(mutableMapOf<String, Any>("once_key" to "once_value"), builder.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `userPropertySetOnce method adds to existing userPropertiesSetOnce map`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userPropertySetOnce("key1", "value1")
+                .userPropertySetOnce("key2", "value2")
+                .build()
+
+        assertEquals(mapOf("key1" to "value1", "key2" to "value2"), options.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `userPropertySetOnce method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.userPropertySetOnce("once_key", "once_value")
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `userPropertiesSetOnce method adds multiple user properties set once`() {
+        val userPropertiesSetOnceToAdd = mapOf("key1" to "value1", "key2" to "value2")
+        val options =
+            PostHogCaptureOptions.builder()
+                .userPropertiesSetOnce(userPropertiesSetOnceToAdd)
+                .build()
+
+        assertEquals(userPropertiesSetOnceToAdd, options.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `userPropertiesSetOnce method creates userPropertiesSetOnce map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.userPropertiesSetOnce)
+
+        val userPropertiesSetOnceToAdd = mapOf("key1" to "value1")
+        builder.userPropertiesSetOnce(userPropertiesSetOnceToAdd)
+
+        assertEquals(mutableMapOf<String, Any>("key1" to "value1"), builder.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `userPropertiesSetOnce method appends to existing userPropertiesSetOnce`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userPropertySetOnce("existing_key", "existing_value")
+                .userPropertiesSetOnce(mapOf("new_key1" to "new_value1", "new_key2" to "new_value2"))
+                .build()
+
+        val expected =
+            mapOf(
+                "existing_key" to "existing_value",
+                "new_key1" to "new_value1",
+                "new_key2" to "new_value2",
+            )
+        assertEquals(expected, options.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `userPropertiesSetOnce method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.userPropertiesSetOnce(mapOf("key" to "value"))
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `group method adds single group`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .group("organization", "org_123")
+                .build()
+
+        assertEquals(mapOf("organization" to "org_123"), options.groups)
+    }
+
+    @Test
+    fun `group method creates groups map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.groups)
+
+        builder.group("organization", "org_123")
+
+        assertEquals(mutableMapOf<String, String>("organization" to "org_123"), builder.groups)
+    }
+
+    @Test
+    fun `group method adds to existing groups map`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .group("organization", "org_123")
+                .group("team", "team_456")
+                .build()
+
+        assertEquals(mapOf("organization" to "org_123", "team" to "team_456"), options.groups)
+    }
+
+    @Test
+    fun `group method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.group("organization", "org_123")
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `groups method adds multiple groups`() {
+        val groupsToAdd = mapOf("organization" to "org_123", "team" to "team_456")
+        val options =
+            PostHogCaptureOptions.builder()
+                .groups(groupsToAdd)
+                .build()
+
+        assertEquals(groupsToAdd, options.groups)
+    }
+
+    @Test
+    fun `groups method creates groups map when null`() {
+        val builder = PostHogCaptureOptions.builder()
+        assertNull(builder.groups)
+
+        val groupsToAdd = mapOf("organization" to "org_123")
+        builder.groups(groupsToAdd)
+
+        assertEquals(mutableMapOf<String, String>("organization" to "org_123"), builder.groups)
+    }
+
+    @Test
+    fun `groups method appends to existing groups`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .group("existing_type", "existing_key")
+                .groups(mapOf("new_type1" to "new_key1", "new_type2" to "new_key2"))
+                .build()
+
+        val expected =
+            mapOf(
+                "existing_type" to "existing_key",
+                "new_type1" to "new_key1",
+                "new_type2" to "new_key2",
+            )
+        assertEquals(expected, options.groups)
+    }
+
+    @Test
+    fun `groups method returns builder for chaining`() {
+        val builder = PostHogCaptureOptions.builder()
+        val result = builder.groups(mapOf("organization" to "org_123"))
+
+        assertEquals(builder, result)
+    }
+
+    @Test
+    fun `builder allows full chaining of all methods`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .property("prop_key", "prop_value")
+                .properties(mapOf("prop_key2" to "prop_value2"))
+                .userProperty("user_key", "user_value")
+                .userProperties(mapOf("user_key2" to "user_value2"))
+                .userPropertySetOnce("once_key", "once_value")
+                .userPropertiesSetOnce(mapOf("once_key2" to "once_value2"))
+                .group("organization", "org_123")
+                .groups(mapOf("team" to "team_456"))
+                .build()
+
+        assertEquals(mapOf("prop_key" to "prop_value", "prop_key2" to "prop_value2"), options.properties)
+        assertEquals(mapOf("user_key" to "user_value", "user_key2" to "user_value2"), options.userProperties)
+        assertEquals(mapOf("once_key" to "once_value", "once_key2" to "once_value2"), options.userPropertiesSetOnce)
+        assertEquals(mapOf("organization" to "org_123", "team" to "team_456"), options.groups)
+    }
+
+    @Test
+    fun `overwriting same key in properties replaces value`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .property("key", "first_value")
+                .property("key", "second_value")
+                .build()
+
+        assertEquals(mapOf("key" to "second_value"), options.properties)
+    }
+
+    @Test
+    fun `overwriting same key in userProperties replaces value`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userProperty("key", "first_value")
+                .userProperty("key", "second_value")
+                .build()
+
+        assertEquals(mapOf("key" to "second_value"), options.userProperties)
+    }
+
+    @Test
+    fun `overwriting same key in userPropertiesSetOnce replaces value`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .userPropertySetOnce("key", "first_value")
+                .userPropertySetOnce("key", "second_value")
+                .build()
+
+        assertEquals(mapOf("key" to "second_value"), options.userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `overwriting same key in groups replaces value`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .group("organization", "org_123")
+                .group("organization", "org_456")
+                .build()
+
+        assertEquals(mapOf("organization" to "org_456"), options.groups)
+    }
+
+    @Test
+    fun `empty maps in properties methods work correctly`() {
+        val options =
+            PostHogCaptureOptions.builder()
+                .properties(emptyMap())
+                .userProperties(emptyMap())
+                .userPropertiesSetOnce(emptyMap())
+                .groups(emptyMap())
+                .build()
+
+        assertEquals(emptyMap(), options.properties)
+        assertEquals(emptyMap(), options.userProperties)
+        assertEquals(emptyMap(), options.userPropertiesSetOnce)
+        assertEquals(emptyMap(), options.groups)
+    }
+
+    @Test
+    fun `maps passed to properties methods are correctly copied`() {
+        val originalProperties = mutableMapOf("key" to "value")
+        val options =
+            PostHogCaptureOptions.builder()
+                .properties(originalProperties)
+                .build()
+
+        // Modify original map
+        originalProperties["new_key"] = "new_value"
+
+        // Built options should not be affected
+        assertEquals(mapOf("key" to "value"), options.properties)
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -1,0 +1,473 @@
+package com.posthog.server
+
+import com.posthog.PostHogOnFeatureFlags
+import java.net.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+internal class PostHogConfigTest {
+    @Test
+    fun `constructor sets all required parameters with defaults`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+
+        assertEquals(TEST_API_KEY, config.apiKey)
+        assertEquals(PostHogConfig.DEFAULT_HOST, config.host)
+        assertEquals(false, config.debug)
+        assertEquals(true, config.sendFeatureFlagEvent)
+        assertEquals(true, config.preloadFeatureFlags)
+        assertEquals(true, config.remoteConfig)
+        assertEquals(PostHogConfig.DEFAULT_FLUSH_AT, config.flushAt)
+        assertEquals(PostHogConfig.DEFAULT_MAX_QUEUE_SIZE, config.maxQueueSize)
+        assertEquals(PostHogConfig.DEFAULT_MAX_BATCH_SIZE, config.maxBatchSize)
+        assertEquals(PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS, config.flushIntervalSeconds)
+        assertNull(config.encryption)
+        assertNull(config.onFeatureFlags)
+        assertNull(config.proxy)
+        assertEquals(PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_SIZE, config.featureFlagCacheSize)
+        assertEquals(PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS, config.featureFlagCacheMaxAgeMs)
+    }
+
+    @Test
+    fun `constructor sets all parameters when provided`() {
+        val mockEncryption = createMockEncryption()
+        val mockOnFeatureFlags = PostHogOnFeatureFlags { }
+        val mockProxy = Proxy.NO_PROXY
+
+        val config =
+            PostHogConfig(
+                apiKey = "custom-api-key",
+                host = "https://custom.host.com",
+                debug = true,
+                sendFeatureFlagEvent = false,
+                preloadFeatureFlags = false,
+                remoteConfig = false,
+                flushAt = 10,
+                maxQueueSize = 500,
+                maxBatchSize = 25,
+                flushIntervalSeconds = 60,
+                encryption = mockEncryption,
+                onFeatureFlags = mockOnFeatureFlags,
+                proxy = mockProxy,
+                featureFlagCacheSize = 2000,
+                featureFlagCacheMaxAgeMs = 600000,
+            )
+
+        assertEquals("custom-api-key", config.apiKey)
+        assertEquals("https://custom.host.com", config.host)
+        assertEquals(true, config.debug)
+        assertEquals(false, config.sendFeatureFlagEvent)
+        assertEquals(false, config.preloadFeatureFlags)
+        assertEquals(false, config.remoteConfig)
+        assertEquals(10, config.flushAt)
+        assertEquals(500, config.maxQueueSize)
+        assertEquals(25, config.maxBatchSize)
+        assertEquals(60, config.flushIntervalSeconds)
+        assertEquals(mockEncryption, config.encryption)
+        assertEquals(mockOnFeatureFlags, config.onFeatureFlags)
+        assertEquals(mockProxy, config.proxy)
+        assertEquals(2000, config.featureFlagCacheSize)
+        assertEquals(600000, config.featureFlagCacheMaxAgeMs)
+    }
+
+    @Test
+    fun `addBeforeSend adds callback to internal list`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val beforeSend = createMockBeforeSend()
+
+        config.addBeforeSend(beforeSend)
+
+        // Verify by converting to core config and checking it was applied
+        val coreConfig = config.asCoreConfig()
+        // Note: We can't directly test the internal list, but we can test that
+        // it gets applied to the core config through the asCoreConfig method
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `removeBeforeSend removes callback from internal list`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val beforeSend = createMockBeforeSend()
+
+        config.addBeforeSend(beforeSend)
+        config.removeBeforeSend(beforeSend)
+
+        // Verify removal by ensuring the core config is created without issues
+        val coreConfig = config.asCoreConfig()
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `addIntegration adds integration to internal list`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val integration = createMockIntegration()
+
+        config.addIntegration(integration)
+
+        // Verify by converting to core config
+        val coreConfig = config.asCoreConfig()
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `asCoreConfig creates core config with all properties`() {
+        val mockEncryption = createMockEncryption()
+        val mockOnFeatureFlags = PostHogOnFeatureFlags { }
+
+        val config =
+            PostHogConfig(
+                apiKey = "test-key",
+                host = "https://test.host.com",
+                debug = true,
+                sendFeatureFlagEvent = false,
+                preloadFeatureFlags = false,
+                remoteConfig = false,
+                flushAt = 15,
+                maxQueueSize = 750,
+                maxBatchSize = 30,
+                flushIntervalSeconds = 45,
+                encryption = mockEncryption,
+                onFeatureFlags = mockOnFeatureFlags,
+                featureFlagCacheSize = 1500,
+                featureFlagCacheMaxAgeMs = 300000,
+            )
+
+        val coreConfig = config.asCoreConfig()
+
+        assertEquals("test-key", coreConfig.apiKey)
+        assertEquals("https://test.host.com", coreConfig.host)
+        assertEquals(true, coreConfig.debug)
+        assertEquals(false, coreConfig.sendFeatureFlagEvent)
+        assertEquals(false, coreConfig.preloadFeatureFlags)
+        assertEquals(false, coreConfig.remoteConfig)
+        assertEquals(15, coreConfig.flushAt)
+        assertEquals(750, coreConfig.maxQueueSize)
+        assertEquals(30, coreConfig.maxBatchSize)
+        assertEquals(45, coreConfig.flushIntervalSeconds)
+        assertEquals(mockEncryption, coreConfig.encryption)
+        assertEquals(mockOnFeatureFlags, coreConfig.onFeatureFlags)
+    }
+
+    @Test
+    fun `asCoreConfig applies beforeSend callbacks to core config`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val beforeSend1 = createMockBeforeSend()
+        val beforeSend2 = createMockBeforeSend()
+
+        config.addBeforeSend(beforeSend1)
+        config.addBeforeSend(beforeSend2)
+
+        val coreConfig = config.asCoreConfig()
+
+        // Verify the core config was created successfully
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `asCoreConfig applies integrations to core config`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val integration1 = createMockIntegration()
+        val integration2 = createMockIntegration()
+
+        config.addIntegration(integration1)
+        config.addIntegration(integration2)
+
+        val coreConfig = config.asCoreConfig()
+
+        // Verify the core config was created successfully
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `companion object constants have correct values`() {
+        assertEquals("https://us.i.posthog.com", PostHogConfig.DEFAULT_US_HOST)
+        assertEquals("https://us-assets.i.posthog.com", PostHogConfig.DEFAULT_US_ASSETS_HOST)
+        assertEquals("https://us.i.posthog.com", PostHogConfig.DEFAULT_HOST)
+        assertEquals("https://eu.i.posthog.com", PostHogConfig.DEFAULT_EU_HOST)
+        assertEquals("https://eu-assets.i.posthog.com", PostHogConfig.DEFAULT_EU_ASSETS_HOST)
+        assertEquals(20, PostHogConfig.DEFAULT_FLUSH_AT)
+        assertEquals(1000, PostHogConfig.DEFAULT_MAX_QUEUE_SIZE)
+        assertEquals(50, PostHogConfig.DEFAULT_MAX_BATCH_SIZE)
+        assertEquals(30, PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS)
+        assertEquals(1000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_SIZE)
+        assertEquals(300000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS) // 5 minutes
+    }
+
+    @Test
+    fun `builder creates builder instance with correct api key`() {
+        val builder = PostHogConfig.builder("test-api-key")
+
+        val config = builder.build()
+        assertEquals("test-api-key", config.apiKey)
+    }
+
+    // Builder tests
+    @Test
+    fun `builder creates config with default values`() {
+        val config = PostHogConfig.builder(TEST_API_KEY).build()
+
+        assertEquals(TEST_API_KEY, config.apiKey)
+        assertEquals(PostHogConfig.DEFAULT_HOST, config.host)
+        assertEquals(false, config.debug)
+        assertEquals(true, config.sendFeatureFlagEvent)
+        assertEquals(true, config.preloadFeatureFlags)
+        assertEquals(true, config.remoteConfig)
+        assertEquals(PostHogConfig.DEFAULT_FLUSH_AT, config.flushAt)
+        assertEquals(PostHogConfig.DEFAULT_MAX_QUEUE_SIZE, config.maxQueueSize)
+        assertEquals(PostHogConfig.DEFAULT_MAX_BATCH_SIZE, config.maxBatchSize)
+        assertEquals(PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS, config.flushIntervalSeconds)
+        assertNull(config.encryption)
+        assertNull(config.onFeatureFlags)
+        assertNull(config.proxy)
+    }
+
+    @Test
+    fun `builder host method sets host and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.host("https://custom.host.com")
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals("https://custom.host.com", config.host)
+    }
+
+    @Test
+    fun `builder debug method sets debug and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.debug(true)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(true, config.debug)
+    }
+
+    @Test
+    fun `builder sendFeatureFlagEvent method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.sendFeatureFlagEvent(false)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(false, config.sendFeatureFlagEvent)
+    }
+
+    @Test
+    fun `builder preloadFeatureFlags method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.preloadFeatureFlags(false)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(false, config.preloadFeatureFlags)
+    }
+
+    @Test
+    fun `builder remoteConfig method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.remoteConfig(false)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(false, config.remoteConfig)
+    }
+
+    @Test
+    fun `builder flushAt method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.flushAt(15)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(15, config.flushAt)
+    }
+
+    @Test
+    fun `builder maxQueueSize method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.maxQueueSize(750)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(750, config.maxQueueSize)
+    }
+
+    @Test
+    fun `builder maxBatchSize method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.maxBatchSize(30)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(30, config.maxBatchSize)
+    }
+
+    @Test
+    fun `builder flushIntervalSeconds method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.flushIntervalSeconds(45)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(45, config.flushIntervalSeconds)
+    }
+
+    @Test
+    fun `builder encryption method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val mockEncryption = createMockEncryption()
+        val result = builder.encryption(mockEncryption)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(mockEncryption, config.encryption)
+    }
+
+    @Test
+    fun `builder onFeatureFlags method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val mockCallback = PostHogOnFeatureFlags { }
+        val result = builder.onFeatureFlags(mockCallback)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(mockCallback, config.onFeatureFlags)
+    }
+
+    @Test
+    fun `builder proxy method sets value and returns builder`() {
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val mockProxy = Proxy.NO_PROXY
+        val result = builder.proxy(mockProxy)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(mockProxy, config.proxy)
+    }
+
+    @Test
+    fun `builder allows method chaining`() {
+        val mockEncryption = createMockEncryption()
+        val mockCallback = PostHogOnFeatureFlags { }
+
+        val config =
+            PostHogConfig.builder(TEST_API_KEY)
+                .host("https://custom.host.com")
+                .debug(true)
+                .sendFeatureFlagEvent(false)
+                .preloadFeatureFlags(false)
+                .remoteConfig(false)
+                .flushAt(15)
+                .maxQueueSize(750)
+                .maxBatchSize(30)
+                .flushIntervalSeconds(45)
+                .encryption(mockEncryption)
+                .onFeatureFlags(mockCallback)
+                .proxy(Proxy.NO_PROXY)
+                .build()
+
+        assertEquals(TEST_API_KEY, config.apiKey)
+        assertEquals("https://custom.host.com", config.host)
+        assertEquals(true, config.debug)
+        assertEquals(false, config.sendFeatureFlagEvent)
+        assertEquals(false, config.preloadFeatureFlags)
+        assertEquals(false, config.remoteConfig)
+        assertEquals(15, config.flushAt)
+        assertEquals(750, config.maxQueueSize)
+        assertEquals(30, config.maxBatchSize)
+        assertEquals(45, config.flushIntervalSeconds)
+        assertEquals(mockEncryption, config.encryption)
+        assertEquals(mockCallback, config.onFeatureFlags)
+        assertEquals(Proxy.NO_PROXY, config.proxy)
+    }
+
+    @Test
+    fun `builder can set null values`() {
+        val config =
+            PostHogConfig.builder(TEST_API_KEY)
+                .encryption(null)
+                .onFeatureFlags(null)
+                .proxy(null)
+                .build()
+
+        assertNull(config.encryption)
+        assertNull(config.onFeatureFlags)
+        assertNull(config.proxy)
+    }
+
+    @Test
+    fun `config properties are mutable after creation`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+
+        // Test that properties can be modified
+        config.debug = true
+        config.sendFeatureFlagEvent = false
+        config.preloadFeatureFlags = false
+        config.remoteConfig = false
+        config.flushAt = 100
+        config.maxQueueSize = 2000
+        config.maxBatchSize = 75
+        config.flushIntervalSeconds = 120
+        config.featureFlagCacheSize = 500
+        config.featureFlagCacheMaxAgeMs = 600000
+
+        assertEquals(true, config.debug)
+        assertEquals(false, config.sendFeatureFlagEvent)
+        assertEquals(false, config.preloadFeatureFlags)
+        assertEquals(false, config.remoteConfig)
+        assertEquals(100, config.flushAt)
+        assertEquals(2000, config.maxQueueSize)
+        assertEquals(75, config.maxBatchSize)
+        assertEquals(120, config.flushIntervalSeconds)
+        assertEquals(500, config.featureFlagCacheSize)
+        assertEquals(600000, config.featureFlagCacheMaxAgeMs)
+    }
+
+    @Test
+    fun `multiple beforeSend callbacks can be added and removed`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val beforeSend1 = createMockBeforeSend()
+        val beforeSend2 = createMockBeforeSend()
+        val beforeSend3 = createMockBeforeSend()
+
+        // Add multiple callbacks
+        config.addBeforeSend(beforeSend1)
+        config.addBeforeSend(beforeSend2)
+        config.addBeforeSend(beforeSend3)
+
+        // Remove one callback
+        config.removeBeforeSend(beforeSend2)
+
+        // Verify by creating core config (which applies all callbacks)
+        val coreConfig = config.asCoreConfig()
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `multiple integrations can be added`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val integration1 = createMockIntegration()
+        val integration2 = createMockIntegration()
+
+        config.addIntegration(integration1)
+        config.addIntegration(integration2)
+
+        // Verify by creating core config (which applies all integrations)
+        val coreConfig = config.asCoreConfig()
+        assertEquals(TEST_API_KEY, coreConfig.apiKey)
+    }
+
+    @Test
+    fun `asCoreConfig creates new instance each time`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+
+        val coreConfig1 = config.asCoreConfig()
+        val coreConfig2 = config.asCoreConfig()
+
+        // Should be different instances
+        assertNotEquals(coreConfig1, coreConfig2)
+        // But should have same properties
+        assertEquals(coreConfig1.apiKey, coreConfig2.apiKey)
+        assertEquals(coreConfig1.host, coreConfig2.host)
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/PostHogTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogTest.kt
@@ -1,0 +1,389 @@
+package com.posthog.server
+
+import com.posthog.PostHogStatelessInterface
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+internal class PostHogTest {
+    private fun createMockStateless(): PostHogStatelessInterface {
+        return mock()
+    }
+
+    private fun createPostHogWithMock(mockInstance: PostHogStatelessInterface): PostHog {
+        val postHog = PostHog()
+
+        // We need to mock PostHogStateless.with() to return our mock
+        // Since we can't easily mock static methods, we'll test the delegation assuming setup works
+
+        // Use reflection to set the private instance field for testing
+        val instanceField = PostHog::class.java.getDeclaredField("instance")
+        instanceField.isAccessible = true
+        instanceField.set(postHog, mockInstance)
+
+        return postHog
+    }
+
+    @Test
+    fun `setup creates PostHogStateless instance with core config`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val postHog = PostHog()
+
+        postHog.setup(config)
+
+        // Verify that setup doesn't throw and the instance is configured
+        // We can't easily verify the internal state without reflection or mocking
+        // but we can verify behavior through other methods
+    }
+
+    @Test
+    fun `close delegates to instance close`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.close()
+
+        verify(mockInstance).close()
+    }
+
+    @Test
+    fun `close handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.close()
+    }
+
+    @Test
+    fun `identify delegates to instance with all parameters`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        val userProperties = mapOf("name" to "John", "age" to 30)
+        val userPropertiesSetOnce = mapOf("first_login" to true)
+
+        postHog.identify("user123", userProperties, userPropertiesSetOnce)
+
+        verify(mockInstance).identify("user123", userProperties, userPropertiesSetOnce)
+    }
+
+    @Test
+    fun `identify handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.identify("user123", mapOf("name" to "John"), null)
+    }
+
+    @Test
+    fun `flush delegates to instance`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.flush()
+
+        verify(mockInstance).flush()
+    }
+
+    @Test
+    fun `flush handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.flush()
+    }
+
+    @Test
+    fun `debug delegates to instance`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.debug(true)
+
+        verify(mockInstance).debug(true)
+    }
+
+    @Test
+    fun `debug handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.debug(false)
+    }
+
+    @Test
+    fun `capture delegates to instance captureStateless with all parameters`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        val properties = mapOf("page" to "home")
+        val userProperties = mapOf("plan" to "premium")
+        val userPropertiesSetOnce = mapOf("signup_date" to "2023-01-01")
+        val groups = mapOf("organization" to "acme")
+
+        postHog.capture(
+            distinctId = "user123",
+            event = "page_view",
+            properties = properties,
+            userProperties = userProperties,
+            userPropertiesSetOnce = userPropertiesSetOnce,
+            groups = groups,
+        )
+
+        verify(mockInstance).captureStateless(
+            "page_view",
+            "user123",
+            properties,
+            userProperties,
+            userPropertiesSetOnce,
+            groups,
+        )
+    }
+
+    @Test
+    fun `capture handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.capture("user123", "test_event", mapOf("key" to "value"))
+    }
+
+    @Test
+    fun `isFeatureEnabled delegates to instance and returns result`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        whenever(mockInstance.isFeatureEnabledStateless("user123", "feature_key", true))
+            .thenReturn(false)
+
+        val result = postHog.isFeatureEnabled("user123", "feature_key", true)
+
+        verify(mockInstance).isFeatureEnabledStateless("user123", "feature_key", true)
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isFeatureEnabled returns false when instance is null`() {
+        val postHog = PostHog()
+
+        val result = postHog.isFeatureEnabled("user123", "feature_key", true)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `getFeatureFlag delegates to instance and returns result`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        whenever(mockInstance.getFeatureFlagStateless("user123", "feature_key", "default"))
+            .thenReturn("variant_a")
+
+        val result = postHog.getFeatureFlag("user123", "feature_key", "default")
+
+        verify(mockInstance).getFeatureFlagStateless("user123", "feature_key", "default")
+        assertEquals("variant_a", result)
+    }
+
+    @Test
+    fun `getFeatureFlag returns null when instance is null`() {
+        val postHog = PostHog()
+
+        val result = postHog.getFeatureFlag("user123", "feature_key", "default")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getFeatureFlagPayload delegates to instance and returns result`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        val payloadData = mapOf("config" to "value")
+        whenever(mockInstance.getFeatureFlagPayloadStateless("user123", "feature_key", null))
+            .thenReturn(payloadData)
+
+        val result = postHog.getFeatureFlagPayload("user123", "feature_key", null)
+
+        verify(mockInstance).getFeatureFlagPayloadStateless("user123", "feature_key", null)
+        assertEquals(payloadData, result)
+    }
+
+    @Test
+    fun `getFeatureFlagPayload returns null when instance is null`() {
+        val postHog = PostHog()
+
+        val result = postHog.getFeatureFlagPayload("user123", "feature_key", "default")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `group delegates to instance groupStateless`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        val groupProperties = mapOf("plan" to "enterprise", "size" to 100)
+
+        postHog.group("user123", "organization", "acme_corp", groupProperties)
+
+        verify(mockInstance).groupStateless("user123", "organization", "acme_corp", groupProperties)
+    }
+
+    @Test
+    fun `group handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.group("user123", "organization", "acme_corp", mapOf("size" to 10))
+    }
+
+    @Test
+    fun `alias delegates to instance aliasStateless`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.alias("user123", "john_doe")
+
+        verify(mockInstance).aliasStateless("user123", "john_doe")
+    }
+
+    @Test
+    fun `alias handles null instance gracefully`() {
+        val postHog = PostHog()
+
+        // Should not throw when instance is null
+        postHog.alias("user123", "john_doe")
+    }
+
+    @Test
+    fun `with companion method creates and sets up PostHog instance`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY, debug = true)
+
+        val postHogInterface = PostHog.with(config)
+
+        // Verify that we get a PostHogInterface back
+        assertEquals(PostHog::class, postHogInterface::class)
+
+        // The instance should be set up (we can't easily verify internal state,
+        // but the method should complete without throwing)
+    }
+
+    @Test
+    fun `with companion method works with different config types`() {
+        val config =
+            PostHogConfig(
+                apiKey = "custom-key",
+                host = "https://custom.host.com",
+                debug = false,
+                flushAt = 5,
+            )
+
+        val postHogInterface = PostHog.with(config)
+
+        assertEquals(PostHog::class, postHogInterface::class)
+    }
+
+    @Test
+    fun `capture with null parameters delegates correctly`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.capture(
+            distinctId = "user123",
+            event = "simple_event",
+            properties = null,
+            userProperties = null,
+            userPropertiesSetOnce = null,
+            groups = null,
+        )
+
+        verify(mockInstance).captureStateless(
+            "simple_event",
+            "user123",
+            null,
+            null,
+            null,
+            null,
+        )
+    }
+
+    @Test
+    fun `identify with null parameters delegates correctly`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.identify("user123", null, null)
+
+        verify(mockInstance).identify("user123", null, null)
+    }
+
+    @Test
+    fun `group with null groupProperties delegates correctly`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        postHog.group("user123", "organization", "acme_corp", null)
+
+        verify(mockInstance).groupStateless("user123", "organization", "acme_corp", null)
+    }
+
+    @Test
+    fun `feature flag methods handle different return types`() {
+        val mockInstance = createMockStateless()
+        val postHog = createPostHogWithMock(mockInstance)
+
+        // Test boolean feature flag
+        whenever(mockInstance.isFeatureEnabledStateless("user123", "bool_flag", false))
+            .thenReturn(true)
+
+        // Test string feature flag
+        whenever(mockInstance.getFeatureFlagStateless("user123", "string_flag", null))
+            .thenReturn("variant_b")
+
+        // Test numeric feature flag
+        whenever(mockInstance.getFeatureFlagStateless("user123", "numeric_flag", 0))
+            .thenReturn(42)
+
+        val boolResult = postHog.isFeatureEnabled("user123", "bool_flag", false)
+        val stringResult = postHog.getFeatureFlag("user123", "string_flag", null)
+        val numericResult = postHog.getFeatureFlag("user123", "numeric_flag", 0)
+
+        assertEquals(true, boolResult)
+        assertEquals("variant_b", stringResult)
+        assertEquals(42, numericResult)
+    }
+
+    @Test
+    fun `all methods work correctly after setup`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        val postHog = PostHog()
+
+        postHog.setup(config)
+
+        // These should all complete without throwing exceptions
+        // (We can't easily verify the actual behavior without mocking PostHogStateless.with())
+        postHog.identify("user123")
+        postHog.capture("user123", "test_event")
+        postHog.group("user123", "org", "test")
+        postHog.alias("user123", "alias")
+        postHog.flush()
+        postHog.debug(true)
+
+        // Feature flag methods should return sensible defaults when no real instance
+        val featureEnabled = postHog.isFeatureEnabled("user123", "test_flag")
+        val featureFlag = postHog.getFeatureFlag("user123", "test_flag")
+        val flagPayload = postHog.getFeatureFlagPayload("user123", "test_flag")
+
+        // With no real setup, these should return defaults/nulls
+        assertFalse(featureEnabled)
+        assertNull(featureFlag)
+        assertNull(flagPayload)
+
+        postHog.close()
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/Utils.kt
+++ b/posthog-server/src/test/java/com/posthog/server/Utils.kt
@@ -1,0 +1,264 @@
+package com.posthog.server
+
+import com.google.gson.internal.bind.util.ISO8601Utils
+import com.posthog.PostHogConfig
+import com.posthog.PostHogEvent
+import com.posthog.internal.PostHogLogger
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import okio.GzipSource
+import okio.buffer
+import java.text.ParsePosition
+import java.util.Date
+import java.util.UUID
+import java.util.concurrent.ExecutorService
+
+/**
+ * Test utilities for posthog-server tests
+ */
+
+public const val TEST_API_KEY: String = "test-api-key"
+
+// Executor utilities
+public fun ExecutorService.awaitExecution() {
+    // instead of using shutdownAndAwaitTermination which shutdown the executor
+    // we schedule a task to be run and await for it to be completed
+    submit {}.get()
+}
+
+public fun ExecutorService.shutdownAndAwaitTermination() {
+    shutdown() // Disable new tasks from being submitted
+    try {
+        // Wait a while for existing tasks to terminate
+        if (!awaitTermination(60, java.util.concurrent.TimeUnit.SECONDS)) {
+            shutdownNow() // Cancel currently executing tasks
+            // Wait a while for tasks to respond to being cancelled
+            if (!awaitTermination(
+                    60,
+                    java.util.concurrent.TimeUnit.SECONDS,
+                )
+            ) {
+                throw RuntimeException("Pool did not terminate")
+            }
+        }
+    } catch (ie: InterruptedException) {
+        // (Re-)Cancel if current thread also interrupted
+        shutdownNow()
+        // Preserve interrupt status
+        Thread.currentThread().interrupt()
+    }
+}
+
+// Event generation utilities
+public val date: Date = ISO8601Utils.parse("2023-09-20T11:58:49.000Z", ParsePosition(0))
+public const val EVENT: String = "event"
+public const val DISTINCT_ID: String = "distinctId"
+public val props: Map<String, Any> = mapOf<String, Any>("prop" to "value")
+public val uuid: UUID = UUID.fromString("8c04e5c1-8f6e-4002-96fd-1804799b6ffe")
+
+public fun generateEvent(
+    eventName: String? = null,
+    givenUuid: UUID? = null,
+): PostHogEvent {
+    return PostHogEvent(
+        eventName ?: EVENT,
+        distinctId = DISTINCT_ID,
+        properties = props.toMutableMap(),
+        timestamp = date,
+        uuid = givenUuid ?: uuid,
+    )
+}
+
+// HTTP utilities
+public fun Buffer.unGzip(): String {
+    return GzipSource(this).use { source ->
+        source.buffer().use { bufferedSource -> bufferedSource.readUtf8() }
+    }
+}
+
+/**
+ * Mock logger that captures log messages for test verification
+ */
+public class TestLogger : PostHogLogger {
+    public val logs: MutableList<String> = mutableListOf()
+
+    override fun log(message: String) {
+        logs.add(message)
+    }
+
+    override fun isEnabled(): Boolean = true
+
+    public fun clear() {
+        logs.clear()
+    }
+
+    public fun containsLog(substring: String): Boolean = logs.any { it.contains(substring) }
+
+    public fun countLogs(substring: String): Int = logs.count { it.contains(substring) }
+}
+
+/**
+ * Creates a mock HTTP server with the given response
+ */
+public fun createMockHttp(response: MockResponse = MockResponse().setBody("")): MockWebServer {
+    val mockServer = MockWebServer()
+    mockServer.start()
+    mockServer.enqueue(response)
+    return mockServer
+}
+
+/**
+ * Creates a mock HTTP server with multiple responses
+ */
+public fun createMockHttp(vararg responses: MockResponse): MockWebServer {
+    val mockServer = MockWebServer()
+    mockServer.start()
+    responses.forEach { mockServer.enqueue(it) }
+    return mockServer
+}
+
+/**
+ * Creates a PostHogConfig for testing
+ */
+public fun createTestConfig(
+    logger: PostHogLogger = TestLogger(),
+    host: String = "https://example.com",
+    apiKey: String = TEST_API_KEY,
+): PostHogConfig {
+    val config =
+        PostHogConfig(
+            apiKey = apiKey,
+            host = host,
+        )
+    config.logger = logger
+    return config
+}
+
+/**
+ * Creates a standard JSON response for feature flags
+ */
+public fun createFlagsResponse(
+    flagKey: String,
+    enabled: Boolean = true,
+    variant: String? = null,
+    payload: String? = null,
+): String {
+    val payloadJson = if (payload != null) "\"$payload\"" else "null"
+    val variantJson = if (variant != null) "\"$variant\"" else "null"
+
+    return """
+        {
+            "flags": {
+                "$flagKey": {
+                    "key": "$flagKey",
+                    "enabled": $enabled,
+                    "variant": $variantJson,
+                    "metadata": {
+                        "version": 1,
+                        "payload": $payloadJson,
+                        "id": 1
+                    },
+                    "reason": {
+                        "kind": "condition_match",
+                        "condition_match_type": "Test condition",
+                        "condition_index": 0
+                    }
+                }
+            }
+        }
+        """.trimIndent()
+}
+
+/**
+ * Creates a JSON response with multiple feature flags
+ */
+public fun createMultipleFlagsResponse(vararg flags: Pair<String, Boolean>): String {
+    val flagsJson =
+        flags.joinToString(",\n") { (key, enabled) ->
+            """
+            "$key": {
+                "key": "$key",
+                "enabled": $enabled,
+                "variant": null,
+                "metadata": {
+                    "version": 1,
+                    "payload": null,
+                    "id": 1
+                },
+                "reason": {
+                    "kind": "condition_match",
+                    "condition_match_type": "Test condition",
+                    "condition_index": 0
+                }
+            }
+            """.trimIndent()
+        }
+
+    return """
+        {
+            "flags": {
+                $flagsJson
+            }
+        }
+        """.trimIndent()
+}
+
+/**
+ * Creates an empty flags response
+ */
+public fun createEmptyFlagsResponse(): String {
+    return """
+        {
+            "flags": {}
+        }
+        """.trimIndent()
+}
+
+/**
+ * Creates a MockResponse with JSON content type
+ */
+public fun jsonResponse(body: String): MockResponse {
+    return MockResponse()
+        .setBody(body)
+        .setHeader("Content-Type", "application/json")
+}
+
+/**
+ * Creates a MockResponse with error status
+ */
+public fun errorResponse(
+    code: Int,
+    message: String = "Error",
+): MockResponse {
+    return MockResponse()
+        .setResponseCode(code)
+        .setBody(message)
+}
+
+/**
+ * Creates a mock PostHogEncryption implementation for testing
+ */
+public fun createMockEncryption(): com.posthog.PostHogEncryption {
+    return object : com.posthog.PostHogEncryption {
+        override fun encrypt(outputStream: java.io.OutputStream): java.io.OutputStream = outputStream
+
+        override fun decrypt(inputStream: java.io.InputStream): java.io.InputStream = inputStream
+    }
+}
+
+/**
+ * Creates a mock PostHogBeforeSend implementation for testing
+ */
+public fun createMockBeforeSend(): com.posthog.PostHogBeforeSend {
+    return com.posthog.PostHogBeforeSend { event -> event }
+}
+
+/**
+ * Creates a mock PostHogIntegration implementation for testing
+ */
+public fun createMockIntegration(): com.posthog.PostHogIntegration {
+    return object : com.posthog.PostHogIntegration {
+        // Using default implementations from interface
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagCacheTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagCacheTest.kt
@@ -1,0 +1,349 @@
+package com.posthog.server.internal
+
+import com.posthog.internal.EvaluationReason
+import com.posthog.internal.FeatureFlag
+import com.posthog.internal.FeatureFlagMetadata
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class PostHogFeatureFlagCacheTest {
+    private fun createTestFlags(): Map<String, FeatureFlag> {
+        val metadata = FeatureFlagMetadata(1, "test-payload", 1)
+        val reason = EvaluationReason("condition_match", "Test condition", 0)
+        return mapOf(
+            "test-flag" to FeatureFlag("test-flag", true, null, metadata, reason),
+            "another-flag" to FeatureFlag("another-flag", false, null, metadata, reason),
+        )
+    }
+
+    private fun createTestKey(
+        distinctId: String = "test-user",
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
+    ): FeatureFlagCacheKey {
+        return FeatureFlagCacheKey(distinctId, groups, personProperties, groupProperties)
+    }
+
+    @Test
+    fun `put and get basic functionality`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey()
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        val retrieved = cache.get(key)
+
+        assertEquals(flags, retrieved)
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `get returns null for non-existent key`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey()
+
+        val retrieved = cache.get(key)
+
+        assertNull(retrieved)
+        assertEquals(0, cache.size())
+    }
+
+    @Test
+    fun `put null flags stores entry correctly`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey()
+
+        cache.put(key, null)
+        val retrieved = cache.get(key)
+
+        assertNull(retrieved)
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `cache expiration removes expired entries on get`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 1) // 1ms TTL
+        val key = createTestKey()
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        assertEquals(1, cache.size())
+
+        // Wait for expiration
+        Thread.sleep(10)
+
+        val retrieved = cache.get(key)
+        assertNull(retrieved)
+        assertEquals(0, cache.size())
+    }
+
+    @Test
+    fun `cache does not expire before TTL`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000) // 1 minute TTL
+        val key = createTestKey()
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        val retrieved = cache.get(key)
+
+        assertEquals(flags, retrieved)
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `LRU eviction removes oldest entry when max size exceeded`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 2, maxAgeMs = 60000)
+        val key1 = createTestKey("user1")
+        val key2 = createTestKey("user2")
+        val key3 = createTestKey("user3")
+        val flags = createTestFlags()
+
+        // Fill cache to capacity
+        cache.put(key1, flags)
+        cache.put(key2, flags)
+        assertEquals(2, cache.size())
+
+        // Adding third entry should evict first
+        cache.put(key3, flags)
+        assertEquals(2, cache.size())
+
+        // key1 should be evicted, key2 and key3 should remain
+        assertNull(cache.get(key1))
+        assertNotNull(cache.get(key2))
+        assertNotNull(cache.get(key3))
+    }
+
+    @Test
+    fun `LRU updates access order on get`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 2, maxAgeMs = 60000)
+        val key1 = createTestKey("user1")
+        val key2 = createTestKey("user2")
+        val key3 = createTestKey("user3")
+        val flags = createTestFlags()
+
+        // Fill cache
+        cache.put(key1, flags)
+        cache.put(key2, flags)
+
+        // Access key1 to make it most recently used
+        cache.get(key1)
+
+        // Add key3, should evict key2 (least recently used)
+        cache.put(key3, flags)
+
+        assertNotNull(cache.get(key1)) // Should still be present
+        assertNull(cache.get(key2)) // Should be evicted
+        assertNotNull(cache.get(key3)) // Should be present
+    }
+
+    @Test
+    fun `clear removes all entries`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key1 = createTestKey("user1")
+        val key2 = createTestKey("user2")
+        val flags = createTestFlags()
+
+        cache.put(key1, flags)
+        cache.put(key2, flags)
+        assertEquals(2, cache.size())
+
+        cache.clear()
+        assertEquals(0, cache.size())
+        assertNull(cache.get(key1))
+        assertNull(cache.get(key2))
+    }
+
+    @Test
+    fun `size returns correct count`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        assertEquals(0, cache.size())
+
+        val flags = createTestFlags()
+        cache.put(createTestKey("user1"), flags)
+        assertEquals(1, cache.size())
+
+        cache.put(createTestKey("user2"), flags)
+        assertEquals(2, cache.size())
+
+        cache.clear()
+        assertEquals(0, cache.size())
+    }
+
+    @Test
+    fun `cleanup removes multiple expired entries`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 1) // 1ms TTL
+        val flags = createTestFlags()
+
+        // Add multiple entries
+        cache.put(createTestKey("user1"), flags)
+        cache.put(createTestKey("user2"), flags)
+        cache.put(createTestKey("user3"), flags)
+        assertEquals(3, cache.size())
+
+        // Wait for expiration
+        Thread.sleep(10)
+
+        // Accessing any key should trigger cleanup of all expired entries
+        cache.get(createTestKey("user1"))
+        assertEquals(0, cache.size())
+    }
+
+    @Test
+    fun `cache key equality with same values`() {
+        val key1 = createTestKey("user1", mapOf("org" to "test"), mapOf("name" to "test"), mapOf("size" to "10"))
+        val key2 = createTestKey("user1", mapOf("org" to "test"), mapOf("name" to "test"), mapOf("size" to "10"))
+
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val flags = createTestFlags()
+
+        cache.put(key1, flags)
+        val retrieved = cache.get(key2)
+
+        assertEquals(flags, retrieved)
+    }
+
+    @Test
+    fun `cache key inequality with different values`() {
+        val key1 = createTestKey("user1")
+        val key2 = createTestKey("user2")
+
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val flags = createTestFlags()
+
+        cache.put(key1, flags)
+        val retrieved = cache.get(key2)
+
+        assertNull(retrieved)
+    }
+
+    @Test
+    fun `cache handles null distinctId`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey(distinctId = null)
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        val retrieved = cache.get(key)
+
+        assertEquals(flags, retrieved)
+    }
+
+    @Test
+    fun `cache handles null groups`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey(groups = null)
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        val retrieved = cache.get(key)
+
+        assertEquals(flags, retrieved)
+    }
+
+    @Test
+    fun `cache handles empty maps`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key =
+            createTestKey(
+                groups = emptyMap(),
+                personProperties = emptyMap(),
+                groupProperties = emptyMap(),
+            )
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        val retrieved = cache.get(key)
+
+        assertEquals(flags, retrieved)
+    }
+
+    @Test
+    fun `cache distinguishes between null and empty maps`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val keyWithNull = createTestKey(groups = null)
+        val keyWithEmpty = createTestKey(groups = emptyMap())
+        val flags = createTestFlags()
+
+        cache.put(keyWithNull, flags)
+        cache.put(keyWithEmpty, flags)
+
+        assertEquals(flags, cache.get(keyWithNull))
+        assertEquals(flags, cache.get(keyWithEmpty))
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `concurrent access maintains cache consistency`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 100, maxAgeMs = 60000)
+        val flags = createTestFlags()
+        val numThreads = 10
+        val numOperationsPerThread = 100
+
+        val threads = mutableListOf<Thread>()
+
+        repeat(numThreads) { threadId ->
+            val thread =
+                Thread {
+                    repeat(numOperationsPerThread) { operation ->
+                        val key = createTestKey("user-$threadId-$operation")
+                        cache.put(key, flags)
+                        cache.get(key)
+                    }
+                }
+            threads.add(thread)
+            thread.start()
+        }
+
+        threads.forEach { it.join() }
+
+        // Cache should not exceed max size due to LRU eviction
+        assertTrue(cache.size() <= 100)
+    }
+
+    @Test
+    fun `put overwrites existing entry`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey()
+        val flags1 = createTestFlags()
+        val metadata = FeatureFlagMetadata(1, "test-payload", 1)
+        val reason = EvaluationReason("condition_match", "Test condition", 0)
+        val flags2 = mapOf("different-flag" to FeatureFlag("different-flag", true, null, metadata, reason))
+
+        cache.put(key, flags1)
+        cache.put(key, flags2)
+
+        assertEquals(flags2, cache.get(key))
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `cache with zero max size behaves correctly`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 0, maxAgeMs = 60000)
+        val key = createTestKey()
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        assertEquals(0, cache.size())
+        assertNull(cache.get(key))
+    }
+
+    @Test
+    fun `cache with zero TTL expires immediately`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 0)
+        val key = createTestKey()
+        val flags = createTestFlags()
+
+        cache.put(key, flags)
+        // Even without waiting, entry should be expired
+        assertNull(cache.get(key))
+        assertEquals(0, cache.size())
+    }
+
+    private fun createTestKey(distinctId: String?): FeatureFlagCacheKey {
+        return FeatureFlagCacheKey(distinctId, null, null, null)
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1,0 +1,373 @@
+package com.posthog.server.internal
+
+import com.posthog.internal.PostHogApi
+import com.posthog.server.TestLogger
+import com.posthog.server.createEmptyFlagsResponse
+import com.posthog.server.createFlagsResponse
+import com.posthog.server.createMockHttp
+import com.posthog.server.createTestConfig
+import com.posthog.server.errorResponse
+import com.posthog.server.jsonResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class PostHogFeatureFlagsTest {
+    @Test
+    fun `getFeatureFlag returns variant when available via API`() {
+        val flagsResponse = createFlagsResponse("test-flag", enabled = true, variant = "variant-a")
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result =
+            remoteConfig.getFeatureFlag(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = "test-user",
+            )
+
+        assertEquals("variant-a", result)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlag returns enabled when variant is null`() {
+        val flagsResponse = createFlagsResponse("test-flag", enabled = true, variant = null)
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result =
+            remoteConfig.getFeatureFlag(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = "test-user",
+            )
+
+        assertEquals(true, result)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlag returns default value when flag not found`() {
+        val flagsResponse = createEmptyFlagsResponse()
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result =
+            remoteConfig.getFeatureFlag(
+                key = "missing-flag",
+                defaultValue = "default",
+                distinctId = "test-user",
+            )
+
+        assertEquals("default", result)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlag returns default value when getFeatureFlags returns null`() {
+        val config = createTestConfig()
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        // The null distinctId will cause getFeatureFlags to return null
+        val result =
+            remoteConfig.getFeatureFlag(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = null,
+            )
+
+        assertEquals("default", result)
+    }
+
+    @Test
+    fun `getFeatureFlagPayload returns payload when available`() {
+        val flagsResponse = createFlagsResponse("test-flag", payload = "test-payload")
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result =
+            remoteConfig.getFeatureFlagPayload(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = "test-user",
+            )
+
+        assertEquals("test-payload", result)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlagPayload returns default value when payload is null`() {
+        val flagsResponse = createFlagsResponse("test-flag", payload = null)
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result =
+            remoteConfig.getFeatureFlagPayload(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = "test-user",
+            )
+
+        assertEquals("default", result)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlagPayload returns default value when getFeatureFlags returns null`() {
+        val config = createTestConfig()
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        // The null distinctId will cause getFeatureFlagPayload to return null
+        val result =
+            remoteConfig.getFeatureFlagPayload(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = null,
+            )
+
+        assertEquals("default", result)
+    }
+
+    @Test
+    fun `getFeatureFlags returns null when distinctId is null`() {
+        val logger = TestLogger()
+        val config = createTestConfig(logger)
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result = remoteConfig.getFeatureFlags()
+
+        assertNull(result)
+        assertTrue(logger.containsLog("getFeatureFlags called but no distinctId available"))
+    }
+
+    @Test
+    fun `getFeatureFlags returns cached flags on cache hit`() {
+        val logger = TestLogger()
+        val flagsResponse = createFlagsResponse("test-flag")
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(logger, url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        // First call should fetch from API and cache
+        val result1 =
+            remoteConfig.getFeatureFlags(
+                distinctId = "test-user",
+            )
+
+        // Second call should use cache (won't make API call)
+        val result2 =
+            remoteConfig.getFeatureFlags(
+                distinctId = "test-user",
+            )
+
+        assertTrue(result1?.isNotEmpty() == true)
+        assertEquals(result1, result2)
+        assertEquals(1, mockServer.requestCount) // Only one API call should be made
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlags handles API errors gracefully`() {
+        val logger = TestLogger()
+        val mockServer = createMockHttp(errorResponse(500, "Internal Server Error"))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(logger, url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result =
+            remoteConfig.getFeatureFlags(
+                distinctId = "test-user",
+            )
+
+        assertNull(result)
+        assertTrue(logger.containsLog("Loading feature flags failed"))
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `clear logs message and empties cache`() {
+        val logger = TestLogger()
+        val flagsResponse = createFlagsResponse("test-flag")
+
+        val mockServer =
+            createMockHttp(
+                jsonResponse(flagsResponse),
+                jsonResponse(flagsResponse),
+            )
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(logger, url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        // Populate cache
+        remoteConfig.getFeatureFlags("test-user")
+        assertEquals(1, mockServer.requestCount) // One API call made
+
+        // Clear cache
+        remoteConfig.clear()
+        assertTrue(logger.containsLog("Feature flags cache cleared"))
+
+        // Next call should be cache miss again
+        logger.clear()
+        remoteConfig.getFeatureFlags("test-user")
+        assertEquals(2, mockServer.requestCount) // Second API call made
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `cache differentiates between different distinctIds`() {
+        val logger = TestLogger()
+        val flagsResponse = createFlagsResponse("test-flag")
+
+        val mockServer =
+            createMockHttp(
+                jsonResponse(flagsResponse),
+                jsonResponse(flagsResponse),
+            )
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(logger, url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        // Different distinctIds should result in different cache entries
+        val result1 = remoteConfig.getFeatureFlags("user1")
+        val result2 = remoteConfig.getFeatureFlags("user2")
+
+        assertTrue(result1?.isNotEmpty() == true)
+        assertTrue(result2?.isNotEmpty() == true)
+        assertEquals(2, mockServer.requestCount)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `cache handles different parameter combinations`() {
+        val flagsResponse = createFlagsResponse("test-flag")
+
+        val mockServer =
+            createMockHttp(
+                jsonResponse(flagsResponse),
+                jsonResponse(flagsResponse),
+            )
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        // Test with all parameters
+        val result1 =
+            remoteConfig.getFeatureFlags(
+                distinctId = "test-user",
+                groups = mapOf("org" to "test-org"),
+                personProperties = mapOf("plan" to "premium"),
+                groupProperties = mapOf("size" to "large"),
+            )
+
+        // Test with null parameters (different cache key)
+        val result2 =
+            remoteConfig.getFeatureFlags(
+                distinctId = "test-user",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+            )
+
+        assertTrue(result1?.isNotEmpty() == true)
+        assertTrue(result2?.isNotEmpty() == true)
+        assertEquals(
+            2,
+            mockServer.requestCount,
+        ) // Should have made 2 API calls for different cache keys
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlag handles different value types correctly`() {
+        // Need to manually construct this one since we need different variants
+        val customFlagsResponse =
+            """
+            {
+                "flags": {
+                    "string-flag": {
+                        "key": "string-flag",
+                        "enabled": true,
+                        "variant": "string-value",
+                        "metadata": { "version": 1, "payload": null, "id": 1 },
+                        "reason": { "kind": "condition_match", "condition_match_type": "Test", "condition_index": 0 }
+                    },
+                    "boolean-flag": {
+                        "key": "boolean-flag",
+                        "enabled": true,
+                        "variant": null,
+                        "metadata": { "version": 1, "payload": null, "id": 1 },
+                        "reason": { "kind": "condition_match", "condition_match_type": "Test", "condition_index": 0 }
+                    },
+                    "disabled-flag": {
+                        "key": "disabled-flag",
+                        "enabled": false,
+                        "variant": null,
+                        "metadata": { "version": 1, "payload": null, "id": 1 },
+                        "reason": { "kind": "condition_match", "condition_match_type": "Test", "condition_index": 0 }
+                    }
+                }
+            }
+            """.trimIndent()
+
+        val mockServer = createMockHttp(jsonResponse(customFlagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val stringResult =
+            remoteConfig.getFeatureFlag("string-flag", "default", "test-user")
+        val booleanResult =
+            remoteConfig.getFeatureFlag("boolean-flag", false, "test-user")
+        val disabledResult =
+            remoteConfig.getFeatureFlag("disabled-flag", true, "test-user")
+
+        assertEquals("string-value", stringResult)
+        assertEquals(true, booleanResult)
+        assertEquals(false, disabledResult)
+
+        mockServer.shutdown()
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogMemoryQueueTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogMemoryQueueTest.kt
@@ -1,0 +1,248 @@
+package com.posthog.server.internal
+
+import com.posthog.PostHogConfig
+import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogApiEndpoint
+import com.posthog.internal.PostHogDateProvider
+import com.posthog.internal.PostHogDeviceDateProvider
+import com.posthog.internal.PostHogNetworkStatus
+import com.posthog.internal.PostHogThreadFactory
+import com.posthog.server.awaitExecution
+import com.posthog.server.createMockHttp
+import com.posthog.server.generateEvent
+import com.posthog.server.shutdownAndAwaitTermination
+import com.posthog.server.unGzip
+import okhttp3.mockwebserver.MockResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import java.util.concurrent.Executors
+import kotlin.test.Test
+
+internal class PostHogMemoryQueueTest {
+    private val executor = Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("Test"))
+
+    private fun getSut(
+        host: String,
+        maxQueueSize: Int = 1000,
+        flushAt: Int = 20,
+        flushIntervalSeconds: Int = 10,
+        dateProvider: PostHogDateProvider = PostHogDeviceDateProvider(),
+        maxBatchSize: Int = 50,
+        networkStatus: PostHogNetworkStatus? = null,
+        retryDelaySeconds: Int = 5,
+    ): PostHogMemoryQueue {
+        val config =
+            PostHogConfig("some_api_key", host).apply {
+                this.maxQueueSize = maxQueueSize
+                this.flushAt = flushAt
+                this.networkStatus = networkStatus
+                this.maxBatchSize = maxBatchSize
+                this.dateProvider = dateProvider
+                this.flushIntervalSeconds = flushIntervalSeconds
+            }
+        val api = PostHogApi(config)
+        return PostHogMemoryQueue(
+            config,
+            api,
+            PostHogApiEndpoint.BATCH,
+            executor = executor,
+            retryDelaySeconds = retryDelaySeconds,
+        )
+    }
+
+    @Test
+    fun `adds a single event`() {
+        val http = createMockHttp()
+        val url = http.url("/")
+        http.enqueue(MockResponse().setBody("{}"))
+        val sut = getSut(url.toString(), flushAt = 1)
+        val event = generateEvent()
+        sut.add(event)
+        executor.awaitExecution()
+
+        val request = http.takeRequest()
+        assertEquals("POST", request.method)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `does not flush empty queue`() {
+        val http = createMockHttp()
+        val sut = getSut(http.url("/").toString(), flushAt = 1)
+        sut.flush()
+        executor.awaitExecution()
+
+        assertEquals(0, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `flushes if queue is above threshold`() {
+        val http = createMockHttp(MockResponse().setBody("{}"))
+        val sut = getSut(http.url("/").toString(), flushAt = 2)
+        val event = generateEvent()
+        sut.add(event)
+        sut.add(event.copy())
+        executor.awaitExecution()
+
+        val request = http.takeRequest()
+        assertEquals("POST", request.method)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `does not flush if queue is below threshold`() {
+        val http = createMockHttp()
+        val sut = getSut(http.url("/").toString(), flushAt = 2)
+        val event = generateEvent()
+        sut.add(event)
+        executor.awaitExecution()
+
+        assertEquals(0, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `discards oldest event when queue is full`() {
+        val http = createMockHttp(MockResponse().setBody("{}"))
+        val sut = getSut(http.url("/").toString(), maxQueueSize = 2, flushAt = 5)
+
+        sut.add(generateEvent("event1"))
+        sut.add(generateEvent("event2"))
+        sut.add(generateEvent("event3")) // Should discard event1
+        executor.awaitExecution()
+
+        sut.flush()
+
+        val request = http.takeRequest()
+        val body = request.body.unGzip()
+
+        assertEquals("POST", request.method)
+        assertTrue("Body should contain event2", body.contains("event2"))
+        assertTrue("Body should contain event3", body.contains("event3"))
+        assertFalse("Body should not contain event1", body.contains("event1"))
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `respects max batch size`() {
+        val http = createMockHttp(MockResponse().setBody("{}"), MockResponse().setBody("{}"))
+        val sut = getSut(http.url("/").toString(), maxBatchSize = 2, flushAt = 3)
+        val event = generateEvent()
+
+        sut.add(event)
+        sut.add(event.copy())
+        sut.add(event.copy())
+        executor.awaitExecution()
+
+        // Should make one request with 2 events (maxBatchSize)
+        val request1 = http.takeRequest()
+        assertEquals("POST", request1.method)
+
+        // Flush the remaining event
+        sut.flush()
+        executor.awaitExecution()
+
+        val request2 = http.takeRequest()
+        assertEquals("POST", request2.method)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `does not flush if network is not connected`() {
+        val http = createMockHttp()
+        val sut =
+            getSut(
+                http.url("/").toString(),
+                flushAt = 1,
+                networkStatus = PostHogNetworkStatus { false },
+            )
+
+        sut.add(generateEvent())
+        executor.awaitExecution()
+
+        assertEquals(0, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `retries on network error`() {
+        val http = createMockHttp(MockResponse().setResponseCode(500))
+        val sut =
+            getSut(
+                http.url("/").toString(),
+                flushAt = 1,
+                flushIntervalSeconds = 1,
+                retryDelaySeconds = 1,
+            )
+        val event = generateEvent()
+
+        sut.start() // Start the timer for retries
+        sut.add(event)
+        executor.awaitExecution()
+
+        assertEquals(1, http.requestCount)
+
+        // Retry will be allowed after one second.
+        // Flush will occur every second.
+        // We wait a bit more than 2 seconds to ensure both have occurred.
+        Thread.sleep(2100)
+        executor.awaitExecution()
+
+        // Should have made both requests (original + retry)
+        assertEquals(2, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `clears queue`() {
+        val http = createMockHttp()
+        val sut = getSut(http.url("/").toString(), flushAt = 10)
+        val event = generateEvent()
+        sut.add(event)
+        sut.add(event.copy())
+        executor.awaitExecution()
+
+        sut.clear()
+        executor.awaitExecution()
+
+        sut.flush()
+        executor.awaitExecution()
+
+        // No requests should be made after clearing
+        assertEquals(0, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `starts and stops timer`() {
+        val http = createMockHttp()
+        val sut = getSut(http.url("/").toString())
+        sut.start()
+        sut.stop()
+        // If we get here without deadlock, the timer management works
+        assertTrue(true)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+}

--- a/posthog/CHANGELOG.md
+++ b/posthog/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: `PostHogConfig` now accepts queue and remote config constructors ([#287])
+
 ## 3.22.0 - 2025-09-25
 
 - feat: Add a server-side stateless interface([#284](https://github.com/PostHog/posthog-android/pull/284))

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -83,8 +83,8 @@ public class com/posthog/PostHogConfig {
 	public static final field DEFAULT_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_ASSETS_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_HOST Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun getApiKey ()Ljava/lang/String;
@@ -110,7 +110,9 @@ public class com/posthog/PostHogConfig {
 	public final fun getPreloadFeatureFlags ()Z
 	public final fun getPropertiesSanitizer ()Lcom/posthog/PostHogPropertiesSanitizer;
 	public final fun getProxy ()Ljava/net/Proxy;
+	public final fun getQueueProvider ()Lkotlin/jvm/functions/Function5;
 	public final fun getRemoteConfig ()Z
+	public final fun getRemoteConfigProvider ()Lkotlin/jvm/functions/Function3;
 	public final fun getReplayStoragePrefix ()Ljava/lang/String;
 	public final fun getReuseAnonymousId ()Z
 	public final fun getSdkName ()Ljava/lang/String;
@@ -371,6 +373,79 @@ public final class com/posthog/PostHogStatelessInterface$DefaultImpls {
 public abstract interface annotation class com/posthog/PostHogVisibleForTesting : java/lang/annotation/Annotation {
 }
 
+public final class com/posthog/internal/EvaluationReason {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/posthog/internal/EvaluationReason;
+	public static synthetic fun copy$default (Lcom/posthog/internal/EvaluationReason;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/posthog/internal/EvaluationReason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getCondition_index ()Ljava/lang/Integer;
+	public final fun getDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/FeatureFlag {
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Lcom/posthog/internal/FeatureFlagMetadata;Lcom/posthog/internal/EvaluationReason;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/posthog/internal/FeatureFlagMetadata;
+	public final fun component5 ()Lcom/posthog/internal/EvaluationReason;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Lcom/posthog/internal/FeatureFlagMetadata;Lcom/posthog/internal/EvaluationReason;)Lcom/posthog/internal/FeatureFlag;
+	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlag;Ljava/lang/String;ZLjava/lang/String;Lcom/posthog/internal/FeatureFlagMetadata;Lcom/posthog/internal/EvaluationReason;ILjava/lang/Object;)Lcom/posthog/internal/FeatureFlag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getMetadata ()Lcom/posthog/internal/FeatureFlagMetadata;
+	public final fun getReason ()Lcom/posthog/internal/EvaluationReason;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/FeatureFlagMetadata {
+	public fun <init> (ILjava/lang/String;I)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (ILjava/lang/String;I)Lcom/posthog/internal/FeatureFlagMetadata;
+	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlagMetadata;ILjava/lang/String;IILjava/lang/Object;)Lcom/posthog/internal/FeatureFlagMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()I
+	public final fun getPayload ()Ljava/lang/String;
+	public final fun getVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/PostHogApi {
+	public fun <init> (Lcom/posthog/PostHogConfig;)V
+	public final fun batch (Ljava/util/List;)V
+	public final fun flags (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public static synthetic fun flags$default (Lcom/posthog/internal/PostHogApi;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public final fun remoteConfig ()Lcom/posthog/internal/PostHogRemoteConfigResponse;
+	public final fun snapshot (Ljava/util/List;)V
+}
+
+public final class com/posthog/internal/PostHogApiEndpoint : java/lang/Enum {
+	public static final field BATCH Lcom/posthog/internal/PostHogApiEndpoint;
+	public static final field SNAPSHOT Lcom/posthog/internal/PostHogApiEndpoint;
+	public static fun valueOf (Ljava/lang/String;)Lcom/posthog/internal/PostHogApiEndpoint;
+	public static fun values ()[Lcom/posthog/internal/PostHogApiEndpoint;
+}
+
+public final class com/posthog/internal/PostHogApiError : java/lang/RuntimeException {
+	public fun <init> (ILjava/lang/String;Lokhttp3/ResponseBody;)V
+	public final fun getBody ()Lokhttp3/ResponseBody;
+	public fun getMessage ()Ljava/lang/String;
+	public final fun getStatusCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/posthog/internal/PostHogContext {
 	public abstract fun getDynamicContext ()Ljava/util/Map;
 	public abstract fun getSdkInfo ()Ljava/util/Map;
@@ -394,15 +469,37 @@ public final class com/posthog/internal/PostHogDeviceDateProvider : com/posthog/
 
 public abstract interface class com/posthog/internal/PostHogFeatureFlagsInterface {
 	public abstract fun clear ()V
-	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun getFeatureFlags ()Ljava/util/Map;
-	public abstract fun isSessionReplayFlagActive ()Z
-	public abstract fun loadRemoteConfig (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
+	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public abstract fun getFeatureFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
 }
 
 public final class com/posthog/internal/PostHogFeatureFlagsInterface$DefaultImpls {
-	public static synthetic fun loadRemoteConfig$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
+	public static synthetic fun getFeatureFlag$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getFeatureFlagPayload$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getFeatureFlags$default (Lcom/posthog/internal/PostHogFeatureFlagsInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Ljava/util/Map;
+}
+
+public final class com/posthog/internal/PostHogFlagsResponse : com/posthog/internal/PostHogRemoteConfigResponse {
+	public fun <init> (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public static synthetic fun copy$default (Lcom/posthog/internal/PostHogFlagsResponse;ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorsWhileComputingFlags ()Z
+	public final fun getFeatureFlagPayloads ()Ljava/util/Map;
+	public final fun getFeatureFlags ()Ljava/util/Map;
+	public final fun getFlags ()Ljava/util/Map;
+	public final fun getQuotaLimited ()Ljava/util/List;
+	public final fun getRequestId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/posthog/internal/PostHogLogger {
@@ -475,6 +572,33 @@ public abstract interface class com/posthog/internal/PostHogQueueInterface {
 	public abstract fun stop ()V
 }
 
+public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/internal/PostHogFeatureFlagsInterface {
+	public fun <init> (Lcom/posthog/PostHogConfig;Lcom/posthog/internal/PostHogApi;Ljava/util/concurrent/ExecutorService;)V
+	public fun clear ()V
+	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Object;
+	public fun getFeatureFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
+	public final fun getFlagDetails (Ljava/lang/String;)Lcom/posthog/internal/FeatureFlag;
+	public final fun getOnRemoteConfigLoaded ()Lkotlin/jvm/functions/Function0;
+	public final fun getRequestId ()Ljava/lang/String;
+	public final fun getSurveys ()Ljava/util/List;
+	public final fun isSessionReplayFlagActive ()Z
+	public final fun loadFeatureFlags (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
+	public static synthetic fun loadFeatureFlags$default (Lcom/posthog/internal/PostHogRemoteConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
+	public final fun loadRemoteConfig (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
+	public static synthetic fun loadRemoteConfig$default (Lcom/posthog/internal/PostHogRemoteConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
+	public final fun setOnRemoteConfigLoaded (Lkotlin/jvm/functions/Function0;)V
+}
+
+public class com/posthog/internal/PostHogRemoteConfigResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHasFeatureFlags ()Ljava/lang/Boolean;
+	public final fun getSessionRecording ()Ljava/lang/Object;
+	public final fun getSurveys ()Ljava/lang/Object;
+}
+
 public final class com/posthog/internal/PostHogSerializer {
 	public fun <init> (Lcom/posthog/PostHogConfig;)V
 	public final fun deserializeString (Ljava/lang/String;)Ljava/lang/Object;
@@ -497,7 +621,9 @@ public final class com/posthog/internal/PostHogThreadFactory : java/util/concurr
 }
 
 public final class com/posthog/internal/PostHogUtilsKt {
+	public static final fun executeSafely (Ljava/util/concurrent/Executor;Ljava/lang/Runnable;)V
 	public static final fun interruptSafely (Ljava/lang/Thread;)V
+	public static final fun isNetworkingError (Ljava/lang/Throwable;)Z
 }
 
 public abstract interface class com/posthog/internal/replay/PostHogSessionReplayHandler {

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -1,16 +1,23 @@
 package com.posthog
 
+import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogApiEndpoint
 import com.posthog.internal.PostHogContext
 import com.posthog.internal.PostHogDateProvider
 import com.posthog.internal.PostHogDeviceDateProvider
+import com.posthog.internal.PostHogFeatureFlagsInterface
 import com.posthog.internal.PostHogLogger
 import com.posthog.internal.PostHogNetworkStatus
 import com.posthog.internal.PostHogNoOpLogger
 import com.posthog.internal.PostHogPreferences
+import com.posthog.internal.PostHogQueue
+import com.posthog.internal.PostHogQueueInterface
+import com.posthog.internal.PostHogRemoteConfig
 import com.posthog.internal.PostHogSerializer
 import com.posthog.surveys.PostHogSurveysConfig
 import java.net.Proxy
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 
 /**
  * The SDK Config
@@ -167,6 +174,16 @@ public open class PostHogConfig(
      * Configuration for PostHog Surveys feature.
      */
     public var surveysConfig: PostHogSurveysConfig = PostHogSurveysConfig(),
+    /**
+     * Factory to instantiate a custom [com.posthog.internal.PostHogRemoteConfigInterface] implementation.
+     */
+    public val remoteConfigProvider: (PostHogConfig, PostHogApi, ExecutorService) -> PostHogFeatureFlagsInterface =
+        { config, api, executor -> PostHogRemoteConfig(config, api, executor) },
+    /**
+     * Factory to instantiate a custom queue implementation.
+     */
+    public val queueProvider: (PostHogConfig, PostHogApi, PostHogApiEndpoint, String?, ExecutorService) -> PostHogQueueInterface =
+        { config, api, endpoint, storagePrefix, executor -> PostHogQueue(config, api, endpoint, storagePrefix, executor) },
 ) {
     @PostHogInternal
     public var logger: PostHogLogger = PostHogNoOpLogger()

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -411,7 +411,7 @@ public open class PostHogStateless protected constructor(
         if (!isEnabled()) {
             return defaultValue
         }
-        val value = featureFlags?.getFeatureFlag(key, defaultValue) ?: defaultValue
+        val value = featureFlags?.getFeatureFlag(key, defaultValue, distinctId) ?: defaultValue
 
         sendFeatureFlagCalled(distinctId, key, value)
 
@@ -426,7 +426,7 @@ public open class PostHogStateless protected constructor(
         if (!isEnabled()) {
             return defaultValue
         }
-        return featureFlags?.getFeatureFlagPayload(key, defaultValue) ?: defaultValue
+        return featureFlags?.getFeatureFlagPayload(key, defaultValue, distinctId) ?: defaultValue
     }
 
     public override fun flush() {

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -9,9 +9,7 @@ import com.posthog.internal.PostHogPreferences
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPrintLogger
-import com.posthog.internal.PostHogQueue
 import com.posthog.internal.PostHogQueueInterface
-import com.posthog.internal.PostHogRemoteConfig
 import com.posthog.internal.PostHogThreadFactory
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -54,8 +52,15 @@ public open class PostHogStateless protected constructor(
 
                 config.cachePreferences = memoryPreferences
                 val api = PostHogApi(config)
-                val queue = PostHogQueue(config, api, PostHogApiEndpoint.BATCH, config.storagePrefix, queueExecutor)
-                val remoteConfig = PostHogRemoteConfig(config, api, featureFlagsExecutor)
+                val queue =
+                    config.queueProvider(
+                        config,
+                        api,
+                        PostHogApiEndpoint.BATCH,
+                        config.storagePrefix,
+                        queueExecutor,
+                    )
+                val remoteConfig = config.remoteConfigProvider(config, api, featureFlagsExecutor)
 
                 // no need to lock optOut here since the setup is locked already
                 val optOut =

--- a/posthog/src/main/java/com/posthog/internal/EvaluationReason.kt
+++ b/posthog/src/main/java/com/posthog/internal/EvaluationReason.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -9,7 +10,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property condition_index the condition index of the reason
  */
 @IgnoreJRERequirement
-internal data class EvaluationReason(
+@PostHogInternal
+public data class EvaluationReason(
     val code: String?,
     val description: String?,
     val condition_index: Int?,

--- a/posthog/src/main/java/com/posthog/internal/FeatureFlag.kt
+++ b/posthog/src/main/java/com/posthog/internal/FeatureFlag.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -11,7 +12,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property reason the reason the feature flag was evaluated
  */
 @IgnoreJRERequirement
-internal data class FeatureFlag(
+@PostHogInternal
+public data class FeatureFlag(
     val key: String,
     val enabled: Boolean,
     val variant: String?,

--- a/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
+++ b/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -9,7 +10,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property version the version of the feature flag
  */
 @IgnoreJRERequirement
-internal data class FeatureFlagMetadata(
+@PostHogInternal
+public data class FeatureFlagMetadata(
     val id: Int,
     val payload: String?,
     val version: Int,

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -113,12 +113,22 @@ internal class PostHogApi(
     }
 
     @Throws(PostHogApiError::class, IOException::class)
-    fun flags(
+    public fun flags(
         distinctId: String,
-        anonymousId: String?,
-        groups: Map<String, String>?,
+        anonymousId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
     ): PostHogFlagsResponse? {
-        val flagsRequest = PostHogFlagsRequest(config.apiKey, distinctId, anonymousId = anonymousId, groups)
+        val flagsRequest =
+            PostHogFlagsRequest(
+                config.apiKey,
+                distinctId,
+                anonymousId = anonymousId,
+                groups,
+                personProperties,
+                groupProperties,
+            )
 
         val url = "$theHost/flags/?v=2&config=true"
         logRequest(flagsRequest, url)

--- a/posthog/src/main/java/com/posthog/internal/PostHogApiEndpoint.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApiEndpoint.kt
@@ -1,6 +1,9 @@
 package com.posthog.internal
 
-internal enum class PostHogApiEndpoint {
+import com.posthog.PostHogInternal
+
+@PostHogInternal
+public enum class PostHogApiEndpoint {
     BATCH,
     SNAPSHOT,
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogApiError.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApiError.kt
@@ -1,7 +1,7 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import okhttp3.ResponseBody
-import java.lang.RuntimeException
 
 /**
  * The API exception if not within the successful range (2xx - 3xx)
@@ -9,10 +9,11 @@ import java.lang.RuntimeException
  * @property message the exception message
  * @property message the OkHttp response body, the source might be closed already
  */
-internal class PostHogApiError(
-    val statusCode: Int,
+@PostHogInternal
+public class PostHogApiError(
+    public val statusCode: Int,
     override val message: String,
-    val body: ResponseBody?,
+    public val body: ResponseBody?,
 ) : RuntimeException(message) {
     override fun toString(): String {
         return "PostHogApiError(statusCode=$statusCode, message='$message')"

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagsInterface.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagsInterface.kt
@@ -1,29 +1,33 @@
 package com.posthog.internal
 
-import com.posthog.PostHogOnFeatureFlags
+import com.posthog.PostHogInternal
 
+@PostHogInternal
 public interface PostHogFeatureFlagsInterface {
-    public fun loadRemoteConfig(
-        distinctId: String,
-        anonymousId: String?,
-        groups: Map<String, String>?,
-        internalOnFeatureFlags: PostHogOnFeatureFlags? = null,
-        onFeatureFlags: PostHogOnFeatureFlags? = null,
-    )
-
     public fun getFeatureFlag(
         key: String,
         defaultValue: Any?,
+        distinctId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
     ): Any?
 
     public fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,
+        distinctId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
     ): Any?
 
-    public fun getFeatureFlags(): Map<String, Any>?
-
-    public fun isSessionReplayFlagActive(): Boolean
+    public fun getFeatureFlags(
+        distinctId: String? = null,
+        groups: Map<String, String>? = null,
+        personProperties: Map<String, String>? = null,
+        groupProperties: Map<String, String>? = null,
+    ): Map<String, Any>?
 
     public fun clear()
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
@@ -6,9 +6,10 @@ package com.posthog.internal
 internal class PostHogFlagsRequest(
     apiKey: String,
     distinctId: String,
-    anonymousId: String?,
-    groups: Map<String, String>?,
-    // add person_properties, group_properties
+    anonymousId: String? = null,
+    groups: Map<String, String>? = null,
+    personProperties: Map<String, String>? = null,
+    groupProperties: Map<String, String>? = null,
 ) : HashMap<String, Any>() {
     init {
         this["api_key"] = apiKey
@@ -18,6 +19,12 @@ internal class PostHogFlagsRequest(
         }
         if (groups?.isNotEmpty() == true) {
             this["\$groups"] = groups
+        }
+        if (personProperties?.isNotEmpty() == true) {
+            this["\$properties"] = personProperties
+        }
+        if (groupProperties?.isNotEmpty() == true) {
+            this["\$group_properties"] = groupProperties
         }
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFlagsResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFlagsResponse.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 /**
@@ -11,7 +12,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property quotaLimited array of quota limited features
  */
 @IgnoreJRERequirement
-internal data class PostHogFlagsResponse(
+@PostHogInternal
+public data class PostHogFlagsResponse(
     // assuming theres no errors if not present
     val errorsWhileComputingFlags: Boolean = false,
     val featureFlags: Map<String, Any>?,

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -1,6 +1,7 @@
 package com.posthog.internal
 
 import com.posthog.PostHogConfig
+import com.posthog.PostHogInternal
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAGS_PAYLOAD
@@ -18,7 +19,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @property api the API
  * @property executor the Executor
  */
-internal class PostHogRemoteConfig(
+@PostHogInternal
+public class PostHogRemoteConfig(
     private val config: PostHogConfig,
     private val api: PostHogApi,
     private val executor: ExecutorService,
@@ -53,7 +55,7 @@ internal class PostHogRemoteConfig(
      * Use this to notify listeners that cached surveys may have changed.
      */
     @Volatile
-    var onRemoteConfigLoaded: (() -> Unit)? = null
+    public var onRemoteConfigLoaded: (() -> Unit)? = null
 
     init {
         preloadSessionReplayFlag()
@@ -392,7 +394,7 @@ internal class PostHogRemoteConfig(
         }
     }
 
-    fun loadFeatureFlags(
+    public fun loadFeatureFlags(
         distinctId: String,
         anonymousId: String?,
         groups: Map<String, String>?,
@@ -600,14 +602,14 @@ internal class PostHogRemoteConfig(
 
     public fun isSessionReplayFlagActive(): Boolean = sessionReplayFlagActive
 
-    fun getRequestId(): String? {
+    public fun getRequestId(): String? {
         loadFeatureFlagsFromCacheIfNeeded()
         synchronized(featureFlagsLock) {
             return requestId
         }
     }
 
-    fun getFlagDetails(key: String): FeatureFlag? {
+    public fun getFlagDetails(key: String): FeatureFlag? {
         loadFeatureFlagsFromCacheIfNeeded()
 
         synchronized(featureFlagsLock) {
@@ -615,7 +617,7 @@ internal class PostHogRemoteConfig(
         }
     }
 
-    fun getSurveys(): List<Survey>? {
+    public fun getSurveys(): List<Survey>? {
         synchronized(remoteConfigLock) {
             return surveys
         }

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -119,12 +119,12 @@ internal class PostHogRemoteConfig(
         }
     }
 
-    override fun loadRemoteConfig(
+    public fun loadRemoteConfig(
         distinctId: String,
         anonymousId: String?,
         groups: Map<String, String>?,
-        internalOnFeatureFlags: PostHogOnFeatureFlags?,
-        onFeatureFlags: PostHogOnFeatureFlags?,
+        internalOnFeatureFlags: PostHogOnFeatureFlags? = null,
+        onFeatureFlags: PostHogOnFeatureFlags? = null,
     ) {
         executor.executeSafely {
             if (config.networkStatus?.isConnected() == false) {
@@ -560,6 +560,10 @@ internal class PostHogRemoteConfig(
     override fun getFeatureFlag(
         key: String,
         defaultValue: Any?,
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
     ): Any? {
         // since we pass featureFlags as a value, we need to load it from cache if needed
         loadFeatureFlagsFromCacheIfNeeded()
@@ -570,6 +574,10 @@ internal class PostHogRemoteConfig(
     override fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
     ): Any? {
         // since we pass featureFlags as a value, we need to load it from cache if needed
         loadFeatureFlagsFromCacheIfNeeded()
@@ -577,7 +585,12 @@ internal class PostHogRemoteConfig(
         return readFeatureFlag(key, defaultValue, featureFlagPayloads)
     }
 
-    override fun getFeatureFlags(): Map<String, Any>? {
+    override fun getFeatureFlags(
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, String>?,
+        groupProperties: Map<String, String>?,
+    ): Map<String, Any>? {
         val flags: Map<String, Any>?
         synchronized(featureFlagsLock) {
             flags = featureFlags?.toMap()
@@ -585,7 +598,7 @@ internal class PostHogRemoteConfig(
         return flags
     }
 
-    override fun isSessionReplayFlagActive(): Boolean = sessionReplayFlagActive
+    public fun isSessionReplayFlagActive(): Boolean = sessionReplayFlagActive
 
     fun getRequestId(): String? {
         loadFeatureFlagsFromCacheIfNeeded()

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfigResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfigResponse.kt
@@ -1,13 +1,15 @@
 package com.posthog.internal
 
+import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 @IgnoreJRERequirement
-internal open class PostHogRemoteConfigResponse(
+@PostHogInternal
+public open class PostHogRemoteConfigResponse(
     // its either a boolean or a map, see https://github.com/PostHog/posthog-js/blob/10fd7f4fa083f997d31a4a4c7be7d311d0a95e74/src/types.ts#L235-L243
-    val sessionRecording: Any? = false,
+    public val sessionRecording: Any? = false,
     // its either a boolean or a map
-    val surveys: Any? = false,
+    public val surveys: Any? = false,
     // Indicates if the team has any flags enabled (if not we don't need to load them)
-    val hasFeatureFlags: Boolean? = false,
+    public val hasFeatureFlags: Boolean? = false,
 )

--- a/posthog/src/main/java/com/posthog/internal/PostHogUtils.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogUtils.kt
@@ -22,7 +22,8 @@ private fun isConnectionTimeout(throwable: Throwable): Boolean {
     return throwable is SocketTimeoutException
 }
 
-internal fun Throwable.isNetworkingError(): Boolean {
+@PostHogInternal
+public fun Throwable.isNetworkingError(): Boolean {
     return isConnectionTimeout(this) ||
         noInternetAvailable(this) ||
         isRequestCanceled(this)
@@ -45,7 +46,8 @@ internal fun File.existsSafely(config: PostHogConfig): Boolean {
     }
 }
 
-internal fun Executor.executeSafely(run: Runnable) {
+@PostHogInternal
+public fun Executor.executeSafely(run: Runnable) {
     try {
         // can throw RejectedExecutionException
         execute(run)

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -93,19 +93,13 @@ internal class PostHogStatelessTest {
             flags[key] = value
         }
 
-        override fun loadRemoteConfig(
-            distinctId: String,
-            anonymousId: String?,
-            groups: Map<String, String>?,
-            internalOnFeatureFlags: PostHogOnFeatureFlags?,
-            onFeatureFlags: PostHogOnFeatureFlags?,
-        ) {
-            // Mock implementation
-        }
-
         override fun getFeatureFlag(
             key: String,
             defaultValue: Any?,
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, String>?,
+            groupProperties: Map<String, String>?,
         ): Any? {
             return flags[key] ?: defaultValue
         }
@@ -113,16 +107,21 @@ internal class PostHogStatelessTest {
         override fun getFeatureFlagPayload(
             key: String,
             defaultValue: Any?,
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, String>?,
+            groupProperties: Map<String, String>?,
         ): Any? {
             return flags[key] ?: defaultValue
         }
 
-        override fun getFeatureFlags(): Map<String, Any> {
+        override fun getFeatureFlags(
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, String>?,
+            groupProperties: Map<String, String>?,
+        ): Map<String, Any> {
             return flags.toMap()
-        }
-
-        override fun isSessionReplayFlagActive(): Boolean {
-            return false
         }
 
         override fun clear() {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -22,11 +22,15 @@ case "$MODULE" in
   "android")
     perl -pi -e "s/androidVersion=.*/androidVersion=$NEW_VERSION/g" $GRADLE_FILEPATH
     ;;
+  "server")
+    perl -pi -e "s/serverVersion=.*/serverVersion=$NEW_VERSION/g" $GRADLE_FILEPATH
+    ;;
   *)
-    echo "Usage: $0 {core|android} <version>"
+    echo "Usage: $0 {core|android|server} <version>"
     echo "Examples:"
     echo "  $0 core 3.0.1"
     echo "  $0 android 3.0.2"
+    echo "  $0 server 1.0.1"
     exit 1
     ;;
 esac

--- a/scripts/create-tag.sh
+++ b/scripts/create-tag.sh
@@ -16,8 +16,11 @@ case "$MODULE" in
   "android")
     TAG_NAME="android-v$NEW_VERSION"
     ;;
+  "server")
+    TAG_NAME="server-v$NEW_VERSION"
+    ;;
   *)
-    echo "Usage: $0 {core|android} <version>"
+    echo "Usage: $0 {core|android|server} <version>"
     exit 1
     ;;
 esac

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ include(":posthog-server")
 
 // samples
 include(":posthog-samples:posthog-android-sample")
+include(":posthog-samples:posthog-java-sample")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ rootProject.name = "PostHog"
 
 include(":posthog")
 include(":posthog-android")
+include(":posthog-server")
 
 // samples
 include(":posthog-samples:posthog-android-sample")


### PR DESCRIPTION
## :bulb: Motivation and Context

This PR adds an initial release of `posthog-server`, the stateless server-side SDK for Kotlin and Java applications.

This initial release features:
- The core event API (capture/identify/alias/group)
- Initial support for stateless feature flags (isFeatureEnabled/getFeatureFlag/getFeatureFlagPayload)
- All API methods require a distinct ID to identify the user in question
- Feature flag requests are cached in a configurable LRU cache with record expiry. Default configuration allows for 1000 cached requests which have a max TTL of five minutes before becoming stale.
- A sample project for Java 8

**Reviewers**: This is naturally going to be a pretty chunky PR. I'd recommend checking out the sample project and the USAGE.md. Small bugs can fixed and behavior can be improved post-release, but I'd like to avoid having to follow up with breaking changes to the core interface.

Related to https://github.com/PostHog/posthog/issues/16419

## :green_heart: How did you test it?

It has pretty extensive unit testing. There's a separate Java sample project that uses the API.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
