### PR TITLE
chore(release): bump core to 6.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,6 @@ android.defaults.buildfeatures.shaders=false
 android.defaults.buildfeatures.resvalues=false
 
 # Release - Module-specific versions
-coreVersion=6.1.0
+coreVersion=6.2.0
 androidVersion=3.28.1
 serverVersion=2.1.0

--- a/posthog/CHANGELOG.md
+++ b/posthog/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Next
 
+## 6.2.0 - 2025-01-19
+
 - feat: implement setPersonProps method ([#369](https://github.com/PostHog/posthog-android/pull/369))
 - fix: Retain cached flags when quota limited ([#372](https://github.com/PostHog/posthog-android/pull/372))
 


### PR DESCRIPTION
- feat: implement setPersonProps method ([#369](https://github.com/PostHog/posthog-android/pull/369))
- fix: Retain cached flags when quota limited ([#372](https://github.com/PostHog/posthog-android/pull/372))
#skip-changelog