### PR TITLE
feat(surveys): support event property filters

### DIFF
--- a/.changeset/gentle-garlics-mix.md
+++ b/.changeset/gentle-garlics-mix.md
@@ -1,0 +1,6 @@
+---
+"posthog-android": minor
+"posthog": minor
+---
+
+support survey event property filters

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -124,7 +124,7 @@ public class com/posthog/android/replay/internal/LogcatParser {
 public final class com/posthog/android/surveys/PostHogSurveysIntegration : com/posthog/PostHogIntegration, com/posthog/internal/surveys/PostHogSurveysHandler {
 	public fun <init> (Landroid/content/Context;Lcom/posthog/PostHogConfig;)V
 	public fun install (Lcom/posthog/PostHogInterface;)V
-	public fun onEvent (Ljava/lang/String;)V
+	public fun onEvent (Ljava/lang/String;Ljava/util/Map;)V
 	public fun onRemoteConfig ()V
 	public fun onSurveysLoaded (Ljava/util/List;)V
 	public fun uninstall ()V

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -24,6 +24,7 @@ import com.posthog.surveys.RatingSurveyQuestion
 import com.posthog.surveys.SingleSurveyQuestion
 import com.posthog.surveys.Survey
 import com.posthog.surveys.SurveyMatchType
+import com.posthog.surveys.SurveyPropertyFilter
 import com.posthog.surveys.SurveyQuestion
 import com.posthog.surveys.SurveyQuestionBranching
 import java.util.Date
@@ -40,6 +41,14 @@ public class PostHogSurveysIntegration(
             SurveyMatchType.NOT_REGEX to { targets, value -> targets.all { pattern -> !isMatchingRegex(value, pattern) } },
             SurveyMatchType.EXACT to { targets, value -> targets.any { value == it } },
             SurveyMatchType.IS_NOT to { targets, value -> targets.all { value != it } },
+            SurveyMatchType.GT to { targets, value ->
+                val numValue = value.toDoubleOrNull()
+                numValue != null && targets.any { t -> t.toDoubleOrNull()?.let { numValue > it } == true }
+            },
+            SurveyMatchType.LT to { targets, value ->
+                val numValue = value.toDoubleOrNull()
+                numValue != null && targets.any { t -> t.toDoubleOrNull()?.let { numValue < it } == true }
+            },
         )
 
     private val deviceType: String = getDeviceType(context) ?: "Mobile"
@@ -62,7 +71,7 @@ public class PostHogSurveysIntegration(
 
     // Event activation tracking
     private val eventActivatedSurveys = mutableSetOf<String>()
-    private val eventsToSurveys = mutableMapOf<String, List<String>>()
+    private val eventsToSurveys = mutableMapOf<String, List<SurveyEventMapping>>()
 
     // Survey response tracking
     private val currentSurveyResponses = mutableMapOf<String, PostHogSurveyResponse>()
@@ -132,7 +141,7 @@ public class PostHogSurveysIntegration(
      *
      * @return List of filtered surveys
      */
-    private fun getActiveMatchingSurveys(): List<Survey> {
+    internal fun getActiveMatchingSurveys(): List<Survey> {
         // Check if surveys are enabled in config
         if (!config.surveys) {
             return emptyList()
@@ -143,12 +152,13 @@ public class PostHogSurveysIntegration(
     }
 
     private fun rebuildEventsToSurveysMap(surveys: List<Survey>) {
-        val eventMap = mutableMapOf<String, MutableList<String>>()
+        val eventMap = mutableMapOf<String, MutableList<SurveyEventMapping>>()
         surveys.forEach { survey ->
             survey.conditions?.events?.values?.forEach { eventCondition ->
                 val eventName = eventCondition.name
                 if (eventName.isNotEmpty()) {
-                    eventMap.getOrPut(eventName) { mutableListOf() }.add(survey.id)
+                    eventMap.getOrPut(eventName) { mutableListOf() }
+                        .add(SurveyEventMapping(surveyId = survey.id, condition = eventCondition))
                 }
             }
         }
@@ -845,16 +855,26 @@ public class PostHogSurveysIntegration(
     /**
      * Called when an event is captured to activate associated surveys
      */
-    public override fun onEvent(event: String) {
-        val activatedSurveys =
+    public override fun onEvent(
+        event: String,
+        properties: Map<String, Any>?,
+    ) {
+        val candidates =
             synchronized(eventActivationLock) {
                 // Copy to avoid concurrent modification issues
                 eventsToSurveys[event]?.toList()
             } ?: return
-        if (activatedSurveys.isEmpty()) return
+        if (candidates.isEmpty()) return
+
+        val matchingSurveyIds =
+            candidates
+                .filter { matchPropertyFilters(it.condition.propertyFilters, properties) }
+                .map { it.surveyId }
+
+        if (matchingSurveyIds.isEmpty()) return
 
         synchronized(eventActivationLock) {
-            for (surveyId in activatedSurveys) {
+            for (surveyId in matchingSurveyIds) {
                 eventActivatedSurveys.add(surveyId)
             }
         }
@@ -863,6 +883,20 @@ public class PostHogSurveysIntegration(
         val shouldShowSurvey = synchronized(lifecycleLock) { isStarted }
         if (shouldShowSurvey) {
             showNextSurvey()
+        }
+    }
+
+    private fun matchPropertyFilters(
+        propertyFilters: Map<String, SurveyPropertyFilter>?,
+        eventProperties: Map<String, Any>?,
+    ): Boolean {
+        if (propertyFilters.isNullOrEmpty()) return true
+
+        return propertyFilters.all { (propertyName, filter) ->
+            val eventValue = eventProperties?.get(propertyName) ?: return@all false
+            val validator = surveyValidationMap[filter.operator] ?: return@all false
+            val eventValueString = eventValue.toString()
+            validator(filter.values, eventValueString)
         }
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/surveys/SurveyEventMapping.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/SurveyEventMapping.kt
@@ -1,0 +1,8 @@
+package com.posthog.android.surveys
+
+import com.posthog.surveys.SurveyEventCondition
+
+internal class SurveyEventMapping(
+    val surveyId: String,
+    val condition: SurveyEventCondition,
+)

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysEventPropertyFilterTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysEventPropertyFilterTest.kt
@@ -1,0 +1,319 @@
+package com.posthog.android.surveys
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.posthog.PostHogConfig
+import com.posthog.PostHogInterface
+import com.posthog.surveys.Survey
+import com.posthog.surveys.SurveyConditions
+import com.posthog.surveys.SurveyEventCondition
+import com.posthog.surveys.SurveyEventConditions
+import com.posthog.surveys.SurveyMatchType
+import com.posthog.surveys.SurveyPropertyFilter
+import com.posthog.surveys.SurveyType
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+internal class PostHogSurveysEventPropertyFilterTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    private fun createIntegration(): PostHogSurveysIntegration {
+        val config =
+            PostHogConfig("test-api-key").apply {
+                surveys = true
+            }
+        val integration = PostHogSurveysIntegration(context, config)
+        val fake = mock<PostHogInterface>()
+        whenever(fake.isFeatureEnabled(any(), any(), any())).thenReturn(true)
+        integration.install(fake)
+        return integration
+    }
+
+    private fun createSurvey(
+        id: String,
+        eventConditions: List<SurveyEventCondition>,
+    ): Survey {
+        return Survey(
+            id = id,
+            name = "Test Survey $id",
+            type = SurveyType.API,
+            questions = emptyList(),
+            description = null,
+            featureFlagKeys = null,
+            linkedFlagKey = null,
+            targetingFlagKey = null,
+            internalTargetingFlagKey = null,
+            conditions =
+                SurveyConditions(
+                    url = null,
+                    urlMatchType = null,
+                    selector = null,
+                    deviceTypes = null,
+                    deviceTypesMatchType = null,
+                    seenSurveyWaitPeriodInDays = null,
+                    events =
+                        SurveyEventConditions(
+                            repeatedActivation = true,
+                            values = eventConditions,
+                        ),
+                ),
+            appearance = null,
+            currentIteration = null,
+            currentIterationStartDate = null,
+            startDate = java.util.Date(),
+            endDate = null,
+            schedule = null,
+        )
+    }
+
+    @Test
+    fun `event without property filters activates survey on matching event name`() {
+        val integration = createIntegration()
+        val survey = createSurvey("s1", listOf(SurveyEventCondition(name = "purchase")))
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("purchase", mapOf("amount" to 100))
+
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `event with exact property filter activates only when property matches`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "product_type" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("premium"),
+                                        operator = SurveyMatchType.EXACT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        // Non-matching property
+        integration.onEvent("purchase", mapOf("product_type" to "basic"))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+
+        // Matching property
+        integration.onEvent("purchase", mapOf("product_type" to "premium"))
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `event with gt property filter activates only when value is greater`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "amount" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("100"),
+                                        operator = SurveyMatchType.GT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("purchase", mapOf("amount" to 50))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+
+        integration.onEvent("purchase", mapOf("amount" to 150))
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `event with lt property filter activates only when value is less`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "amount" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("100"),
+                                        operator = SurveyMatchType.LT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("purchase", mapOf("amount" to 150))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+
+        integration.onEvent("purchase", mapOf("amount" to 50))
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `event with multiple property filters requires all to match`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "product_type" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("premium"),
+                                        operator = SurveyMatchType.EXACT,
+                                    ),
+                                "amount" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("100"),
+                                        operator = SurveyMatchType.GT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        // Only one matches
+        integration.onEvent("purchase", mapOf("product_type" to "premium", "amount" to 50))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+
+        // Both match
+        integration.onEvent("purchase", mapOf("product_type" to "premium", "amount" to 200))
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `missing event property does not activate survey`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "product_type" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("premium"),
+                                        operator = SurveyMatchType.EXACT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("purchase", mapOf("other_prop" to "value"))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+
+        integration.onEvent("purchase", null)
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+    }
+
+    @Test
+    fun `icontains property filter matches case-insensitively`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "search",
+                        propertyFilters =
+                            mapOf(
+                                "query" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("product"),
+                                        operator = SurveyMatchType.I_CONTAINS,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("search", mapOf("query" to "New PRODUCT features"))
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `is_not property filter excludes matching values`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "status" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("cancelled"),
+                                        operator = SurveyMatchType.IS_NOT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("purchase", mapOf("status" to "cancelled"))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+
+        integration.onEvent("purchase", mapOf("status" to "completed"))
+        assertTrue(integration.getActiveMatchingSurveys().any { it.id == "s1" })
+    }
+
+    @Test
+    fun `non-matching event name does not activate survey even with matching properties`() {
+        val integration = createIntegration()
+        val survey =
+            createSurvey(
+                "s1",
+                listOf(
+                    SurveyEventCondition(
+                        name = "purchase",
+                        propertyFilters =
+                            mapOf(
+                                "product_type" to
+                                    SurveyPropertyFilter(
+                                        values = listOf("premium"),
+                                        operator = SurveyMatchType.EXACT,
+                                    ),
+                            ),
+                    ),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        integration.onEvent("page_view", mapOf("product_type" to "premium"))
+        assertTrue(integration.getActiveMatchingSurveys().isEmpty())
+    }
+}

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -1276,8 +1276,12 @@ public final class com/posthog/internal/replay/RRWireframe {
 }
 
 public abstract interface class com/posthog/internal/surveys/PostHogSurveysHandler {
-	public abstract fun onEvent (Ljava/lang/String;)V
+	public abstract fun onEvent (Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun onSurveysLoaded (Ljava/util/List;)V
+}
+
+public final class com/posthog/internal/surveys/PostHogSurveysHandler$DefaultImpls {
+	public static synthetic fun onEvent$default (Lcom/posthog/internal/surveys/PostHogSurveysHandler;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
 public final class com/posthog/internal/surveys/SurveyUtilsKt {
@@ -1708,12 +1712,15 @@ public final class com/posthog/surveys/SurveyConditions {
 }
 
 public final class com/posthog/surveys/SurveyEventCondition {
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/posthog/surveys/SurveyEventCondition;
-	public static synthetic fun copy$default (Lcom/posthog/surveys/SurveyEventCondition;Ljava/lang/String;ILjava/lang/Object;)Lcom/posthog/surveys/SurveyEventCondition;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcom/posthog/surveys/SurveyEventCondition;
+	public static synthetic fun copy$default (Lcom/posthog/surveys/SurveyEventCondition;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/surveys/SurveyEventCondition;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
+	public final fun getPropertyFilters ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1747,8 +1754,10 @@ public final class com/posthog/surveys/SurveyFeatureFlagKeyValue {
 public final class com/posthog/surveys/SurveyMatchType : java/lang/Enum {
 	public static final field Companion Lcom/posthog/surveys/SurveyMatchType$Companion;
 	public static final field EXACT Lcom/posthog/surveys/SurveyMatchType;
+	public static final field GT Lcom/posthog/surveys/SurveyMatchType;
 	public static final field IS_NOT Lcom/posthog/surveys/SurveyMatchType;
 	public static final field I_CONTAINS Lcom/posthog/surveys/SurveyMatchType;
+	public static final field LT Lcom/posthog/surveys/SurveyMatchType;
 	public static final field NOT_I_CONTAINS Lcom/posthog/surveys/SurveyMatchType;
 	public static final field NOT_REGEX Lcom/posthog/surveys/SurveyMatchType;
 	public static final field REGEX Lcom/posthog/surveys/SurveyMatchType;
@@ -1759,6 +1768,12 @@ public final class com/posthog/surveys/SurveyMatchType : java/lang/Enum {
 
 public final class com/posthog/surveys/SurveyMatchType$Companion {
 	public final fun fromValue (Ljava/lang/String;)Lcom/posthog/surveys/SurveyMatchType;
+}
+
+public final class com/posthog/surveys/SurveyPropertyFilter {
+	public fun <init> (Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;)V
+	public final fun getOperator ()Lcom/posthog/surveys/SurveyMatchType;
+	public final fun getValues ()Ljava/util/List;
 }
 
 public class com/posthog/surveys/SurveyQuestion {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -536,7 +536,7 @@ public class PostHog private constructor(
                     timestamp,
                 )
                 // Notify surveys integration about the event
-                surveysHandler?.onEvent(event)
+                surveysHandler?.onEvent(event, mergedProperties)
             }
         } catch (e: Throwable) {
             config?.logger?.log("Capture failed: $e.")

--- a/posthog/src/main/java/com/posthog/internal/surveys/PostHogSurveysHandler.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/PostHogSurveysHandler.kt
@@ -8,7 +8,10 @@ public interface PostHogSurveysHandler {
     /**
      * To be called by Posthog when an event is captured
      */
-    public fun onEvent(event: String)
+    public fun onEvent(
+        event: String,
+        properties: Map<String, Any>? = null,
+    )
 
     /**
      * Notifies the integration that surveys have been loaded or updated from remote config.

--- a/posthog/src/main/java/com/posthog/surveys/SurveyEnums.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyEnums.kt
@@ -63,6 +63,8 @@ public enum class SurveyMatchType(public val value: String) {
     IS_NOT("is_not"),
     I_CONTAINS("icontains"),
     NOT_I_CONTAINS("not_icontains"),
+    GT("gt"),
+    LT("lt"),
     ;
 
     public companion object {
@@ -74,6 +76,8 @@ public enum class SurveyMatchType(public val value: String) {
                 "is_not" -> IS_NOT
                 "icontains" -> I_CONTAINS
                 "not_icontains" -> NOT_I_CONTAINS
+                "gt" -> GT
+                "lt" -> LT
                 else -> null
             }
         }

--- a/posthog/src/main/java/com/posthog/surveys/SurveyEventCondition.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyEventCondition.kt
@@ -2,4 +2,5 @@ package com.posthog.surveys
 
 public data class SurveyEventCondition(
     val name: String,
+    val propertyFilters: Map<String, SurveyPropertyFilter>? = null,
 )

--- a/posthog/src/main/java/com/posthog/surveys/SurveyPropertyFilter.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyPropertyFilter.kt
@@ -1,0 +1,6 @@
+package com.posthog.surveys
+
+public class SurveyPropertyFilter(
+    public val values: List<String>,
+    public val operator: SurveyMatchType,
+)


### PR DESCRIPTION
## 💡 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

android does not support survey event property filters - adding it!

closes https://github.com/PostHog/posthog-android/issues/392


## 💚 How did you test it?

unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
