### PR TITLE
chore: Modules define their own POM properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,10 +17,6 @@ plugins {
     // TODO: add jacoco/codecov, gradle-versions-plugin
 }
 
-allprojects {
-    version = properties[PostHogPublishConfig.versionNameProperty].toString()
-}
-
 subprojects {
     apply(plugin = "org.jetbrains.dokka")
 }

--- a/buildSrc/src/main/java/PostHogPublishConfig.kt
+++ b/buildSrc/src/main/java/PostHogPublishConfig.kt
@@ -42,9 +42,9 @@ fun Project.publishingAndroidConfig() {
             publications.create("release", MavenPublication::class.java) {
                 from(components.getByName("release"))
 
-                postHogConfig(projectName, properties)
+                postHogConfig(projectName, version.toString())
 
-                pom.postHogConfig(projectName)
+                pom.postHogConfig(projectName, moduleDescription = "Official PostHog SDK for Android applications")
             }
         }
 
@@ -67,9 +67,10 @@ fun Project.javadocConfig() {
 fun MavenPom.postHogConfig(
     projectName: String,
     repo: String = "posthog-android",
+    moduleDescription: String,
 ) {
     name.set(projectName)
-    description.set("SDK for posthog.com")
+    description.set(moduleDescription)
     url.set("https://github.com/postHog/$repo")
 
     licenses {
@@ -100,19 +101,11 @@ fun MavenPom.postHogConfig(
 
 fun MavenPublication.postHogConfig(
     projectName: String,
-    properties: Map<String, Any?>,
+    version: String,
 ) {
     groupId = "com.posthog"
     artifactId = projectName
-    version =
-        when (projectName) {
-            "posthog" -> properties["coreVersion"].toString()
-            "posthog-android" -> properties["androidVersion"].toString()
-            "posthog-server" -> properties["serverVersion"].toString()
-            else -> throw IllegalArgumentException(
-                "Unknown project name '$projectName'. Please add version mapping in PostHogPublishConfig.kt",
-            )
-        }
+    this.version = version
 }
 
 fun SigningExtension.postHogConfig(

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -2,6 +2,8 @@
 
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
+version = properties["androidVersion"].toString()
+
 plugins {
     id("com.android.library")
     kotlin("android")

--- a/posthog-server/build.gradle.kts
+++ b/posthog-server/build.gradle.kts
@@ -3,6 +3,8 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+version = properties["serverVersion"].toString()
+
 plugins {
     `java-library`
     kotlin("jvm")
@@ -52,9 +54,11 @@ publishing {
             artifact(dokkaJavadocJar)
             artifact(dokkaHtmlJar)
 
-            postHogConfig(project.name, properties)
-
-            pom.postHogConfig(project.name)
+            postHogConfig(project.name, project.version.toString())
+            pom.postHogConfig(
+                project.name,
+                moduleDescription = "Official PostHog SDK for server-side JVM applications",
+            )
         }
     }
     signing.postHogConfig("maven", this)

--- a/posthog/build.gradle.kts
+++ b/posthog/build.gradle.kts
@@ -3,6 +3,8 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+version = properties["coreVersion"].toString()
+
 plugins {
     `java-library`
     kotlin("jvm")
@@ -52,9 +54,12 @@ publishing {
             artifact(dokkaJavadocJar)
             artifact(dokkaHtmlJar)
 
-            postHogConfig(project.name, properties)
+            postHogConfig(project.name, project.version.toString())
 
-            pom.postHogConfig(project.name)
+            pom.postHogConfig(
+                project.name,
+                moduleDescription = "Core library for PostHog SDKs",
+            )
         }
     }
     signing.postHogConfig("maven", this)


### PR DESCRIPTION
#skip-changelog

## :bulb: Motivation and Context
All modules currently share a single description, "SDK for posthog.com". This is visible from Maven Central.

Instead of centralizing version or having a single description per module, each module is now responsible for setting their own version (still managed centrally via gradle.properties) and POM description.

## :green_heart: How did you test it?

Viewing the POMs generated via:
```sh
./gradlew :posthog:generatePomFileForMavenPublication
./gradlew :posthog-android:generatePomFileForReleasePublication
./gradlew :posthog-server:generatePomFileForMavenPublication
```

We now have:
  | Module          | Version | Description                                           |
  |-----------------|---------|-------------------------------------------------------|
  | posthog         | 3.23.1  | Core library for PostHog SDKs                         |
  | posthog-android | 3.22.0  | Official PostHog SDK for Android applications         |
  | posthog-server  | 1.0.2   | Official PostHog SDK for server-side JVM applications |
  
## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
