### PR TITLE
feat: Allow stateless override of event timestamp

### DIFF
--- a/posthog-server/CHANGELOG.md
+++ b/posthog-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: `timestamp` can now be overridden when capturing an event ([#297](https://github.com/PostHog/posthog-android/issues/297))
+
 ## 1.0.3 - 2025-10-01
 
 - fix: Events now record SDK info such as `$lib` and `$lib_version` ([#296](https://github.com/PostHog/posthog-android/pull/296))

--- a/posthog-server/USAGE.md
+++ b/posthog-server/USAGE.md
@@ -147,6 +147,31 @@ postHog.capture(
 );
 ```
 
+#### Overriding event timestamps
+
+If you need to change the timestamp on an event, you can do so by using the `timestamp` builder method on `PostHogCaptureOptions`.
+
+```java
+postHog.capture(
+    "distinct-id",
+    "past-event",
+    PostHogCaptureOptions
+        .builder()
+        .timestamp(customTime)
+        .build()
+);
+```
+
+Or, directly via named property in Kotlin:
+
+```kotlin
+postHog.capture(
+    distinctId = "distinct-id",
+    event = "past-event",
+    timestamp = customTime
+)
+```
+
 ## User Identification
 
 #### Kotlin

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -4,7 +4,7 @@ public final class com/posthog/server/PostHog : com/posthog/server/PostHogInterf
 	public fun alias (Ljava/lang/String;Ljava/lang/String;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
-	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public fun close ()V
 	public fun debug (Z)V
 	public fun flush ()V
@@ -29,10 +29,11 @@ public final class com/posthog/server/PostHog$Companion {
 
 public final class com/posthog/server/PostHogCaptureOptions {
 	public static final field Companion Lcom/posthog/server/PostHogCaptureOptions$Companion;
-	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun builder ()Lcom/posthog/server/PostHogCaptureOptions$Builder;
 	public final fun getGroups ()Ljava/util/Map;
 	public final fun getProperties ()Ljava/util/Map;
+	public final fun getTimestamp ()Ljava/util/Date;
 	public final fun getUserProperties ()Ljava/util/Map;
 	public final fun getUserPropertiesSetOnce ()Ljava/util/Map;
 }
@@ -42,6 +43,7 @@ public final class com/posthog/server/PostHogCaptureOptions$Builder {
 	public final fun build ()Lcom/posthog/server/PostHogCaptureOptions;
 	public final fun getGroups ()Ljava/util/Map;
 	public final fun getProperties ()Ljava/util/Map;
+	public final fun getTimestamp ()Ljava/util/Date;
 	public final fun getUserProperties ()Ljava/util/Map;
 	public final fun getUserPropertiesSetOnce ()Ljava/util/Map;
 	public final fun group (Ljava/lang/String;Ljava/lang/String;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
@@ -50,8 +52,12 @@ public final class com/posthog/server/PostHogCaptureOptions$Builder {
 	public final fun property (Ljava/lang/String;Ljava/lang/Object;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
 	public final fun setGroups (Ljava/util/Map;)V
 	public final fun setProperties (Ljava/util/Map;)V
+	public final fun setTimestamp (Ljava/util/Date;)V
 	public final fun setUserProperties (Ljava/util/Map;)V
 	public final fun setUserPropertiesSetOnce (Ljava/util/Map;)V
+	public final fun timestamp (J)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun timestamp (Ljava/time/Instant;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
+	public final fun timestamp (Ljava/util/Date;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
 	public final fun userProperties (Ljava/util/Map;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
 	public final fun userPropertiesSetOnce (Ljava/util/Map;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
 	public final fun userProperty (Ljava/lang/String;Ljava/lang/Object;)Lcom/posthog/server/PostHogCaptureOptions$Builder;
@@ -142,7 +148,7 @@ public abstract interface class com/posthog/server/PostHogInterface {
 	public abstract fun alias (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
-	public abstract synthetic fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public abstract synthetic fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public abstract fun close ()V
 	public abstract fun debug (Z)V
 	public abstract fun flush ()V
@@ -163,7 +169,7 @@ public abstract interface class com/posthog/server/PostHogInterface {
 public final class com/posthog/server/PostHogInterface$DefaultImpls {
 	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
-	public static synthetic fun capture$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun capture$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)V
 	public static synthetic fun debug$default (Lcom/posthog/server/PostHogInterface;ZILjava/lang/Object;)V
 	public static fun getFeatureFlag (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
 	public static synthetic fun getFeatureFlag$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;

--- a/posthog-server/src/main/java/com/posthog/server/PostHog.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHog.kt
@@ -41,6 +41,7 @@ public class PostHog : PostHogInterface {
         userProperties: Map<String, Any>?,
         userPropertiesSetOnce: Map<String, Any>?,
         groups: Map<String, String>?,
+        timestamp: java.util.Date?,
     ) {
         instance?.captureStateless(
             event,
@@ -49,6 +50,7 @@ public class PostHog : PostHogInterface {
             userProperties,
             userPropertiesSetOnce,
             groups,
+            timestamp,
         )
     }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHogCaptureOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogCaptureOptions.kt
@@ -1,5 +1,8 @@
 package com.posthog.server
 
+import java.time.Instant
+import java.util.Date
+
 /**
  * Provides an ergonomic interface when providing options for capturing events
  * This is mainly meant to be used from Java, as Kotlin can use named parameters.
@@ -10,12 +13,14 @@ public class PostHogCaptureOptions private constructor(
     public val userProperties: Map<String, Any>?,
     public val userPropertiesSetOnce: Map<String, Any>?,
     public val groups: Map<String, String>?,
+    public val timestamp: Date? = null,
 ) {
     public class Builder {
         public var properties: MutableMap<String, Any>? = null
         public var userProperties: MutableMap<String, Any>? = null
         public var userPropertiesSetOnce: MutableMap<String, Any>? = null
         public var groups: MutableMap<String, String>? = null
+        public var timestamp: Date? = null
 
         /**
          * Add a single custom property to the capture options
@@ -123,10 +128,45 @@ public class PostHogCaptureOptions private constructor(
             return this
         }
 
-        public fun build(): PostHogCaptureOptions = PostHogCaptureOptions(properties, userProperties, userPropertiesSetOnce, groups)
+        /**
+         * Override the timestamp for the event.
+         * @see <a href="https://posthog.com/docs/data/timestamps">Documentation: Timestamps</a>
+         */
+        public fun timestamp(date: Date): Builder {
+            this.timestamp = date
+            return this
+        }
+
+        /**
+         * Override the timestamp for the event.
+         * @see <a href="https://posthog.com/docs/data/timestamps">Documentation: Timestamps</a>
+         */
+        public fun timestamp(epochMillis: Long): Builder {
+            this.timestamp = Date(epochMillis)
+            return this
+        }
+
+        /**
+         * Override the timestamp for the event.
+         * @see <a href="https://posthog.com/docs/data/timestamps">Documentation: Timestamps</a>
+         */
+        public fun timestamp(instant: Instant): Builder {
+            this.timestamp = Date(instant.toEpochMilli())
+            return this
+        }
+
+        public fun build(): PostHogCaptureOptions =
+            PostHogCaptureOptions(
+                properties,
+                userProperties,
+                userPropertiesSetOnce,
+                groups,
+                timestamp,
+            )
     }
 
     public companion object {
-        @JvmStatic public fun builder(): Builder = Builder()
+        @JvmStatic
+        public fun builder(): Builder = Builder()
     }
 }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
@@ -1,5 +1,7 @@
 package com.posthog.server
 
+import java.util.Date
+
 public sealed interface PostHogInterface {
     /**
      * Setup the SDK
@@ -81,6 +83,7 @@ public sealed interface PostHogInterface {
         userProperties: Map<String, Any>? = null,
         userPropertiesSetOnce: Map<String, Any>? = null,
         groups: Map<String, String>? = null,
+        timestamp: Date? = null,
     )
 
     /**
@@ -101,6 +104,7 @@ public sealed interface PostHogInterface {
             options.userProperties,
             options.userPropertiesSetOnce,
             options.groups,
+            options.timestamp,
         )
     }
 

--- a/posthog/CHANGELOG.md
+++ b/posthog/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- feat: Stateless client can override event `timestamp` when capturing an event ([#297](https://github.com/PostHog/posthog-android/issues/297))
+
 ## 3.23.1 - 2025-09-30
 
 - fix: `PostHogStateless` now deduplicates `$feature_flag_called` events ([#293](https://github.com/PostHog/posthog-android/pull/293))

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -306,8 +306,9 @@ public class com/posthog/PostHogStateless : com/posthog/PostHogStatelessInterfac
 	protected fun <init> (Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;)V
 	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun aliasStateless (Ljava/lang/String;Ljava/lang/String;)V
-	protected final fun buildEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/posthog/PostHogEvent;
-	public fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	protected final fun buildEvent (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lcom/posthog/PostHogEvent;
+	public static synthetic fun buildEvent$default (Lcom/posthog/PostHogStateless;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lcom/posthog/PostHogEvent;
+	public fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public fun close ()V
 	public fun debug (Z)V
 	public fun flush ()V
@@ -338,7 +339,7 @@ public class com/posthog/PostHogStateless : com/posthog/PostHogStatelessInterfac
 
 public final class com/posthog/PostHogStateless$Companion : com/posthog/PostHogStatelessInterface {
 	public fun aliasStateless (Ljava/lang/String;Ljava/lang/String;)V
-	public fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public fun close ()V
 	public fun debug (Z)V
 	public fun flush ()V
@@ -358,7 +359,7 @@ public final class com/posthog/PostHogStateless$Companion : com/posthog/PostHogS
 
 public abstract interface class com/posthog/PostHogStatelessInterface : com/posthog/PostHogCoreInterface {
 	public abstract fun aliasStateless (Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public abstract fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public abstract fun getFeatureFlagPayloadStateless (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getFeatureFlagStateless (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun groupStateless (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
@@ -366,7 +367,7 @@ public abstract interface class com/posthog/PostHogStatelessInterface : com/post
 }
 
 public final class com/posthog/PostHogStatelessInterface$DefaultImpls {
-	public static synthetic fun captureStateless$default (Lcom/posthog/PostHogStatelessInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun captureStateless$default (Lcom/posthog/PostHogStatelessInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)V
 	public static synthetic fun getFeatureFlagPayloadStateless$default (Lcom/posthog/PostHogStatelessInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getFeatureFlagStateless$default (Lcom/posthog/PostHogStatelessInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun groupStateless$default (Lcom/posthog/PostHogStatelessInterface;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -470,6 +470,7 @@ public class PostHog private constructor(
                     userProperties,
                     userPropertiesSetOnce,
                     groups,
+                    null,
                 )
                 // Notify surveys integration about the event
                 surveysHandler?.onEvent(event)

--- a/posthog/src/main/java/com/posthog/PostHogStatelessInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStatelessInterface.kt
@@ -1,5 +1,7 @@
 package com.posthog
 
+import java.util.Date
+
 /**
  * The Stateless PostHog SDK entry point
  */
@@ -11,6 +13,7 @@ public interface PostHogStatelessInterface : PostHogCoreInterface {
      * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
      * @param userPropertiesSetOnce the user properties to set only once, set as a "$set_once" property, Docs https://posthog.com/docs/product-analytics/user-properties
      * @param groups the groups, set as a "$groups" property, Docs https://posthog.com/docs/product-analytics/group-analytics
+     * @param timestamp the timestamp for the event, if not provided the current time will be used, Docs https://posthog.com/docs/data/timestamps
      */
     public fun captureStateless(
         event: String,
@@ -19,6 +22,7 @@ public interface PostHogStatelessInterface : PostHogCoreInterface {
         userProperties: Map<String, Any>? = null,
         userPropertiesSetOnce: Map<String, Any>? = null,
         groups: Map<String, String>? = null,
+        timestamp: Date? = null,
     )
 
     /**


### PR DESCRIPTION
## :bulb: Motivation and Context

Some users wish to use their own timestamps when capturing an event to ensure order of events. This change allows users to set their own timestamps when capturing an event.


## :green_heart: How did you test it?

Unit tests and local testing via the sample Java project

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
