### PR TITLE
feat: propagate personProperties and groups in feature flag events

### DIFF
--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -454,7 +454,16 @@ public open class PostHogStateless protected constructor(
                     groupProperties,
                 )?.let { props["\$feature_flag_error"] = it }
 
-                captureStateless(PostHogEventName.FEATURE_FLAG_CALLED.event, distinctId, properties = props)
+                val userProps = personProperties
+                    ?.filterValues { it != null }
+                    ?.mapValues { it.value!! }
+                captureStateless(
+                    PostHogEventName.FEATURE_FLAG_CALLED.event,
+                    distinctId,
+                    properties = props,
+                    userProperties = userProps,
+                    groups = groups,
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

- Propagate `personProperties` (as `userProperties`) and `groups` to `captureStateless` when `$feature_flag_called` events are sent during feature flag evaluation
- Previously these properties were available during flag evaluation but not passed through to the captured event, meaning the feature flag evaluation context was lost

---
Split from original PR addressing contributor feedback to keep changes focused.