### PR TITLE
chore: update changelog

### DIFF
--- a/posthog-android/CHANGELOG.md
+++ b/posthog-android/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 ## 3.29.1 - 2026-01-21
 
+### Changed
+
 - fix: handle corrupted Intent bundles with duplicate keys in referrer info ([#377](https://github.com/PostHog/posthog-android/pull/377))
 - chore: do not capture $set events if user props have not changed ([#375](https://github.com/PostHog/posthog-android/pull/375))
-
-## 3.29.0 - 2026-01-19
-
-### Changed
 - Renamed `evaluationEnvironments` to `evaluationContexts` for clearer semantics ([#368](https://github.com/PostHog/posthog-android/pull/368)). The term "contexts" better reflects that this feature is for specifying evaluation contexts (e.g., "web", "mobile", "checkout") rather than deployment environments (e.g., "staging", "production").
 - The API now sends `evaluation_contexts` instead of `evaluation_environments` to the server.
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Looks like we mistakenly stamped posthog-android changelog with `3.29.0` without an actual release. 
This will sync changelog with posthog-android releases

#skip-changelog

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] If there are related changes in the [core](https://github.com/PostHog/posthog-android/tree/main/posthog) package, I've already released them, or I'll release them before this one.
