### PR TITLE
fix(core): Deduplicate `$feature_flag_called` events

### DIFF
--- a/posthog-server/CHANGELOG.md
+++ b/posthog-server/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Next
 
+- fix: Support deduplication of `$feature_flag_called` events ([#291](https://github.com/PostHog/posthog-android/pull/291))
 - fix: Adds missing `featureFlagCacheSize`, `featureFlagCacheMaxAgeMs` mutators to `PostHogConfig` builder ([#291](https://github.com/PostHog/posthog-android/pull/291))
 
 ## 1.0.0

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -68,6 +68,7 @@ public class com/posthog/server/PostHogConfig {
 	public static final field DEFAULT_EU_HOST Ljava/lang/String;
 	public static final field DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS I
 	public static final field DEFAULT_FEATURE_FLAG_CACHE_SIZE I
+	public static final field DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE I
 	public static final field DEFAULT_FLUSH_AT I
 	public static final field DEFAULT_FLUSH_INTERVAL_SECONDS I
 	public static final field DEFAULT_HOST Ljava/lang/String;
@@ -75,8 +76,8 @@ public class com/posthog/server/PostHogConfig {
 	public static final field DEFAULT_MAX_QUEUE_SIZE I
 	public static final field DEFAULT_US_ASSETS_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_HOST Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Ljava/net/Proxy;II)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Ljava/net/Proxy;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Ljava/net/Proxy;III)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;Ljava/net/Proxy;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
 	public static final fun builder (Ljava/lang/String;)Lcom/posthog/server/PostHogConfig$Builder;
@@ -85,6 +86,7 @@ public class com/posthog/server/PostHogConfig {
 	public final fun getEncryption ()Lcom/posthog/PostHogEncryption;
 	public final fun getFeatureFlagCacheMaxAgeMs ()I
 	public final fun getFeatureFlagCacheSize ()I
+	public final fun getFeatureFlagCalledCacheSize ()I
 	public final fun getFlushAt ()I
 	public final fun getFlushIntervalSeconds ()I
 	public final fun getHost ()Ljava/lang/String;
@@ -100,6 +102,7 @@ public class com/posthog/server/PostHogConfig {
 	public final fun setEncryption (Lcom/posthog/PostHogEncryption;)V
 	public final fun setFeatureFlagCacheMaxAgeMs (I)V
 	public final fun setFeatureFlagCacheSize (I)V
+	public final fun setFeatureFlagCalledCacheSize (I)V
 	public final fun setFlushAt (I)V
 	public final fun setFlushIntervalSeconds (I)V
 	public final fun setMaxBatchSize (I)V
@@ -118,6 +121,7 @@ public final class com/posthog/server/PostHogConfig$Builder {
 	public final fun encryption (Lcom/posthog/PostHogEncryption;)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun featureFlagCacheMaxAgeMs (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun featureFlagCacheSize (I)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun featureFlagCalledCacheSize (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun flushAt (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun flushIntervalSeconds (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun host (Ljava/lang/String;)Lcom/posthog/server/PostHogConfig$Builder;

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -97,6 +97,13 @@ public open class PostHogConfig constructor(
      */
     @PostHogExperimental
     public var featureFlagCacheMaxAgeMs: Int = DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS,
+    /**
+     * The maximum size of the feature flag called cache in memory. This cache prevents
+     * duplicate $feature_flag_called events from being sent by keeping track of per-user
+     * feature flag usage.
+     * Defaults to 1000
+     */
+    public var featureFlagCalledCacheSize: Int = DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE,
 ) {
     private val beforeSendCallbacks = mutableListOf<PostHogBeforeSend>()
     private val integrations = mutableListOf<PostHogIntegration>()
@@ -166,6 +173,7 @@ public open class PostHogConfig constructor(
         public const val DEFAULT_FLUSH_INTERVAL_SECONDS: Int = 30
         public const val DEFAULT_FEATURE_FLAG_CACHE_SIZE: Int = 1000
         public const val DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS: Int = 5 * 60 * 1000 // 5 minutes
+        public const val DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE: Int = 1000
 
         @JvmStatic
         public fun builder(apiKey: String): Builder = Builder(apiKey)
@@ -186,6 +194,7 @@ public open class PostHogConfig constructor(
         private var proxy: Proxy? = null
         private var featureFlagCacheSize: Int = DEFAULT_FEATURE_FLAG_CACHE_SIZE
         private var featureFlagCacheMaxAgeMs: Int = DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS
+        private var featureFlagCalledCacheSize: Int = DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE
 
         public fun host(host: String): Builder = apply { this.host = host }
 
@@ -216,6 +225,9 @@ public open class PostHogConfig constructor(
         public fun featureFlagCacheMaxAgeMs(featureFlagCacheMaxAgeMs: Int): Builder =
             apply { this.featureFlagCacheMaxAgeMs = featureFlagCacheMaxAgeMs }
 
+        public fun featureFlagCalledCacheSize(featureFlagCalledCacheSize: Int): Builder =
+            apply { this.featureFlagCalledCacheSize = featureFlagCalledCacheSize }
+
         public fun build(): PostHogConfig =
             PostHogConfig(
                 apiKey = apiKey,
@@ -233,6 +245,7 @@ public open class PostHogConfig constructor(
                 proxy = proxy,
                 featureFlagCacheSize = featureFlagCacheSize,
                 featureFlagCacheMaxAgeMs = featureFlagCacheMaxAgeMs,
+                featureFlagCalledCacheSize = featureFlagCalledCacheSize,
             )
     }
 }

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -366,6 +366,7 @@ internal class PostHogConfigTest {
                 .proxy(Proxy.NO_PROXY)
                 .featureFlagCacheSize(10)
                 .featureFlagCacheMaxAgeMs(20)
+                .featureFlagCalledCacheSize(30)
                 .build()
 
         assertEquals(TEST_API_KEY, config.apiKey)
@@ -383,6 +384,7 @@ internal class PostHogConfigTest {
         assertEquals(Proxy.NO_PROXY, config.proxy)
         assertEquals(10, config.featureFlagCacheSize)
         assertEquals(20, config.featureFlagCacheMaxAgeMs)
+        assertEquals(30, config.featureFlagCalledCacheSize)
     }
 
     @Test

--- a/posthog/CHANGELOG.md
+++ b/posthog/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: `PostHogStateless` now deduplicates `$feature_flag_called` events ([#293](https://github.com/PostHog/posthog-android/pull/293)))
+
 ## 3.23.0 - 2025-09-29
 
 - feat: `PostHogConfig` now accepts queue and remote config constructors ([#287](https://github.com/PostHog/posthog-android/pull/287))

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -80,11 +80,12 @@ public class com/posthog/PostHogConfig {
 	public static final field Companion Lcom/posthog/PostHogConfig$Companion;
 	public static final field DEFAULT_EU_ASSETS_HOST Ljava/lang/String;
 	public static final field DEFAULT_EU_HOST Ljava/lang/String;
+	public static final field DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE I
 	public static final field DEFAULT_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_ASSETS_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_HOST Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZZIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun getApiKey ()Ljava/lang/String;
@@ -94,6 +95,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getDateProvider ()Lcom/posthog/internal/PostHogDateProvider;
 	public final fun getDebug ()Z
 	public final fun getEncryption ()Lcom/posthog/PostHogEncryption;
+	public final fun getFeatureFlagCalledCacheSize ()I
 	public final fun getFlushAt ()I
 	public final fun getFlushIntervalSeconds ()I
 	public final fun getGetAnonymousId ()Lkotlin/jvm/functions/Function1;
@@ -131,6 +133,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setDateProvider (Lcom/posthog/internal/PostHogDateProvider;)V
 	public final fun setDebug (Z)V
 	public final fun setEncryption (Lcom/posthog/PostHogEncryption;)V
+	public final fun setFeatureFlagCalledCacheSize (I)V
 	public final fun setFlushAt (I)V
 	public final fun setFlushIntervalSeconds (I)V
 	public final fun setGetAnonymousId (Lkotlin/jvm/functions/Function1;)V

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -54,6 +54,12 @@ public open class PostHogConfig(
      */
     public var sendFeatureFlagEvent: Boolean = true,
     /**
+     * Maximum number of distinct feature flag calls to cache for deduplication
+     * When the cache is full, the least recently used entries are evicted
+     * Defaults to 1000
+     */
+    public var featureFlagCalledCacheSize: Int = DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE,
+    /**
      * Preload feature flags automatically
      * Docs https://posthog.com/docs/feature-flags and https://posthog.com/docs/experiments
      * Defaults to true
@@ -311,5 +317,7 @@ public open class PostHogConfig(
 
         public const val DEFAULT_EU_HOST: String = "https://eu.i.posthog.com"
         public const val DEFAULT_EU_ASSETS_HOST: String = "https://eu-assets.i.posthog.com"
+
+        public const val DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE: Int = 1000
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
@@ -1,0 +1,130 @@
+package com.posthog.internal
+
+/**
+ * LRU cache for tracking which feature flag values have been seen
+ * to deduplicate $feature_flag_called events
+ */
+internal class PostHogFeatureFlagCalledCache(
+    private val maxSize: Int,
+) {
+    // LinkedHashMap isn't supported in Android API 21. We use a linked list instead
+    // to maintain the order of access for LRU eviction
+    private class Node(
+        val key: FeatureFlagCalledKey,
+        var prev: Node? = null,
+        var next: Node? = null,
+    )
+
+    private val cache = HashMap<FeatureFlagCalledKey, Node>()
+    private var head: Node? = null // Most recently used
+    private var tail: Node? = null // Least recently used
+
+    /**
+     * Atomically check if this combination has been seen before, and if not, mark it as seen.
+     * Returns true if this is the first time seeing this combination (was added), false if already seen.
+     */
+    @Synchronized
+    fun add(
+        distinctId: String,
+        flagKey: String,
+        value: Any?,
+    ): Boolean {
+        val key = FeatureFlagCalledKey(distinctId, flagKey, value)
+
+        val existingNode = cache.get(key)
+        if (existingNode != null) {
+            // Mark as most recent
+            moveToHead(existingNode)
+            return false
+        }
+
+        val newNode = Node(key)
+        cache.put(key, newNode)
+        addToHead(newNode)
+
+        // When over max size, evict some percentage of the oldest entries
+        if (cache.size > maxSize) {
+            val evictionCount = (maxSize * BATCH_EVICTION_FACTOR).toInt().coerceAtLeast(1)
+            repeat(evictionCount) {
+                removeTail()
+            }
+        }
+
+        return true
+    }
+
+    private fun addToHead(node: Node) {
+        node.next = head
+        node.prev = null
+        head?.prev = node
+        head = node
+        if (tail == null) {
+            tail = node
+        }
+    }
+
+    private fun removeNode(node: Node) {
+        val prev = node.prev
+        val next = node.next
+
+        if (prev != null) {
+            prev.next = next
+        } else {
+            head = next
+        }
+
+        if (next != null) {
+            next.prev = prev
+        } else {
+            tail = prev
+        }
+    }
+
+    private fun moveToHead(node: Node) {
+        if (node == head) return
+        removeNode(node)
+        addToHead(node)
+    }
+
+    private fun removeTail() {
+        val tailNode = tail ?: return
+        cache.remove(tailNode.key)
+        val prev = tailNode.prev
+        if (prev != null) {
+            prev.next = null
+            tail = prev
+        } else {
+            head = null
+            tail = null
+        }
+    }
+
+    /**
+     * Clear all cached entries
+     */
+    @Synchronized
+    fun clear() {
+        cache.clear()
+        head = null
+        tail = null
+    }
+
+    /**
+     * Get current cache size
+     */
+    @Synchronized
+    fun size(): Int = cache.size
+
+    private companion object {
+        const val BATCH_EVICTION_FACTOR = 0.2
+    }
+}
+
+/**
+ * Cache key combining distinct ID, flag key, and value
+ */
+internal data class FeatureFlagCalledKey(
+    val distinctId: String,
+    val flagKey: String,
+    val value: Any?,
+)

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagCalledCacheTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagCalledCacheTest.kt
@@ -1,0 +1,284 @@
+package com.posthog.internal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class PostHogFeatureFlagCalledCacheTest {
+    @Test
+    fun `add returns true for new entries`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user123", "flag1", "value1"))
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `add returns false for existing entries`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user123", "flag1", "value1"))
+        assertFalse(cache.add("user123", "flag1", "value1"))
+        assertFalse(cache.add("user123", "flag1", "value1"))
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `different users with same flag are tracked separately`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertTrue(cache.add("user2", "flag1", "value1"))
+
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `different flags for same user are tracked separately`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertTrue(cache.add("user1", "flag2", "value1"))
+
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `different values for same user and flag are tracked separately`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertTrue(cache.add("user1", "flag1", "value2"))
+
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `null values are handled correctly`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", null))
+        assertTrue(cache.add("user1", "flag1", "value1"))
+
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `add respects max size`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 3)
+
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertTrue(cache.add("user2", "flag1", "value1"))
+        assertTrue(cache.add("user3", "flag1", "value1"))
+
+        assertEquals(3, cache.size())
+
+        // Adding 4th entry should evict the oldest
+        assertTrue(cache.add("user4", "flag1", "value1"))
+
+        assertEquals(3, cache.size())
+    }
+
+    @Test
+    fun `LRU eviction removes oldest entry`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 3)
+
+        cache.add("user1", "flag1", "value1")
+        cache.add("user2", "flag1", "value1")
+        cache.add("user3", "flag1", "value1")
+
+        // user1 is the oldest, should be evicted when user4 is added
+        cache.add("user4", "flag1", "value1")
+
+        // user1 should now be evicted, so add should return true
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertEquals(3, cache.size())
+    }
+
+    @Test
+    fun `add updates access order for existing entries`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 3)
+
+        cache.add("user1", "flag1", "value1")
+        cache.add("user2", "flag1", "value1")
+        cache.add("user3", "flag1", "value1")
+
+        // Try to re-add user1 - should return false but update position to most recent
+        assertFalse(cache.add("user1", "flag1", "value1"))
+
+        // Add user4, user2 should be evicted (it's now the oldest, since user1 was moved to end)
+        cache.add("user4", "flag1", "value1")
+
+        // user2 was evicted, so trying to add it again should return true
+        assertTrue(cache.add("user2", "flag1", "value1"))
+
+        // user1 should still be in cache (it was refreshed)
+        assertFalse(cache.add("user1", "flag1", "value1"))
+
+        assertEquals(3, cache.size())
+    }
+
+    @Test
+    fun `clear removes all entries`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        cache.add("user1", "flag1", "value1")
+        cache.add("user2", "flag1", "value1")
+        cache.add("user3", "flag1", "value1")
+
+        assertEquals(3, cache.size())
+
+        cache.clear()
+
+        assertEquals(0, cache.size())
+        // After clear, all entries should be new again
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertTrue(cache.add("user2", "flag1", "value1"))
+        assertTrue(cache.add("user3", "flag1", "value1"))
+    }
+
+    @Test
+    fun `size returns correct count`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertEquals(0, cache.size())
+
+        cache.add("user1", "flag1", "value1")
+        assertEquals(1, cache.size())
+
+        cache.add("user2", "flag1", "value1")
+        assertEquals(2, cache.size())
+
+        cache.add("user3", "flag1", "value1")
+        assertEquals(3, cache.size())
+    }
+
+    @Test
+    fun `cache handles complex scenario with multiple users and flags`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 5)
+
+        cache.add("user1", "flag1", "variant_a")
+        cache.add("user1", "flag2", "variant_b")
+        cache.add("user2", "flag1", "variant_a")
+        cache.add("user2", "flag2", "variant_c")
+        cache.add("user3", "flag1", null)
+
+        assertEquals(5, cache.size())
+
+        // Add 6th entry, should evict oldest (user1, flag1, variant_a)
+        cache.add("user3", "flag2", "variant_d")
+
+        // user1/flag1/variant_a was evicted, so it should be new again
+        assertTrue(cache.add("user1", "flag1", "variant_a"))
+        assertEquals(5, cache.size())
+    }
+
+    @Test
+    fun `cache with size 1 works correctly`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 1)
+
+        cache.add("user1", "flag1", "value1")
+        assertFalse(cache.add("user1", "flag1", "value1"))
+
+        cache.add("user2", "flag1", "value1")
+        // user1 was evicted, so it's new again
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        // user2 was evicted by user1
+        assertTrue(cache.add("user2", "flag1", "value1"))
+    }
+
+    @Test
+    fun `add is atomic for check and add`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        // First call should return true (not seen before)
+        val firstResult = cache.add("user123", "flag1", "value1")
+        assertTrue(firstResult)
+
+        // Second call should return false (already seen)
+        val secondResult = cache.add("user123", "flag1", "value1")
+        assertFalse(secondResult)
+
+        // Should only have one entry
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `batch eviction removes 20 percent when exceeding max size`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        // Fill cache to max capacity
+        for (i in 1..10) {
+            cache.add("user$i", "flag1", "value1")
+        }
+        assertEquals(10, cache.size())
+
+        // Adding 11th entry should trigger batch eviction of 20% (2 entries)
+        cache.add("user11", "flag1", "value1")
+
+        // Size should be: 10 - 2 (evicted) + 1 (new) = 9
+        assertEquals(9, cache.size())
+
+        // The two oldest entries (user1, user2) should have been evicted
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertEquals(10, cache.size())
+
+        // user3 should still be in cache, accessing it moves it to the end
+        assertFalse(cache.add("user3", "flag1", "value1"))
+
+        // Now adding user2 should trigger another batch eviction
+        // This will evict user4 and user5 (the new oldest after user3 was moved to end)
+        assertTrue(cache.add("user2", "flag1", "value1"))
+        assertEquals(9, cache.size())
+
+        // user3 should still be in cache (was moved to end, so not evicted)
+        assertFalse(cache.add("user3", "flag1", "value1"))
+
+        // user4 and user5 should have been evicted
+        assertTrue(cache.add("user4", "flag1", "value1"))
+        assertTrue(cache.add("user5", "flag1", "value1"))
+    }
+
+    @Test
+    fun `batch eviction evicts at least one entry for small caches`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 3)
+
+        // Fill to capacity
+        cache.add("user1", "flag1", "value1")
+        cache.add("user2", "flag1", "value1")
+        cache.add("user3", "flag1", "value1")
+        assertEquals(3, cache.size())
+
+        // 20% of 3 is 0.6, rounds down to 0, but should evict at least 1
+        cache.add("user4", "flag1", "value1")
+
+        // Size should be: 3 - 1 (evicted) + 1 (new) = 3
+        assertEquals(3, cache.size())
+
+        // user1 should have been evicted
+        assertTrue(cache.add("user1", "flag1", "value1"))
+    }
+
+    @Test
+    fun `batch eviction allows cache to grow beyond max before next eviction`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        // Fill to capacity
+        for (i in 1..10) {
+            cache.add("user$i", "flag1", "value1")
+        }
+
+        // Trigger first batch eviction by adding 11th entry
+        cache.add("user11", "flag1", "value1")
+        assertEquals(9, cache.size()) // 10 - 2 + 1
+
+        // Can now add one more entry without triggering eviction
+        cache.add("user12", "flag1", "value1")
+        assertEquals(10, cache.size())
+
+        // Adding another should trigger next batch eviction
+        cache.add("user13", "flag1", "value1")
+        assertEquals(9, cache.size()) // 10 - 2 + 1
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

From documentation:

> *Note:* Tracking whether it's a new user or if a flag value has changed happens in a local cache. This means that if you reinitialize the PostHog client, the cache resets as well – causing `$feature_flag_called` events to be sent again when calling `getFeatureFlag` or `isFeatureEnabled`. PostHog is built to handle this, and so duplicate `$feature_flag_called` events won't affect your analytics.

This appears not to have been true of the `PostHogStateless` client. This PR fixes that.

## :green_heart: How did you test it?

Additional unit tests. Some unrelated [Android tests are failing](https://github.com/PostHog/posthog-android/issues/292) and I'll be looking into that shortly in another PR.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
