### PR TITLE
Revert "fix: gradle plugin group id"

### DIFF
--- a/posthog-android-gradle-plugin/build.gradle.kts
+++ b/posthog-android-gradle-plugin/build.gradle.kts
@@ -149,9 +149,6 @@ publishing {
         }
 
         publications.named<MavenPublication>("postHogAndroidPluginPluginMarkerMaven") {
-            // Override the group ID to match the main plugin publication
-            groupId = postHogGroupId
-
             pom {
                 configurePom(
                     "PostHog Android Gradle Plugin (Gradle Plugin)",


### PR DESCRIPTION
Reverts PostHog/posthog-android#339
_#skip-changelog_
this is needed because the group id has to match the plugin id marker to be found, TIL