### PR TITLE
chore: attach release info to proguard mapping upload

### DIFF
--- a/.changeset/attach-release-info-to-proguard-upload.md
+++ b/.changeset/attach-release-info-to-proguard-upload.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": minor
+---
+
+Attach release info (`applicationId`, `versionName`, `versionCode`) to proguard mapping uploads via the new posthog-cli `--release-name`, `--release-version`, and `--build` flags.

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
@@ -109,12 +109,16 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
         variant: ApplicationVariant,
         mappingFiles: Provider<FileCollection>,
     ): TaskProvider<PostHogUploadProguardMappingsTask> {
+        val primaryOutput = variant.outputs.firstOrNull()
         val uploadMapIdTask =
             PostHogUploadProguardMappingsTask.register(
                 project = project,
                 generateMapIdTask = generateMapIdTask,
                 mappingFiles = mappingFiles,
                 taskSuffix = variant.name.capitalizeUS(),
+                releaseName = variant.applicationId,
+                releaseVersion = primaryOutput?.versionName?.map { it.orEmpty() },
+                build = primaryOutput?.versionCode?.map { it?.toString().orEmpty() },
             )
         return uploadMapIdTask
     }

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
@@ -118,7 +118,7 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
                 taskSuffix = variant.name.capitalizeUS(),
                 releaseName = variant.applicationId,
                 releaseVersion = primaryOutput?.versionName?.map { it.orEmpty() },
-                build = primaryOutput?.versionCode?.map { it?.toString().orEmpty() },
+                build = primaryOutput?.versionCode,
             )
         return uploadMapIdTask
     }

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
@@ -5,9 +5,12 @@ package com.posthog.android
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
@@ -35,6 +38,18 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     public abstract var mappingsFiles: Provider<FileCollection>
+
+    @get:Input
+    @get:Optional
+    public abstract val releaseName: Property<String>
+
+    @get:Input
+    @get:Optional
+    public abstract val releaseVersion: Property<String>
+
+    @get:Input
+    @get:Optional
+    public abstract val build: Property<String>
 
     override fun exec() {
         if (!mappingsFiles.isPresent || mappingsFiles.get().isEmpty) {
@@ -65,6 +80,18 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
         args.add(mappingFile.toString())
         args.add("--map-id")
         args.add(uuid)
+        releaseName.orNull?.takeIf { it.isNotEmpty() }?.let {
+            args.add("--release-name")
+            args.add(it)
+        }
+        releaseVersion.orNull?.takeIf { it.isNotEmpty() }?.let {
+            args.add("--release-version")
+            args.add(it)
+        }
+        build.orNull?.takeIf { it.isNotEmpty() }?.let {
+            args.add("--build")
+            args.add(it)
+        }
     }
 
     internal companion object {
@@ -73,6 +100,9 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
             generateMapIdTask: Provider<PostHogGenerateMapIdTask>,
             mappingFiles: Provider<FileCollection>,
             taskSuffix: String = "",
+            releaseName: Provider<String>? = null,
+            releaseVersion: Provider<String>? = null,
+            build: Provider<String>? = null,
         ): TaskProvider<PostHogUploadProguardMappingsTask> {
             val uploadPostHogProguardMappingsTask =
                 project.tasks.register(
@@ -83,6 +113,9 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
                     workingDir(project.rootDir)
                     this.mapIdFile.set(generateMapIdTask.flatMap { it.outputFile })
                     this.mappingsFiles = mappingFiles
+                    releaseName?.let { this.releaseName.set(it) }
+                    releaseVersion?.let { this.releaseVersion.set(it) }
+                    build?.let { this.build.set(it) }
                 }
             return uploadPostHogProguardMappingsTask
         }

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
@@ -49,7 +49,7 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
 
     @get:Input
     @get:Optional
-    public abstract val build: Property<String>
+    public abstract val build: Property<Int?>
 
     override fun exec() {
         if (!mappingsFiles.isPresent || mappingsFiles.get().isEmpty) {
@@ -88,9 +88,9 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
             args.add("--release-version")
             args.add(it)
         }
-        build.orNull?.takeIf { it.isNotEmpty() }?.let {
+        build.orNull?.takeIf { it > 0 }?.let {
             args.add("--build")
-            args.add(it)
+            args.add(it.toString())
         }
     }
 
@@ -102,7 +102,7 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
             taskSuffix: String = "",
             releaseName: Provider<String>? = null,
             releaseVersion: Provider<String>? = null,
-            build: Provider<String>? = null,
+            build: Provider<Int?>? = null,
         ): TaskProvider<PostHogUploadProguardMappingsTask> {
             val uploadPostHogProguardMappingsTask =
                 project.tasks.register(


### PR DESCRIPTION
## :bulb: Motivation and Context

The posthog-cli's `exp proguard upload` accepts `--release-name`, `--release-version`, and `--build` (via flattened `ReleaseArgs`), but this plugin only passed `--path` and `--map-id`. As a result, proguard uploads either fell back to git-derived release info (repo name + commit SHA) or created no release association at all — not the app's actual release identity.

iOS (posthog-ios#558) and React Native (posthog-js) already attach this info on their symbol/sourcemap uploads. This PR brings Android to parity.

<img width="514" height="136" alt="Captura de pantalla 2026-04-17 a la(s) 1 27 59 p m" src="https://github.com/user-attachments/assets/5264f8ab-f927-47c1-ab46-ecf9db0f47e2" />


## :green_heart: How did you test it?

Built `:posthog-samples:posthog-android-sample:assembleRelease` twice against environment 381971:

**Before:**
```
posthog-cli exp proguard upload --path ... --map-id bbb498d5...
```
→ CLI auto-created release `posthog-android@eac1385...` (git repo name + commit SHA).

**After (with `versionCode=2`, `versionName="1.1"` for validation):**
```
posthog-cli exp proguard upload --path ... --map-id bbb498d5... \
  --release-name com.posthog.android.sample --release-version 1.1 --build 2
```
→ Release associated with the app's actual identity.

Empty-string values from the variant are filtered out so the CLI still falls back to git-derived info when `applicationId` / `versionName` / `versionCode` aren't set.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages