### PR TITLE
fix: ignore isLaidOut check for React Native replay

### DIFF
--- a/.changeset/quick-pigs-rule.md
+++ b/.changeset/quick-pigs-rule.md
@@ -1,0 +1,5 @@
+---
+'posthog-android': patch
+---
+
+Ignore `isLaidOut` checks for React Native session replay.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -66,6 +66,7 @@ import com.posthog.android.replay.internal.NextDrawListener.Companion.onNextDraw
 import com.posthog.android.replay.internal.ViewTreeSnapshotStatus
 import com.posthog.android.replay.internal.isAlive
 import com.posthog.android.replay.internal.isAliveAndAttachedToWindow
+import com.posthog.internal.PostHogSessionManager
 import com.posthog.internal.PostHogThreadFactory
 import com.posthog.internal.replay.PostHogSessionReplayHandler
 import com.posthog.internal.replay.RRCustomEvent
@@ -671,7 +672,7 @@ public class PostHogReplayIntegration(
     private fun View.isViewStateStableForMatrixOperations(): Boolean {
         return try {
             isAttachedToWindow &&
-                isLaidOut &&
+                (isLaidOut || PostHogSessionManager.isReactNative) &&
                 // Check if view has valid dimensions
                 width > 0 && height > 0 &&
                 // Check if view is not in layout transition (API 18+)


### PR DESCRIPTION
## :bulb: Motivation and Context
Possible fix for https://github.com/PostHog/posthog-js/issues/3346.
and https://posthog.slack.com/archives/C089TNZQF19/p1775162582175299

React Native session replay views can reach this path before Android reports them as laid out, which causes the stability check to reject otherwise valid views.

## :green_heart: How did you test it?
- Ran `./gradlew :posthog-android:compileDebugKotlin`

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes
- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
