### PR TITLE
fix(server): Cache feature flag responses in constant time

### DIFF
--- a/posthog-server/CHANGELOG.md
+++ b/posthog-server/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## Next
 
+- fix: Caching of feature flags occurs in constant time ([#294](https://github.com/PostHog/posthog-android/pull/294))
+
 ## 1.0.1 - 2025-09-30
 
 - fix: Support deduplication of `$feature_flag_called` events ([#291](https://github.com/PostHog/posthog-android/pull/291))
 - fix: Adds missing `featureFlagCacheSize`, `featureFlagCacheMaxAgeMs` mutators to `PostHogConfig` builder ([#291](https://github.com/PostHog/posthog-android/pull/291))
 
-## 1.0.0 - 2025-09-30
+## 1.0.0 - 2025-09-29
 
 - Initial release ([#288](https://github.com/PostHog/posthog-android/pull/288))

--- a/posthog-server/build.gradle.kts
+++ b/posthog-server/build.gradle.kts
@@ -93,12 +93,6 @@ dependencies {
 
     // compatibility
     signature("org.codehaus.mojo.signature:java18:${PosthogBuildConfig.Plugins.SIGNATURE_JAVA18}@signature")
-    signature(
-        "net.sf.androidscents.signature:android-api-level-${PosthogBuildConfig.Android.MIN_SDK}:${PosthogBuildConfig.Plugins.ANIMAL_SNIFFER_SDK_VERSION}@signature",
-    )
-    signature(
-        "com.toasttab.android:gummy-bears-api-${PosthogBuildConfig.Android.MIN_SDK}:${PosthogBuildConfig.Plugins.GUMMY_BEARS_API}@signature",
-    )
 
     // tests
     testImplementation("org.mockito.kotlin:mockito-kotlin:${PosthogBuildConfig.Dependencies.MOCKITO}")

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagCacheTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagCacheTest.kt
@@ -174,21 +174,21 @@ internal class PostHogFeatureFlagCacheTest {
     }
 
     @Test
-    fun `cleanup removes multiple expired entries`() {
+    fun `getting an expired entry removes it`() {
         val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 1) // 1ms TTL
         val flags = createTestFlags()
 
-        // Add multiple entries
-        cache.put(createTestKey("user1"), flags)
-        cache.put(createTestKey("user2"), flags)
-        cache.put(createTestKey("user3"), flags)
+        for (i in 1..3) {
+            cache.put(createTestKey("user$i"), flags)
+        }
         assertEquals(3, cache.size())
 
         // Wait for expiration
         Thread.sleep(10)
 
-        // Accessing any key should trigger cleanup of all expired entries
-        cache.get(createTestKey("user1"))
+        for (i in 1..3) {
+            assertEquals(null, cache.get(createTestKey("user$i")))
+        }
         assertEquals(0, cache.size())
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Flag caching was needlessly performing linear time operations when it could have been constant.

## :green_heart: How did you test it?

Existing tests are passing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
