### PR TITLE
docs: add sdk compliance adapter contributing guide

### DIFF
--- a/sdk_compliance_adapter/CONTRIBUTING.md
+++ b/sdk_compliance_adapter/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+This package contains the PostHog Android SDK compliance adapter used with the PostHog SDK Test Harness.
+
+## Prerequisites
+
+- x86_64 architecture for the full local test flow because of the Java 8 dependency
+- Java 8, 11, and 17 for local Gradle builds
+
+On Apple Silicon, Docker will use emulation. It is slower, but it works.
+
+## Building
+
+### Local build
+
+```bash
+./gradlew :sdk_compliance_adapter:build
+```
+
+### Docker build
+
+```bash
+docker build -f sdk_compliance_adapter/Dockerfile -t posthog-android-adapter .
+```
+
+The Dockerfile uses Gradle toolchain auto-download to fetch the required Java versions.
+
+## Running tests
+
+Tests run automatically in GitHub Actions on pushes to `main`/`master`, pull requests, and manual workflow dispatches.
+
+### Local Docker Compose run
+
+```bash
+cd sdk_compliance_adapter
+docker-compose up --build --abort-on-container-exit
+```
+
+This runs:
+
+- `test-harness` - compliance test runner
+- `adapter` - this SDK adapter
+- `mock-server` - mock PostHog server

--- a/sdk_compliance_adapter/IMPLEMENTATION_NOTES.md
+++ b/sdk_compliance_adapter/IMPLEMENTATION_NOTES.md
@@ -69,37 +69,11 @@ Note: When providing a custom httpClient, the SDK uses it as-is without adding t
 
 **These changes are backward compatible** - existing code works unchanged.
 
-## Building
+## Development workflow
 
-### Local Build (requires Java 8, 11, and 17)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local build and compliance test commands.
 
-```bash
-./gradlew :sdk_compliance_adapter:build
-```
-
-### Docker Build (recommended)
-
-```bash
-docker build -f sdk_compliance_adapter/Dockerfile -t posthog-android-adapter .
-```
-
-The Dockerfile uses Gradle toolchain auto-download to fetch required Java versions.
-
-## Running Tests
-
-### With Docker Compose
-
-```bash
-cd sdk_compliance_adapter
-docker-compose up --build --abort-on-container-exit
-```
-
-This runs:
-- **test-harness** - Compliance test runner
-- **adapter** - This SDK adapter
-- **mock-server** - Mock PostHog server
-
-### SDK Type
+## SDK Type
 
 The Android SDK uses **server SDK format**:
 - Endpoint: `/batch/`

--- a/sdk_compliance_adapter/README.md
+++ b/sdk_compliance_adapter/README.md
@@ -2,25 +2,9 @@
 
 This compliance adapter wraps the PostHog Android SDK and exposes a standardized HTTP API for automated compliance testing using the [PostHog SDK Test Harness](https://github.com/PostHog/posthog-sdk-test-harness).
 
-## Quick Start
+## Contributing
 
-### Running Tests in CI (Recommended)
-
-Tests run automatically in GitHub Actions on:
-- Push to `main`/`master` branch
-- Pull requests
-- Manual trigger via `workflow_dispatch`
-
-See `.github/workflows/sdk-compliance-tests.yml`
-
-### Running Tests Locally
-
-**Note:** Requires x86_64 architecture due to Java 8 dependency. On Apple Silicon, Docker will use emulation (slower but works).
-
-```bash
-cd sdk_compliance_adapter
-docker-compose up --build --abort-on-container-exit
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local build and compliance test instructions.
 
 ## Architecture
 


### PR DESCRIPTION
## :bulb: Motivation and Context

The Android repo already has package-level contributing guides, but the `sdk_compliance_adapter` development workflow was still documented in README-style files.

This PR adds a dedicated `sdk_compliance_adapter/CONTRIBUTING.md` and updates the other adapter docs to point to it.

## :green_heart: How did you test it?

- Not run (docs-only changes)
- Checked the updated markdown links and file locations

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
