### PR TITLE
fix(server): Correctly identify the SDK User-Agent

### DIFF
--- a/posthog-server/CHANGELOG.md
+++ b/posthog-server/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- fix: Events now record SDK info such as `$lib` and `$lib_version` ([#296](https://github.com/PostHog/posthog-android/pull/296))
+- fix: SDK requests now assign the expected User-Agent ([#296](https://github.com/PostHog/posthog-android/pull/296))
+
 ## 1.0.2 - 2025-09-30
 
 - fix: Caching of feature flags occurs in constant time ([#294](https://github.com/PostHog/posthog-android/pull/294))

--- a/posthog-server/build.gradle.kts
+++ b/posthog-server/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 buildConfig {
     useKotlinOutput()
     packageName("com.posthog")
+    buildConfigField("String", "SDK_NAME", "\"posthog-server\"")
     buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
 }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -1,5 +1,6 @@
 package com.posthog.server
 
+import com.posthog.BuildConfig
 import com.posthog.PostHogBeforeSend
 import com.posthog.PostHogEncryption
 import com.posthog.PostHogExperimental
@@ -153,6 +154,10 @@ public open class PostHogConfig constructor(
         // Apply stored callbacks and integrations
         beforeSendCallbacks.forEach { coreConfig.addBeforeSend(it) }
         integrations.forEach { coreConfig.addIntegration(it) }
+
+        // Set SDK identification
+        coreConfig.sdkName = BuildConfig.SDK_NAME
+        coreConfig.sdkVersion = BuildConfig.VERSION_NAME
 
         return coreConfig
     }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -8,6 +8,7 @@ import com.posthog.PostHogIntegration
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.server.internal.PostHogFeatureFlags
 import com.posthog.server.internal.PostHogMemoryQueue
+import com.posthog.server.internal.PostHogServerContext
 import java.net.Proxy
 
 /**
@@ -158,6 +159,7 @@ public open class PostHogConfig constructor(
         // Set SDK identification
         coreConfig.sdkName = BuildConfig.SDK_NAME
         coreConfig.sdkVersion = BuildConfig.VERSION_NAME
+        coreConfig.context = PostHogServerContext(coreConfig)
 
         return coreConfig
     }

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogServerContext.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogServerContext.kt
@@ -1,0 +1,19 @@
+package com.posthog.server.internal
+
+import com.posthog.internal.PostHogContext
+
+/**
+ * PostHog context implementation for server-side SDK
+ * Provides SDK identification in event properties
+ */
+internal class PostHogServerContext(private val config: com.posthog.PostHogConfig) : PostHogContext {
+    override fun getStaticContext(): Map<String, Any> = emptyMap()
+
+    override fun getDynamicContext(): Map<String, Any> = emptyMap()
+
+    override fun getSdkInfo(): Map<String, Any> =
+        mapOf(
+            "\$lib" to config.sdkName,
+            "\$lib_version" to config.sdkVersion,
+        )
+}

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogServerContextTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogServerContextTest.kt
@@ -1,0 +1,41 @@
+package com.posthog.server.internal
+
+import com.posthog.PostHogConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class PostHogServerContextTest {
+    @Test
+    fun `returns SDK info with lib and lib_version`() {
+        val config = PostHogConfig("test-api-key")
+        config.sdkName = "posthog-server"
+        config.sdkVersion = "1.0.2"
+
+        val context = PostHogServerContext(config)
+        val sdkInfo = context.getSdkInfo()
+
+        assertEquals("posthog-server", sdkInfo["\$lib"])
+        assertEquals("1.0.2", sdkInfo["\$lib_version"])
+    }
+
+    @Test
+    fun `returns empty static context`() {
+        val config = PostHogConfig("test-api-key")
+        val context = PostHogServerContext(config)
+
+        val staticContext = context.getStaticContext()
+
+        assertTrue(staticContext.isEmpty())
+    }
+
+    @Test
+    fun `returns empty dynamic context`() {
+        val config = PostHogConfig("test-api-key")
+        val context = PostHogServerContext(config)
+
+        val dynamicContext = context.getDynamicContext()
+
+        assertTrue(dynamicContext.isEmpty())
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

SDK info such as `$lib` and `$lib_version` was not being set in event properties. Similarly, the user agent used for API requests reflected the core library instead.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
