### PR TITLE
chore: use dominant/average color instead of just black

### DIFF
--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/MyApp.kt
@@ -38,7 +38,7 @@ class MyApp : Application() {
                     }
                 }
                 sessionReplayConfig.maskAllTextInputs = true
-                sessionReplayConfig.maskAllImages = false
+                sessionReplayConfig.maskAllImages = true
                 sessionReplayConfig.captureLogcat = false
                 sessionReplayConfig.screenshot = true
                 surveys = false

--- a/posthog-samples/posthog-android-sample/src/main/res/layout/normal_activity.xml
+++ b/posthog-samples/posthog-android-sample/src/main/res/layout/normal_activity.xml
@@ -33,6 +33,13 @@
     <!--                />-->
     <!--            &lt;!&ndash;        android:tag="ph-no-capture"&ndash;&gt;-->
 
+    <ImageView
+        android:id="@+id/imvAndroid"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:src="@drawable/android_logo"
+        />
+
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## :bulb: Motivation and Context
just a POC since it does not work well all the cases
eg if the doninant color is white and the background is white, its masked but you actually dont know there was something there eventhough the text color was red

<img width="399" height="182" alt="Screenshot 2026-01-29 at 14 44 12" src="https://github.com/user-attachments/assets/1aca3f44-b922-4b8e-8ee7-dced0bf72645" />



## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] If there are related changes in the [core](https://github.com/PostHog/posthog-android/tree/main/posthog) package, I've already released them, or I'll release them before this one.
