### PR TITLE
fix: trim whitespace from API keys and host config

### DIFF
--- a/.changeset/trim-whitespace-config-values.md
+++ b/.changeset/trim-whitespace-config-values.md
@@ -1,0 +1,7 @@
+---
+posthog-android: patch
+posthog: patch
+posthog-server: patch
+---
+
+Trim surrounding whitespace from API keys, personal API keys, and host config before using them.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -18,14 +18,14 @@ public open class PostHogConfig constructor(
     /**
      * The PostHog API Key
      */
-    public val apiKey: String,
+    apiKey: String,
     /**
      * The PostHog Host
      * Defaults to https://us.i.posthog.com
      * EU Host: https://eu.i.posthog.com
      *
      */
-    public val host: String = DEFAULT_HOST,
+    host: String = DEFAULT_HOST,
     /**
      * Logs the debug logs to the [logger] if enabled
      * Defaults to false
@@ -124,7 +124,7 @@ public open class PostHogConfig constructor(
      * Required when localEvaluation is true.
      * Defaults to null
      */
-    public var personalApiKey: String? = null,
+    personalApiKey: String? = null,
     /**
      * Interval in seconds for polling feature flag definitions for local evaluation
      * Defaults to 30 seconds
@@ -138,6 +138,25 @@ public open class PostHogConfig constructor(
      */
     public var evaluationContexts: List<String>? = null,
 ) {
+    /**
+     * The PostHog API Key
+     */
+    public val apiKey: String = apiKey.trim()
+
+    /**
+     * The PostHog Host
+     * Defaults to https://us.i.posthog.com
+     * EU Host: https://eu.i.posthog.com
+     */
+    public val host: String = host.trim().ifBlank { DEFAULT_HOST }
+
+    /**
+     * Personal API key for local evaluation
+     * Required when localEvaluation is true.
+     * Defaults to null
+     */
+    public var personalApiKey: String? = personalApiKey?.trim()?.ifBlank { null }
+
     private val beforeSendCallbacks = mutableListOf<PostHogBeforeSend>()
     private val integrations = mutableListOf<PostHogIntegration>()
 
@@ -290,9 +309,9 @@ public open class PostHogConfig constructor(
 
         public fun personalApiKey(personalApiKey: String?): Builder =
             apply {
-                this.personalApiKey = personalApiKey
+                this.personalApiKey = personalApiKey?.trim()?.ifBlank { null }
                 if (localEvaluation == null) {
-                    this.localEvaluation = personalApiKey != null
+                    this.localEvaluation = this.personalApiKey != null
                 }
             }
 

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -31,6 +31,34 @@ internal class PostHogConfigTest {
     }
 
     @Test
+    fun `trims whitespace-sensitive config values`() {
+        val config =
+            PostHogConfig(
+                apiKey = " \n$TEST_API_KEY\t ",
+                host = " \nhttps://eu.i.posthog.com/\t ",
+                personalApiKey = " \nphx_test_personal_api_key\t ",
+            )
+
+        assertEquals(TEST_API_KEY, config.apiKey)
+        assertEquals("https://eu.i.posthog.com/", config.host)
+        assertEquals("phx_test_personal_api_key", config.personalApiKey)
+    }
+
+    @Test
+    fun `defaults blank personal api key to null after trimming whitespace`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY, personalApiKey = " \n\t ")
+
+        assertNull(config.personalApiKey)
+    }
+
+    @Test
+    fun `defaults a blank host after trimming whitespace`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY, host = " \n\t ")
+
+        assertEquals(PostHogConfig.DEFAULT_HOST, config.host)
+    }
+
+    @Test
     fun `constructor sets all parameters when provided`() {
         val mockEncryption = createMockEncryption()
         val mockOnFeatureFlags = PostHogOnFeatureFlags { }
@@ -494,6 +522,28 @@ internal class PostHogConfigTest {
         val config =
             PostHogConfig.builder(TEST_API_KEY)
                 .personalApiKey(null)
+                .build()
+
+        assertNull(config.personalApiKey)
+        assertEquals(false, config.localEvaluation)
+    }
+
+    @Test
+    fun `builder personalApiKey trims whitespace and enables localEvaluation when not explicitly set`() {
+        val config =
+            PostHogConfig.builder(TEST_API_KEY)
+                .personalApiKey(" \ntest-personal-api-key\t ")
+                .build()
+
+        assertEquals("test-personal-api-key", config.personalApiKey)
+        assertEquals(true, config.localEvaluation)
+    }
+
+    @Test
+    fun `builder blank personalApiKey does not enable localEvaluation when not explicitly set`() {
+        val config =
+            PostHogConfig.builder(TEST_API_KEY)
+                .personalApiKey(" \n\t ")
                 .build()
 
         assertNull(config.personalApiKey)

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -99,6 +99,10 @@ public class PostHog private constructor(
                 config.logger =
                     if (config.logger is PostHogNoOpLogger) PostHogPrintLogger(config) else config.logger
 
+                if (config.apiKey.isEmpty()) {
+                    config.logger.log("apiKey is empty after trimming whitespace; check your project API key")
+                }
+
                 if (!apiKeys.add(config.apiKey)) {
                     config.logger.log("API Key: ${config.apiKey} already has a PostHog instance.")
                 }

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -315,12 +315,6 @@ public open class PostHogConfig(
     @PostHogInternal
     public var logger: PostHogLogger = PostHogNoOpLogger()
 
-    init {
-        if (this.apiKey.isEmpty()) {
-            logger.log("apiKey is empty after trimming whitespace; check your project API key")
-        }
-    }
-
     @PostHogInternal
     public val serializer: PostHogSerializer by lazy {
         PostHogSerializer(this)

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -31,14 +31,14 @@ public open class PostHogConfig(
     /**
      * The PostHog API Key
      */
-    public val apiKey: String,
+    apiKey: String,
     /**
      * The PostHog Host
      * Defaults to https://us.i.posthog.com
      * EU Host: https://eu.i.posthog.com
      *
      */
-    public val host: String = DEFAULT_HOST,
+    host: String = DEFAULT_HOST,
     /**
      * Logs the debug logs to the [logger] if enabled
      * Defaults to false
@@ -300,8 +300,26 @@ public open class PostHogConfig(
     @PostHogInternal
     public var httpClient: OkHttpClient? = null
 
+    /**
+     * The PostHog API Key
+     */
+    public val apiKey: String = apiKey.trim()
+
+    /**
+     * The PostHog Host
+     * Defaults to https://us.i.posthog.com
+     * EU Host: https://eu.i.posthog.com
+     */
+    public val host: String = host.trim().ifBlank { DEFAULT_HOST }
+
     @PostHogInternal
     public var logger: PostHogLogger = PostHogNoOpLogger()
+
+    init {
+        if (this.apiKey.isEmpty()) {
+            logger.log("apiKey is empty after trimming whitespace; check your project API key")
+        }
+    }
 
     @PostHogInternal
     public val serializer: PostHogSerializer by lazy {

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -53,6 +53,10 @@ public open class PostHogStateless protected constructor(
                 config.logger =
                     if (config.logger is PostHogNoOpLogger) PostHogPrintLogger(config) else config.logger
 
+                if (config.apiKey.isEmpty()) {
+                    config.logger.log("apiKey is empty after trimming whitespace; check your project API key")
+                }
+
                 if (!apiKeys.add(config.apiKey)) {
                     config.logger.log("API Key: ${config.apiKey} already has a PostHog instance.")
                 }

--- a/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
@@ -16,6 +16,21 @@ internal class PostHogConfigTest {
     }
 
     @Test
+    fun `trims whitespace-sensitive config values`() {
+        val config = PostHogConfig(" \n$API_KEY\t ", " \nhttps://eu.i.posthog.com/\t ")
+
+        assertEquals(API_KEY, config.apiKey)
+        assertEquals("https://eu.i.posthog.com/", config.host)
+    }
+
+    @Test
+    fun `defaults a blank host after trimming whitespace`() {
+        val config = PostHogConfig(API_KEY, " \n\t ")
+
+        assertEquals(PostHogConfig.DEFAULT_HOST, config.host)
+    }
+
+    @Test
     fun `debug is disabled by default`() {
         assertFalse(config.debug)
     }

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -237,6 +237,17 @@ internal class PostHogStatelessTest {
     }
 
     @Test
+    fun `setup logs empty trimmed api key after logger initialization`() {
+        sut = createStatelessInstance()
+        val mockLogger = MockLogger()
+        config = PostHogConfig(" \n\t ", "https://api.posthog.com").apply { logger = mockLogger }
+
+        sut.setup(config)
+
+        assertTrue(mockLogger.messages.any { it.contains("apiKey is empty after trimming whitespace") })
+    }
+
+    @Test
     fun `setup logs warning when called multiple times`() {
         sut = createStatelessInstance()
         config = createConfig()


### PR DESCRIPTION
## :bulb: Motivation and Context
This ports the whitespace-trimming fix from `posthog-go` to `posthog-android`. It trims surrounding spaces and line breaks from the project API key and host before using them so the SDK does not silently send invalid tokens or build broken endpoints from whitespace-polluted configuration.


## :green_heart: How did you test it?
- `./gradlew :posthog:test --tests com.posthog.PostHogConfigTest`


## :pencil: Checklist
- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
