### PR TITLE
fix: session replay throttling is broken

### DIFF
--- a/.changeset/heavy-pets-love.md
+++ b/.changeset/heavy-pets-love.md
@@ -1,0 +1,6 @@
+---
+"posthog-android": patch
+---
+
+fix: session replay callback parameters were swapped, causing throttling to not work correctly and stopSessionRecording() to appear broken
+

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -437,6 +437,9 @@ public class PostHogReplayIntegration(
         viewRef: WeakReference<View>,
         windowRef: WeakReference<Window>,
     ) {
+        // Early bail if stopped and this is processing previous generateSnapshot() from executor.submit
+        if (!isActive()) return  
+
         val view = viewRef.get() ?: return
         val status = decorViews[view] ?: return
         val window = windowRef.get() ?: return

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -438,7 +438,7 @@ public class PostHogReplayIntegration(
         windowRef: WeakReference<Window>,
     ) {
         // Early bail if stopped and this is processing previous generateSnapshot() from executor.submit
-        if (!isActive()) return  
+        if (!isActive()) return
 
         val view = viewRef.get() ?: return
         val status = decorViews[view] ?: return

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/NextDrawListener.kt
@@ -40,7 +40,7 @@ internal class NextDrawListener(
             onDrawThrottlerCallback: () -> Unit,
         ): NextDrawListener {
             val nextDrawListener =
-                NextDrawListener(this, mainHandler, dateProvider, throttleDelayMs, onDrawThrottlerCallback, onDrawCallback)
+                NextDrawListener(this, mainHandler, dateProvider, throttleDelayMs, onDrawCallback, onDrawThrottlerCallback)
             nextDrawListener.safelyRegisterForNextDraw()
             return nextDrawListener
         }


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue: https://posthoghelp.zendesk.com/agent/tickets/53725 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/55294)

Callback parameters in `NextDrawListener.onNextDraw()` were passed in the wrong order to the constructor, which means that throttling logic was being bypassed all-together. This basically caused the snapshot generation callback to ran on every draw instead of being throttled. As a result, stopSessionRecording() appears broken because: 
- generation of snapshots (not snapshots themselves) are queued through [executor.submit {}](https://github.com/PostHog/posthog-android/blob/5db2dc9a47f59ff72c24bfa535856127361e6d15/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt#L200-L206). 
- with throttling off this means that the queue was growing large, so even after `stopSessionRecording()` and `isActive = false`, the SDK was still draining and capturing the previous generateSnapshot() requests

Fix: 
- Fixed the constructor parameters to bring throttling back
- Add a `isActive` check in generateSnapshot() since these may be delayed calls



## :green_heart: How did you test it?

Manual test using sample app. 
- Before the fix I could see $snapshots being captured even after calling StopSessionRecording()
- After the fix I see that no more $snapshots events are being captured

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
