### PR TITLE
feat: add device bucketing support

### DIFF
--- a/.changeset/device-bucketing.md
+++ b/.changeset/device-bucketing.md
@@ -1,0 +1,5 @@
+---
+"posthog": minor
+---
+
+feat: add device bucketing support for stable feature flag assignment across identity changes

--- a/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogFake.kt
@@ -167,6 +167,10 @@ public class PostHogFake : PostHogInterface {
         return ""
     }
 
+    override fun getDeviceId(): String {
+        return ""
+    }
+
     override fun debug(enable: Boolean) {
     }
 

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -293,7 +293,14 @@ internal class PostHogFeatureFlags(
         }
 
         return try {
-            val response = api.flags(distinctId, anonymousId = null, groups = groups, personProperties = personProperties, groupProperties = groupProperties)
+            val response =
+                api.flags(
+                    distinctId,
+                    anonymousId = null,
+                    groups = groups,
+                    personProperties = personProperties,
+                    groupProperties = groupProperties,
+                )
             val flags = response?.flags
             cache.put(
                 cacheKey,

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -293,7 +293,7 @@ internal class PostHogFeatureFlags(
         }
 
         return try {
-            val response = api.flags(distinctId, null, groups, personProperties, groupProperties)
+            val response = api.flags(distinctId, anonymousId = null, groups = groups, personProperties = personProperties, groupProperties = groupProperties)
             val flags = response?.flags
             cache.put(
                 cacheKey,

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -33,6 +33,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogStateless, com/posth
 	public fun endSession ()V
 	public fun flush ()V
 	public fun getConfig ()Lcom/posthog/PostHogConfig;
+	public fun getDeviceId ()Ljava/lang/String;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagResult (Ljava/lang/String;Ljava/lang/Boolean;)Lcom/posthog/FeatureFlagResult;
@@ -73,6 +74,7 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun endSession ()V
 	public fun flush ()V
 	public fun getConfig ()Lcom/posthog/PostHogConfig;
+	public fun getDeviceId ()Ljava/lang/String;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun getFeatureFlagResult (Ljava/lang/String;Ljava/lang/Boolean;)Lcom/posthog/FeatureFlagResult;
@@ -311,6 +313,7 @@ public abstract interface class com/posthog/PostHogInterface : com/posthog/PostH
 	public abstract fun distinctId ()Ljava/lang/String;
 	public abstract fun endSession ()V
 	public abstract fun getConfig ()Lcom/posthog/PostHogConfig;
+	public abstract fun getDeviceId ()Ljava/lang/String;
 	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;
 	public abstract fun getFeatureFlagPayload (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getFeatureFlagResult (Ljava/lang/String;Ljava/lang/Boolean;)Lcom/posthog/FeatureFlagResult;
@@ -634,8 +637,8 @@ public final class com/posthog/internal/MultiVariateConfig {
 public final class com/posthog/internal/PostHogApi {
 	public fun <init> (Lcom/posthog/PostHogConfig;)V
 	public final fun batch (Ljava/util/List;)V
-	public final fun flags (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/internal/PostHogFlagsResponse;
-	public static synthetic fun flags$default (Lcom/posthog/internal/PostHogApi;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public final fun flags (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/internal/PostHogFlagsResponse;
+	public static synthetic fun flags$default (Lcom/posthog/internal/PostHogApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/internal/PostHogFlagsResponse;
 	public final fun localEvaluation (Ljava/lang/String;Ljava/lang/String;)Lcom/posthog/internal/LocalEvaluationApiResponse;
 	public static synthetic fun localEvaluation$default (Lcom/posthog/internal/PostHogApi;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/posthog/internal/LocalEvaluationApiResponse;
 	public final fun remoteConfig ()Lcom/posthog/internal/PostHogRemoteConfigResponse;
@@ -781,6 +784,7 @@ public abstract interface class com/posthog/internal/PostHogPreferences {
 	public static final field ANONYMOUS_ID Ljava/lang/String;
 	public static final field BUILD Ljava/lang/String;
 	public static final field Companion Lcom/posthog/internal/PostHogPreferences$Companion;
+	public static final field DEVICE_ID Ljava/lang/String;
 	public static final field DISTINCT_ID Ljava/lang/String;
 	public static final field GROUPS Ljava/lang/String;
 	public static final field LAST_SEEN_SURVEY_DATE Ljava/lang/String;
@@ -797,6 +801,7 @@ public abstract interface class com/posthog/internal/PostHogPreferences {
 public final class com/posthog/internal/PostHogPreferences$Companion {
 	public static final field ANONYMOUS_ID Ljava/lang/String;
 	public static final field BUILD Ljava/lang/String;
+	public static final field DEVICE_ID Ljava/lang/String;
 	public static final field DISTINCT_ID Ljava/lang/String;
 	public static final field GROUPS Ljava/lang/String;
 	public static final field LAST_SEEN_SURVEY_DATE Ljava/lang/String;

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -10,6 +10,7 @@ import com.posthog.internal.PostHogOnRemoteConfigLoaded
 import com.posthog.internal.PostHogPreferences.Companion.ALL_INTERNAL_KEYS
 import com.posthog.internal.PostHogPreferences.Companion.ANONYMOUS_ID
 import com.posthog.internal.PostHogPreferences.Companion.BUILD
+import com.posthog.internal.PostHogPreferences.Companion.DEVICE_ID
 import com.posthog.internal.PostHogPreferences.Companion.DISTINCT_ID
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
@@ -175,6 +176,12 @@ public class PostHog private constructor(
 
                 legacyPreferences(config, config.serializer)
 
+                // Initialize device_id if not already set. This provides a stable identifier
+                // for device-level feature flag bucketing that survives identify() and reset().
+                // We seed it from the anonymous ID at init time; once set, it never changes
+                // unless the app is reinstalled or local storage is cleared.
+                initDeviceId()
+
                 super.enabled = true
 
                 queue.start()
@@ -333,6 +340,16 @@ public class PostHog private constructor(
         set(value) {
             getPreferences().setValue(DISTINCT_ID, value)
         }
+
+    private fun initDeviceId() {
+        val existing = getPreferences().getValue(DEVICE_ID) as? String
+        if (existing.isNullOrBlank()) {
+            val anonId = anonymousId
+            if (anonId.isNotBlank()) {
+                getPreferences().setValue(DEVICE_ID, anonId)
+            }
+        }
+    }
 
     private var isIdentified: Boolean = false
         get() {
@@ -1224,9 +1241,10 @@ public class PostHog private constructor(
             return
         }
 
-        // only remove properties, preserve BUILD and VERSION keys in order to fix over-sending
-        // of 'Application Installed' events and under-sending of 'Application Updated' events
-        val except = mutableListOf(VERSION, BUILD)
+        // Preserve BUILD and VERSION to prevent over-sending "Application Installed" events
+        // and under-sending "Application Updated" events. Preserve DEVICE_ID to maintain
+        // stable feature flag bucketing across identity changes.
+        val except = mutableListOf(VERSION, BUILD, DEVICE_ID)
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)
         if (config?.reuseAnonymousId == true) {
@@ -1281,6 +1299,23 @@ public class PostHog private constructor(
             return ""
         }
         return distinctId
+    }
+
+    override fun getDeviceId(): String {
+        if (!isEnabled()) {
+            return ""
+        }
+        val deviceId = getPreferences().getValue(DEVICE_ID) as? String
+        if (deviceId.isNullOrBlank()) {
+            // Lazy init for upgrades: existing installs won't have a device_id yet
+            val anonId = anonymousId
+            if (anonId.isNotBlank()) {
+                getPreferences().setValue(DEVICE_ID, anonId)
+                return anonId
+            }
+            return ""
+        }
+        return deviceId
     }
 
     override fun startSession() {
@@ -1626,6 +1661,8 @@ public class PostHog private constructor(
         }
 
         override fun distinctId(): String = shared.distinctId()
+
+        override fun getDeviceId(): String = shared.getDeviceId()
 
         override fun debug(enable: Boolean) {
             shared.debug(enable)

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -54,6 +54,7 @@ public class PostHog private constructor(
     private val reloadFeatureFlags: Boolean = true,
 ) : PostHogInterface, PostHogStateless() {
     private val anonymousLock = Any()
+    private val deviceIdLock = Any()
     private val identifiedLock = Any()
     private val groupsLock = Any()
     private val personProcessingLock: Any = Any()
@@ -176,11 +177,10 @@ public class PostHog private constructor(
 
                 legacyPreferences(config, config.serializer)
 
-                // Initialize device_id if not already set. This provides a stable identifier
-                // for device-level feature flag bucketing that survives identify() and reset().
-                // We seed it from the anonymous ID at init time; once set, it never changes
-                // unless the app is reinstalled or local storage is cleared.
-                initDeviceId()
+                // Initialize device_id if not already set. getDeviceId() handles lazy init
+                // by seeding from the anonymous ID, providing a stable identifier for
+                // device-level feature flag bucketing that survives identify() and reset().
+                getDeviceId()
 
                 super.enabled = true
 
@@ -340,16 +340,6 @@ public class PostHog private constructor(
         set(value) {
             getPreferences().setValue(DISTINCT_ID, value)
         }
-
-    private fun initDeviceId() {
-        val existing = getPreferences().getValue(DEVICE_ID) as? String
-        if (existing.isNullOrBlank()) {
-            val anonId = anonymousId
-            if (anonId.isNotBlank()) {
-                getPreferences().setValue(DEVICE_ID, anonId)
-            }
-        }
-    }
 
     private var isIdentified: Boolean = false
         get() {
@@ -1305,17 +1295,19 @@ public class PostHog private constructor(
         if (!isEnabled()) {
             return ""
         }
-        val deviceId = getPreferences().getValue(DEVICE_ID) as? String
-        if (deviceId.isNullOrBlank()) {
-            // Lazy init for upgrades: existing installs won't have a device_id yet
-            val anonId = anonymousId
-            if (anonId.isNotBlank()) {
-                getPreferences().setValue(DEVICE_ID, anonId)
-                return anonId
+        synchronized(deviceIdLock) {
+            val deviceId = getPreferences().getValue(DEVICE_ID) as? String
+            if (deviceId.isNullOrBlank()) {
+                // Lazy init for upgrades: existing installs won't have a device_id yet
+                val anonId = anonymousId
+                if (anonId.isNotBlank()) {
+                    getPreferences().setValue(DEVICE_ID, anonId)
+                    return anonId
+                }
+                return ""
             }
-            return ""
+            return deviceId
         }
-        return deviceId
     }
 
     override fun startSession() {

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -155,6 +155,15 @@ public interface PostHogInterface : PostHogCoreInterface {
     public fun distinctId(): String
 
     /**
+     * Returns the stable device identifier used for device-level feature flag bucketing.
+     * This ID persists across [identify] and [reset] calls, only changing on a fresh
+     * app install, manual cache clearing, or OS-initiated storage cleanup.
+     *
+     * @return The device ID, or an empty string if not yet initialized
+     */
+    public fun getDeviceId(): String
+
+    /**
      * Starts a session
      * The SDK will automatically start a session when you call [setup]
      * On Android, the SDK will automatically start a session when the app is in the foreground

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -134,6 +134,7 @@ public class PostHogApi(
     public fun flags(
         distinctId: String,
         anonymousId: String? = null,
+        deviceId: String? = null,
         groups: Map<String, String>? = null,
         personProperties: Map<String, Any?>? = null,
         groupProperties: Map<String, Map<String, Any?>>? = null,
@@ -143,6 +144,7 @@ public class PostHogApi(
                 config.apiKey,
                 distinctId,
                 anonymousId = anonymousId,
+                deviceId = deviceId,
                 groups,
                 personProperties,
                 groupProperties,

--- a/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
@@ -9,6 +9,7 @@ internal class PostHogFlagsRequest(
     apiKey: String,
     distinctId: String,
     anonymousId: String? = null,
+    deviceId: String? = null,
     groups: Map<String, String>? = null,
     personProperties: Map<String, Any?>? = null,
     groupProperties: Map<String, Map<String, Any?>>? = null,
@@ -20,6 +21,9 @@ internal class PostHogFlagsRequest(
         this["timezone"] = TimeZone.getDefault().id
         if (!anonymousId.isNullOrBlank()) {
             this["\$anon_distinct_id"] = anonymousId
+        }
+        if (!deviceId.isNullOrBlank()) {
+            this["\$device_id"] = deviceId
         }
         if (groups?.isNotEmpty() == true) {
             this["groups"] = groups

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -46,6 +46,7 @@ public interface PostHogPreferences {
         public const val LAST_SEEN_SURVEY_DATE: String = "lastSeenSurveyDate"
         public const val VERSION: String = "version"
         public const val BUILD: String = "build"
+        public const val DEVICE_ID: String = "deviceId"
         public const val STRINGIFIED_KEYS: String = "stringifiedKeys"
 
         public val ALL_INTERNAL_KEYS: Set<String> =
@@ -64,6 +65,7 @@ public interface PostHogPreferences {
                 LAST_SEEN_SURVEY_DATE,
                 VERSION,
                 BUILD,
+                DEVICE_ID,
                 STRINGIFIED_KEYS,
                 FEATURE_FLAG_REQUEST_ID,
                 FEATURE_FLAG_EVALUATED_AT,

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -5,6 +5,7 @@ import com.posthog.PostHogConfig
 import com.posthog.PostHogInternal
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.internal.PostHogPreferences.Companion.CAPTURE_PERFORMANCE
+import com.posthog.internal.PostHogPreferences.Companion.DEVICE_ID
 import com.posthog.internal.PostHogPreferences.Companion.ERROR_TRACKING
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAGS_PAYLOAD
@@ -529,10 +530,13 @@ public class PostHogRemoteConfig(
         }
 
         try {
+            val deviceId = config.cachePreferences?.getValue(DEVICE_ID) as? String
+
             val response =
                 api.flags(
                     distinctId,
                     anonymousId = anonymousId,
+                    deviceId = deviceId,
                     groups = groups,
                     personProperties = getPersonPropertiesForFlags(),
                     groupProperties = getGroupPropertiesForFlags(),

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -3016,4 +3016,176 @@ internal class PostHogTest {
 
         sut.close()
     }
+
+    @Test
+    fun `getDeviceId returns a non-empty value after setup`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false)
+
+        val deviceId = sut.getDeviceId()
+        assertTrue(deviceId.isNotBlank())
+
+        sut.close()
+    }
+
+    @Test
+    fun `getDeviceId equals anonymousId on first init`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val cachePreferences = PostHogMemoryPreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = cachePreferences)
+
+        val deviceId = sut.getDeviceId()
+        val distinctId = sut.distinctId()
+
+        // On first init with no identify, distinctId equals the anonymous ID
+        assertEquals(distinctId, deviceId)
+
+        sut.close()
+    }
+
+    @Test
+    fun `getDeviceId persists across SDK restarts`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val cachePreferences = PostHogMemoryPreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = cachePreferences)
+
+        val originalDeviceId = sut.getDeviceId()
+        sut.close()
+
+        // Re-init with same preferences
+        val sut2 = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = cachePreferences)
+
+        assertEquals(originalDeviceId, sut2.getDeviceId())
+
+        sut2.close()
+    }
+
+    @Test
+    fun `getDeviceId is preserved across identify`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, personProfiles = PersonProfiles.ALWAYS)
+
+        val originalDeviceId = sut.getDeviceId()
+        sut.identify("user-123")
+
+        assertEquals(originalDeviceId, sut.getDeviceId())
+        assertEquals("user-123", sut.distinctId())
+
+        sut.close()
+    }
+
+    @Test
+    fun `getDeviceId is preserved across reset`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, personProfiles = PersonProfiles.ALWAYS)
+
+        val originalDeviceId = sut.getDeviceId()
+        sut.identify("user-123")
+        sut.reset()
+
+        assertEquals(originalDeviceId, sut.getDeviceId())
+        // distinct_id should have changed after reset
+        assertNotEquals("user-123", sut.distinctId())
+
+        sut.close()
+    }
+
+    @Test
+    fun `device_id is sent in flags request`() {
+        val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
+        val responseFlagsApi = file.readText()
+
+        val http =
+            mockHttp(
+                response =
+                    MockResponse()
+                        .setBody(responseFlagsApi),
+            )
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false)
+
+        val deviceId = sut.getDeviceId()
+        assertTrue(deviceId.isNotBlank())
+
+        sut.reloadFeatureFlags()
+        remoteConfigExecutor.shutdownAndAwaitTermination()
+
+        val request = http.takeRequest()
+        val body = request.body.unGzip()
+        val flagsRequest = serializer.deserialize<Map<String, Any>>(body.reader())
+
+        assertEquals(deviceId, flagsRequest["\$device_id"])
+
+        sut.close()
+    }
+
+    @Test
+    fun `device_id remains the same in flags request after identify`() {
+        val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
+        val responseFlagsApi = file.readText()
+
+        val http =
+            mockHttp(
+                total = 3,
+                response =
+                    MockResponse()
+                        .setBody(responseFlagsApi),
+            )
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, personProfiles = PersonProfiles.ALWAYS)
+
+        val deviceId = sut.getDeviceId()
+        sut.identify("user-123")
+
+        // Drain the $identify batch event that gets flushed automatically
+        queueExecutor.awaitExecution()
+        http.takeRequest()
+
+        sut.reloadFeatureFlags()
+        remoteConfigExecutor.shutdownAndAwaitTermination()
+
+        val request = http.takeRequest()
+        val body = request.body.unGzip()
+        val flagsRequest = serializer.deserialize<Map<String, Any>>(body.reader())
+
+        assertEquals(deviceId, flagsRequest["\$device_id"])
+
+        sut.close()
+    }
+
+    @Test
+    fun `getDeviceId lazy-inits for upgrades from older SDK versions`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        // Simulate an upgrade: preferences have an anonymous ID but no device_id
+        val cachePreferences = PostHogMemoryPreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = cachePreferences)
+
+        // The device_id should have been initialized during setup
+        val deviceId = sut.getDeviceId()
+        assertTrue(deviceId.isNotBlank())
+
+        // Clear the device_id to simulate an upgrade scenario where initDeviceId wasn't called
+        cachePreferences.remove("deviceId")
+
+        // getDeviceId should lazy-init from the anonymous ID
+        val lazyDeviceId = sut.getDeviceId()
+        assertTrue(lazyDeviceId.isNotBlank())
+        assertEquals(deviceId, lazyDeviceId)
+
+        sut.close()
+    }
 }

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -101,7 +101,7 @@ internal class PostHogApiTest {
 
         val sut = getSut(host = url.toString())
 
-        val response = sut.flags("distinctId", anonymousId = "anonId", emptyMap())
+        val response = sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
 
         val request = http.takeRequest()
 
@@ -123,7 +123,7 @@ internal class PostHogApiTest {
 
         val exc =
             assertThrows(PostHogApiError::class.java) {
-                sut.flags("distinctId", anonymousId = "anonId", emptyMap())
+                sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
             }
         assertEquals(400, exc.statusCode)
         assertEquals("Client Error", exc.message)
@@ -383,7 +383,7 @@ internal class PostHogApiTest {
 
         val sut = getSut(host = url.toString(), debug = true, logger = logger)
 
-        sut.flags("distinctId", anonymousId = "anonId", emptyMap())
+        sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
 
         assertTrue(
             logger.messages.any { it.contains("Request headers for") && it.contains("/flags") },

--- a/posthog/src/test/java/com/posthog/internal/PostHogFlagsRequestTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFlagsRequestTest.kt
@@ -17,7 +17,7 @@ internal class PostHogFlagsRequestTest {
                 API_KEY,
                 DISTINCT_ID,
                 anonymousId = ANON_ID,
-                groups,
+                groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
             )
@@ -66,5 +66,36 @@ internal class PostHogFlagsRequestTest {
         assertEquals(API_KEY, request["api_key"])
         assertEquals(DISTINCT_ID, request["distinct_id"])
         assertEquals(null, request["evaluation_contexts"])
+    }
+
+    @Test
+    fun `includes device_id when provided`() {
+        val request =
+            PostHogFlagsRequest(
+                API_KEY,
+                DISTINCT_ID,
+                deviceId = "device-123",
+            )
+
+        assertEquals("device-123", request["\$device_id"])
+    }
+
+    @Test
+    fun `excludes device_id when null`() {
+        val request = PostHogFlagsRequest(API_KEY, DISTINCT_ID)
+
+        assertEquals(null, request["\$device_id"])
+    }
+
+    @Test
+    fun `excludes device_id when blank`() {
+        val request =
+            PostHogFlagsRequest(
+                API_KEY,
+                DISTINCT_ID,
+                deviceId = "",
+            )
+
+        assertEquals(null, request["\$device_id"])
     }
 }


### PR DESCRIPTION
## Summary

- Adds a persistent `$device_id` to the Android SDK for stable device-level feature flag bucketing across identity changes
- The device ID is seeded from the anonymous ID on first init, persists across `identify()` and `reset()` calls, and is sent in `/flags` request payloads
- Ports the equivalent feature from [posthog-js#3340](https://github.com/PostHog/posthog-js/pull/3340) (React Native SDK) to Android

## Problem

Users running experiments targeting anonymous users see variant assignments flip when `identify()` or `reset()` changes the `distinct_id`. The hash changes, causing a different bucket and different variant for the same physical device.

## Changes

- **`PostHogPreferences`**: Add `DEVICE_ID` constant and include in `ALL_INTERNAL_KEYS`
- **`PostHogFlagsRequest`**: Add optional `deviceId` parameter, serialized as `$device_id`
- **`PostHogApi.flags()`**: Thread `deviceId` parameter to `PostHogFlagsRequest`
- **`PostHogRemoteConfig`**: Read `deviceId` from `cachePreferences` in `executeFeatureFlags()` and pass to API
- **`PostHog.kt`**:
  - `initDeviceId()` — seeds device_id from anonymous ID on first setup
  - `reset()` — preserves `DEVICE_ID` across resets (alongside `VERSION` and `BUILD`)
  - `getDeviceId()` — public method with lazy-init fallback for SDK upgrades
- **`PostHogInterface`**: Add `getDeviceId()` to public API surface

## Test plan

- [x] 3 new `PostHogFlagsRequestTest` tests (includes/excludes device_id)
- [x] 7 new `PostHogTest` tests (init, persistence, identify/reset preservation, flags payload, lazy-init upgrades)
- [x] All existing core tests pass (116 total)
- [x] All existing server tests pass