### PR TITLE
fix: walk view children of ComposeView for interop scenarios

### DIFF
--- a/posthog-android/CHANGELOG.md
+++ b/posthog-android/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- fix: walk view children for Compose views in session replay masking ([#417](https://github.com/PostHog/posthog-android/pull/417))
+
+
 # 3.31.0 - 2026-02-05
 
 - fix: Queue pending feature flags reload instead of dropping requests when a reload is already in flight ([#407](https://github.com/PostHog/posthog-android/pull/407))

--- a/posthog-android/CHANGELOG.md
+++ b/posthog-android/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 - fix: walk view children for Compose views in session replay masking ([#417](https://github.com/PostHog/posthog-android/pull/417))
 
-
 # 3.31.0 - 2026-02-05
 
 - fix: Queue pending feature flags reload instead of dropping requests when a reload is already in flight ([#407](https://github.com/PostHog/posthog-android/pull/407))


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ticket: https://posthoghelp.zendesk.com/agent/tickets/50498 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/53670)

Ensures `findMaskableWidgets` walks children of Compose views to handle
interop scenarios (e.g. AndroidView, FragmentContainerView). 

## :green_heart: How did you test it?

<table>
<tr>
<td> Before
<td> After
<tr>
<td>  <img width="439" height="918" alt="CleanShot 2026-02-16 at 12 20 40" src="https://github.com/user-attachments/assets/8fc44560-339f-466d-8b9b-5c70da94a717" />

<td>  <img width="436" height="885" alt="CleanShot 2026-02-16 at 12 18 01" src="https://github.com/user-attachments/assets/8c4db285-7914-4fac-bc48-ee43e6b78574" />

</table>

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
- [ ] If there are related changes in the [core](https://github.com/PostHog/posthog-android/tree/main/posthog) package, I've already released them, or I'll release them before this one.
