### PR TITLE
chore(release): bump server to 2.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.defaults.buildfeatures.resvalues=false
 # Release - Module-specific versions
 coreVersion=5.2.0
 androidVersion=3.27.2
-serverVersion=2.0.1
+serverVersion=2.1.0

--- a/posthog-server/CHANGELOG.md
+++ b/posthog-server/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+## 2.1.0 - 2025-12-05
+
 - feat: Include `evaluated_at` properties in `$feature_flag_called` events ([#321](https://github.com/PostHog/posthog-android/pull/321))
 - feat: Add `appendFeatureFlags` optional boolean to `capture` ([#347](https://github.com/PostHog/posthog-android/pull/347))
 


### PR DESCRIPTION
#skip-changelog

## 2.1.0 - 2025-12-05

- feat: Include `evaluated_at` properties in `$feature_flag_called` events ([#321](https://github.com/PostHog/posthog-android/pull/321))
- feat: Add `appendFeatureFlags` optional boolean to `capture` ([#347](https://github.com/PostHog/posthog-android/pull/347))

