### PR TITLE
fix: Fallback for missing exception file names

### DIFF
--- a/posthog/CHANGELOG.md
+++ b/posthog/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+- fix: Exceptions record `className.methodName` in the absence of debug information ([#317](https://github.com/PostHog/posthog-android/pull/317))
+
 ## 5.1.0 - 2025-11-06
 
 - feat: Add an optional shutdown override to `FeatureFlagInterface` ([#299](https://github.com/PostHog/posthog-android/pull/299))

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -78,6 +78,18 @@ public class ThrowableCoercer {
                     val fileName = frame.fileName
                     if (fileName?.isNotEmpty() == true) {
                         myFrame["filename"] = fileName
+                    } else {
+                        // If the file name is not available (e.g., the application has been compiled without debug info),
+                        // substitute with class and method names.
+                        val frameClass = frame.className?.takeIf { it.isNotEmpty() }
+                        val frameMethod = frame.methodName?.takeIf { it.isNotEmpty() }
+                        val fullyQualifiedName =
+                            listOfNotNull(frameClass, frameMethod)
+                                .takeIf { it.isNotEmpty() }
+                                ?.joinToString(".")
+                        if (fullyQualifiedName?.isNotEmpty() == true) {
+                            myFrame["filename"] = fullyQualifiedName
+                        }
                     }
 
                     myFrame["in_app"] = isInApp(frame.className, inAppIncludes)

--- a/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
@@ -1,0 +1,133 @@
+package com.posthog.internal.errortracking
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class ThrowableCoercerTest {
+    private val coercer = ThrowableCoercer()
+
+    @Test
+    fun `filename uses fileName when available`() {
+        val exception =
+            createExceptionWithStackTrace(
+                className = "com.example.MyClass",
+                methodName = "myMethod",
+                fileName = "MyClass.java",
+                lineNumber = 42,
+            )
+
+        val result = coercer.fromThrowableToPostHogProperties(exception)
+
+        val frames = getFrames(result)
+        assertEquals("MyClass.java", frames[0]["filename"])
+    }
+
+    @Test
+    fun `filename uses className and methodName when fileName is null`() {
+        val exception =
+            createExceptionWithStackTrace(
+                className = "com.example.MyClass",
+                methodName = "myMethod",
+                fileName = null,
+                lineNumber = -1,
+            )
+
+        val result = coercer.fromThrowableToPostHogProperties(exception)
+
+        val frames = getFrames(result)
+        assertEquals("com.example.MyClass.myMethod", frames[0]["filename"])
+    }
+
+    @Test
+    fun `filename uses only className when methodName is null`() {
+        val exception =
+            createExceptionWithStackTrace(
+                className = "com.example.MyClass",
+                methodName = null,
+                fileName = null,
+                lineNumber = -1,
+            )
+
+        val result = coercer.fromThrowableToPostHogProperties(exception)
+
+        val frames = getFrames(result)
+        assertEquals("com.example.MyClass", frames[0]["filename"])
+    }
+
+    @Test
+    fun `filename uses only methodName when className is null`() {
+        val exception =
+            createExceptionWithStackTrace(
+                className = null,
+                methodName = "myMethod",
+                fileName = null,
+                lineNumber = -1,
+            )
+
+        val result = coercer.fromThrowableToPostHogProperties(exception)
+
+        val frames = getFrames(result)
+        assertEquals("myMethod", frames[0]["filename"])
+    }
+
+    @Test
+    fun `filename uses only methodName when className is empty`() {
+        val exception =
+            createExceptionWithStackTrace(
+                className = "",
+                methodName = "myMethod",
+                fileName = null,
+                lineNumber = -1,
+            )
+
+        val result = coercer.fromThrowableToPostHogProperties(exception)
+
+        val frames = getFrames(result)
+        assertEquals("myMethod", frames[0]["filename"])
+    }
+
+    @Test
+    fun `filename is null when both className and methodName are null`() {
+        val exception =
+            createExceptionWithStackTrace(
+                className = null,
+                methodName = null,
+                fileName = null,
+                lineNumber = -1,
+            )
+
+        val result = coercer.fromThrowableToPostHogProperties(exception)
+
+        val frames = getFrames(result)
+        assertNull(frames[0]["filename"])
+    }
+
+    // Helper function to create an exception with a specific stack trace
+    private fun createExceptionWithStackTrace(
+        className: String?,
+        methodName: String?,
+        fileName: String?,
+        lineNumber: Int,
+    ): Throwable {
+        val exception = RuntimeException("Test exception")
+        val stackTraceElement =
+            StackTraceElement(
+                className ?: "",
+                methodName ?: "",
+                fileName,
+                lineNumber,
+            )
+        exception.stackTrace = arrayOf(stackTraceElement)
+        return exception
+    }
+
+    // Helper function to extract frames from the result
+    @Suppress("UNCHECKED_CAST")
+    private fun getFrames(result: Map<String, Any>): List<Map<String, Any>> {
+        val exceptionList = result["\$exception_list"] as List<Map<String, Any>>
+        val exception = exceptionList[0]
+        val stackTrace = exception["stacktrace"] as Map<String, Any>
+        return stackTrace["frames"] as List<Map<String, Any>>
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

When compiling a Java application _without_ debug information (`javac -g:none`), filenames and line numbers are stripped from the compiled bytecode.

I've noticed that this causes the app to display "empty" frames:

<img width="523" height="129" alt="image" src="https://github.com/user-attachments/assets/e21adfeb-f03d-4712-9a7a-991984799356" />

A potential solution is to substitute the file name and line number with the class and method names:

<img width="523" height="129" alt="image" src="https://github.com/user-attachments/assets/e67c170b-85fd-4655-934b-7070bebcccc6" />

It's worth mentioning that in the absence of file names and line numbers, this information _is_ still emitted in the exception stack trace as `module`, `function`. Is it appropriate to solve this here or elsewhere?
```json
{
    "event": "$exception",
    "distinct_id": "26142034-a912-4fcf-9175-b61330cb7366",
    "properties": {
        "$lib": "posthog-server",
        "$lib_version": "2.0.0",
        "$exception_level": "error",
        "$exception_list": [
            {
                "type": "RuntimeException",
                "mechanism": {
                    "handled": true,
                    "synthetic": false,
                    "type": "generic"
                },
                "thread_id": 1,
                "value": "This is a test exception",
                "module": "java.lang",
                "stacktrace": {
                    "frames": [
                        {
                            "module": "com.posthog.java.sample.PostHogJavaExample",
                            "function": "dangerousMethod",
                            "platform": "java",
                            "in_app": true
                        },
                        {
                            "module": "com.posthog.java.sample.PostHogJavaExample",
                            "function": "main",
                            "platform": "java",
                            "in_app": true
                        }
                    ],
                    "type": "raw"
                }
            }
        ],
        "service": "weather-api",
        "$process_person_profile": false
    },
    "timestamp": "2025-11-06T22:19:06.461Z",
    "uuid": "019a5b40-855d-77ca-8389-053fb609fbd8"
}
```



## :green_heart: How did you test it?

Tested against the java sample with `javac -g:none`. Also added some unit tests to simulate the same thing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
