### PR TITLE
fix: move getDeviceId() after enabled=true and add android to changeset

### DIFF
--- a/.changeset/device-bucketing.md
+++ b/.changeset/device-bucketing.md
@@ -1,5 +1,6 @@
 ---
 "posthog": minor
+"posthog-android": minor
 ---
 
 feat: add device bucketing support for stable feature flag assignment across identity changes

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -177,12 +177,12 @@ public class PostHog private constructor(
 
                 legacyPreferences(config, config.serializer)
 
+                super.enabled = true
+
                 // Initialize device_id if not already set. getDeviceId() handles lazy init
                 // by seeding from the anonymous ID, providing a stable identifier for
                 // device-level feature flag bucketing that survives identify() and reset().
                 getDeviceId()
-
-                super.enabled = true
 
                 queue.start()
 


### PR DESCRIPTION
## Summary
- Moves `getDeviceId()` call after `super.enabled = true` in `setup()` so `isEnabled()` doesn't short-circuit device ID initialization
- Adds `posthog-android` to the changeset for a proper minor version bump

Follow-up to #481 — these two issues were flagged in review but missed before merge.