### PR TITLE
chore: add Slack failure notification to version-bump job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,17 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
 
+            - name: Notify Slack - Failed
+              continue-on-error: true
+              if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
+              uses: PostHog/.github/.github/actions/slack-thread-reply@main
+              with:
+                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
+                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
+                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
+                  message: '❌ Failed to bump versions for `posthog-android`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  emoji_reaction: 'x'
+
     notify-rejected:
         name: Notify Slack - Rejected
         needs: [version-bump, notify-approval-needed]


### PR DESCRIPTION
## :bulb: Motivation and Context

Same issue as [posthog-ios](https://github.com/PostHog/posthog-ios/pull/508): when the `version-bump` job fails for a non-rejection reason, nobody gets notified on Slack.

The existing "Notify Slack - Failed" step lives inside the `publish` job, but if `version-bump` fails, `publish` is **skipped entirely** (its condition requires `needs.version-bump.outputs.committed == 'true'`). And `notify-rejected` only fires for explicit rejections.

**Fix:** Add an inline "Notify Slack - Failed" step at the end of the `version-bump` job using `${{ failure() }}`, following the [posthog-js pattern](https://github.com/PostHog/posthog-js/blob/main/.github/workflows/release.yml#L336-L345).

## :green_heart: How did you test it?

YAML lint validation passed. Logic follows the proven pattern from posthog-js.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.