### PR TITLE
ci: release pls

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,111 @@
+name: release please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      core_release_created: ${{ steps.release.outputs['posthog--release_created'] }}
+      android_release_created: ${{ steps.release.outputs['posthog-android--release_created'] }}
+      server_release_created: ${{ steps.release.outputs['posthog-server--release_created'] }}
+      plugin_release_created: ${{ steps.release.outputs['posthog-android-gradle-plugin--release_created'] }}
+      core_tag: ${{ steps.release.outputs['posthog--tag_name'] }}
+      android_tag: ${{ steps.release.outputs['posthog-android--tag_name'] }}
+      server_tag: ${{ steps.release.outputs['posthog-server--tag_name'] }}
+      plugin_tag: ${{ steps.release.outputs['posthog-android-gradle-plugin--tag_name'] }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  publish-core:
+    needs: release-please
+    if: needs.release-please.outputs.core_release_created == 'true'
+    runs-on: ubuntu-latest
+    env:
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - name: Publish Core to Maven Central
+        run: make releaseCore
+
+  publish-android:
+    needs: [release-please, publish-core]
+    if: |
+      always() &&
+      needs.release-please.outputs.android_release_created == 'true' &&
+      (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - name: Publish Android to Maven Central
+        run: make releaseAndroid
+
+  publish-server:
+    needs: [release-please, publish-core]
+    if: |
+      always() &&
+      needs.release-please.outputs.server_release_created == 'true' &&
+      (needs.publish-core.result == 'success' || needs.publish-core.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - name: Publish Server to Maven Central
+        run: make releaseServer
+
+  publish-plugin:
+    needs: [release-please, publish-android]
+    if: |
+      always() &&
+      needs.release-please.outputs.plugin_release_created == 'true' &&
+      (needs.publish-android.result == 'success' || needs.publish-android.result == 'skipped')
+    runs-on: ubuntu-latest
+    env:
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - name: Publish Android Plugin to Maven Central
+        run: make releaseAndroidPlugin

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "posthog": "5.2.0",
+  "posthog-android": "3.27.2",
+  "posthog-server": "2.0.1",
+  "posthog-android-gradle-plugin": "1.0.2"
+}

--- a/buildSrc/src/main/java/PosthogBuildConfig.kt
+++ b/buildSrc/src/main/java/PosthogBuildConfig.kt
@@ -1,6 +1,24 @@
+import groovy.json.JsonSlurper
 import org.gradle.api.JavaVersion
+import java.io.File
 
 object PosthogBuildConfig {
+
+    /**
+     * Reads a module version from .release-please-manifest.json
+     *
+     * @param key The module key in the manifest (e.g., "posthog", "posthog-android")
+     * @return The version string
+     */
+    fun version(key: String): String {
+        val manifestFile = File(System.getProperty("user.dir"), ".release-please-manifest.json")
+        if (!manifestFile.exists()) {
+            error("Release manifest not found: ${manifestFile.absolutePath}")
+        }
+        val versions = JsonSlurper().parseText(manifestFile.readText()) as Map<*, *>
+        return versions[key]?.toString()
+            ?: error("Version for '$key' not found in manifest")
+    }
     fun shouldSkipDebugVariant(name: String): Boolean {
         return isCI() && name == "debug"
     }

--- a/posthog-android-gradle-plugin/build.gradle.kts
+++ b/posthog-android-gradle-plugin/build.gradle.kts
@@ -1,9 +1,14 @@
+import groovy.json.JsonSlurper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 
 val postHogGroupId = "com.posthog"
 group = postHogGroupId
-version = properties["androidPluginVersion"].toString()
+
+val manifest = file("../.release-please-manifest.json")
+val versions = JsonSlurper().parseText(manifest.readText()) as Map<*, *>
+version = versions["posthog-android-gradle-plugin"]?.toString()
+    ?: error("Version for 'posthog-android-gradle-plugin' not found in manifest")
 
 // Extension function for common POM configuration
 fun MavenPom.configurePom(

--- a/posthog-android/build.gradle.kts
+++ b/posthog-android/build.gradle.kts
@@ -2,7 +2,7 @@
 
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
-version = properties["androidVersion"].toString()
+version = PosthogBuildConfig.version("posthog-android")
 
 plugins {
     id("com.android.library")

--- a/posthog-server/build.gradle.kts
+++ b/posthog-server/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = properties["serverVersion"].toString()
+version = PosthogBuildConfig.version("posthog-server")
 
 plugins {
     `java-library`

--- a/posthog/build.gradle.kts
+++ b/posthog/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-version = properties["coreVersion"].toString()
+version = PosthogBuildConfig.version("posthog")
 
 plugins {
     `java-library`

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "ea03a27a80e3d25c19a40e84abb35340b386892a",
+  "release-type": "simple",
+  "packages": {
+    "posthog": {
+      "component": "core"
+    },
+    "posthog-android": {
+      "component": "android"
+    },
+    "posthog-server": {
+      "component": "server"
+    },
+    "posthog-android-gradle-plugin": {
+      "component": "androidPlugin"
+    }
+  }
+}


### PR DESCRIPTION
**Work in progress!** 🚨 

This branch explores how we could improve our automated releases by introducing [release-please](https://github.com/googleapis/release-please).

This workflow would maintains a release PR that accumulates changes. When you merge the PR, it automatically creates the associated GitHub releases, tags and Sonatype publishing.

Changelog practices would change slightly. Instead of manually editing respective CHANGELOG.md files, the workflow [parses commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary) to determine version bumps and changelog entries. E.g., `feat` maps to a minor version bump, `fix` to patch. 

Because this is a monorepo, changes would be scoped by path. E.g., a `fix` commit which modifies files in `posthog-android` would result in a CHANGELOG entry and version bump only for that module.

Releases would be ordered topologically, e.g., core must release before posthog-android. I'm thinking changes to core can optionally trigger subsequent releases in a dependent module via a label on a PR (`release/android`, `release/server`?), this way we can easily/quickly update downstream packages if they rely on a change in core without actually being changed themselves.

Not married to any particular idea here, open to feedback!

---

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] If there are related changes in the [core](https://github.com/PostHog/posthog-android/tree/main/posthog) package, I've already released them, or I'll release them before this one.
