### PR TITLE
feat: add tracing headers to OkHttp requests

### DIFF
--- a/.changeset/odd-swans-wave.md
+++ b/.changeset/odd-swans-wave.md
@@ -1,5 +1,6 @@
 ---
 'posthog': minor
+'posthog-android': minor
 ---
 
-Add tracing header support for OkHttp requests.
+Add tracing header support for Android OkHttp requests.

--- a/.changeset/odd-swans-wave.md
+++ b/.changeset/odd-swans-wave.md
@@ -1,0 +1,5 @@
+---
+'posthog': minor
+---
+
+Add tracing header support for OkHttp requests.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -171,7 +171,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getStoragePrefix ()Ljava/lang/String;
 	public final fun getSurveys ()Z
 	public final fun getSurveysConfig ()Lcom/posthog/surveys/PostHogSurveysConfig;
-	public final fun getTracingHeaders ()Ljava/util/List;
+	public final synthetic fun getTracingHeaders ()Ljava/util/List;
 	public final fun removeBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun removeIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun setCachePreferences (Lcom/posthog/internal/PostHogPreferences;)V

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -124,6 +124,7 @@ public class com/posthog/PostHogConfig {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
+	public final fun getAddTracingHeaders ()Ljava/util/List;
 	public final fun getApiKey ()Ljava/lang/String;
 	public final fun getBeforeSendList ()Ljava/util/List;
 	public final fun getCachePreferences ()Lcom/posthog/internal/PostHogPreferences;
@@ -173,6 +174,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getSurveysConfig ()Lcom/posthog/surveys/PostHogSurveysConfig;
 	public final fun removeBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun removeIntegration (Lcom/posthog/PostHogIntegration;)V
+	public final fun setAddTracingHeaders (Ljava/util/List;)V
 	public final fun setCachePreferences (Lcom/posthog/internal/PostHogPreferences;)V
 	public final fun setContext (Lcom/posthog/internal/PostHogContext;)V
 	public final fun setDateProvider (Lcom/posthog/internal/PostHogDateProvider;)V

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -124,7 +124,6 @@ public class com/posthog/PostHogConfig {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
-	public final fun getAddTracingHeaders ()Ljava/util/List;
 	public final fun getApiKey ()Ljava/lang/String;
 	public final fun getBeforeSendList ()Ljava/util/List;
 	public final fun getCachePreferences ()Lcom/posthog/internal/PostHogPreferences;
@@ -172,9 +171,9 @@ public class com/posthog/PostHogConfig {
 	public final fun getStoragePrefix ()Ljava/lang/String;
 	public final fun getSurveys ()Z
 	public final fun getSurveysConfig ()Lcom/posthog/surveys/PostHogSurveysConfig;
+	public final fun getTracingHeaders ()Ljava/util/List;
 	public final fun removeBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun removeIntegration (Lcom/posthog/PostHogIntegration;)V
-	public final fun setAddTracingHeaders (Ljava/util/List;)V
 	public final fun setCachePreferences (Lcom/posthog/internal/PostHogPreferences;)V
 	public final fun setContext (Lcom/posthog/internal/PostHogContext;)V
 	public final fun setDateProvider (Lcom/posthog/internal/PostHogDateProvider;)V
@@ -214,6 +213,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setStoragePrefix (Ljava/lang/String;)V
 	public final fun setSurveys (Z)V
 	public final fun setSurveysConfig (Lcom/posthog/surveys/PostHogSurveysConfig;)V
+	public final fun setTracingHeaders (Ljava/util/List;)V
 }
 
 public final class com/posthog/PostHogConfig$Companion {

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -299,7 +299,11 @@ public open class PostHogConfig(
      * - The Android SDK does not send `X-POSTHOG-WINDOW-ID` because mobile apps do not have a per-window/tab concept
      * - Existing values for these headers will be overwritten when PostHog provides a value
      */
-    public var addTracingHeaders: List<String>? = null
+    public var tracingHeaders: List<String>? = null
+        get() = field?.toList()
+        set(value) {
+            field = value?.toList()
+        }
 
     /**
      * Optional custom OkHttpClient for HTTP requests.

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -285,6 +285,9 @@ public open class PostHogConfig(
      */
     public var releaseIdentifier: String? = null,
 ) {
+    @Volatile
+    private var tracingHeadersList: List<String>? = null
+
     /**
      * When set, PostHog injects tracing headers into OkHttp requests whose destination hostname
      * exactly matches one of the configured hostnames.
@@ -298,11 +301,13 @@ public open class PostHogConfig(
      * - Hostname matching is exact and does not include ports or subdomain wildcards
      * - The Android SDK does not send `X-POSTHOG-WINDOW-ID` because mobile apps do not have a per-window/tab concept
      * - Existing values for these headers will be overwritten when PostHog provides a value
+     * - Reading this property returns a snapshot
      */
-    public var tracingHeaders: List<String>? = null
-        get() = field?.toList()
+    @get:JvmSynthetic
+    public var tracingHeaders: List<String>?
+        get() = tracingHeadersList?.let { ArrayList(it) }
         set(value) {
-            field = value?.toList()
+            tracingHeadersList = value?.let { ArrayList(it) }
         }
 
     /**

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -286,6 +286,22 @@ public open class PostHogConfig(
     public var releaseIdentifier: String? = null,
 ) {
     /**
+     * When set, PostHog injects tracing headers into OkHttp requests whose destination hostname
+     * exactly matches one of the configured hostnames.
+     *
+     * Injected headers:
+     * - `X-POSTHOG-DISTINCT-ID`
+     * - `X-POSTHOG-SESSION-ID`
+     *
+     * Notes:
+     * - Requires installing [PostHogOkHttpInterceptor] on each [OkHttpClient] that should send tracing headers
+     * - Hostname matching is exact and does not include ports or subdomain wildcards
+     * - The Android SDK does not send `X-POSTHOG-WINDOW-ID` because mobile apps do not have a per-window/tab concept
+     * - Existing values for these headers will be overwritten when PostHog provides a value
+     */
+    public var addTracingHeaders: List<String>? = null
+
+    /**
      * Optional custom OkHttpClient for HTTP requests.
      *
      * When set, the SDK will use this client instead of creating its own.

--- a/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
@@ -116,7 +116,7 @@ private fun addTracingHeadersToRequest(
         return request
     }
 
-    val normalizedHostnames = normalizeTracingHeaderHostnames(hostnames)
+    val normalizedHostnames = normalizeTracingHeaderHostnames(hostnames) ?: return request
     if (normalizedHostnames.isEmpty()) {
         return request
     }
@@ -139,11 +139,10 @@ private fun addTracingHeadersToRequest(
     return requestBuilder.build()
 }
 
-private fun normalizeTracingHeaderHostnames(hostnames: List<String>?): Set<String> {
+private fun normalizeTracingHeaderHostnames(hostnames: List<String>?): Set<String>? {
     return hostnames
         ?.asSequence()
         ?.map { it.trim().lowercase() }
         ?.filter { it.isNotEmpty() }
         ?.toSet()
-        ?: emptySet()
 }

--- a/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
@@ -6,6 +6,14 @@ import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 
+/**
+ * Interceptor that captures network telemetry for session replay and, when
+ * [PostHogConfig.addTracingHeaders] is configured, injects PostHog tracing headers into matching
+ * OkHttp requests.
+ *
+ * Install this interceptor on each [okhttp3.OkHttpClient] whose requests should be captured or
+ * annotated with tracing headers.
+ */
 public class PostHogOkHttpInterceptor(
     private var captureNetworkTelemetry: Boolean = true,
     private val postHog: PostHogInterface? = null,
@@ -13,29 +21,39 @@ public class PostHogOkHttpInterceptor(
     @JvmOverloads
     public constructor(captureNetworkTelemetry: Boolean = true) : this(captureNetworkTelemetry, null)
 
+    private val currentPostHog: PostHogInterface
+        get() = postHog ?: PostHog
+
     private val isSessionReplayActive: Boolean
         get() = postHog?.isSessionReplayActive() ?: PostHog.isSessionReplayActive()
 
     private val isNetworkCaptureEnabled: Boolean
         get() {
-            val config = (postHog ?: PostHog).getConfig<PostHogConfig>() ?: return true
+            val config = currentPostHog.getConfig<PostHogConfig>() ?: return true
             val remoteConfig = config.remoteConfigHolder
             // if remote config hasn't loaded yet, default to true (don't block locally enabled capture)
             return remoteConfig?.isCaptureNetworkTimingEnabled() ?: true
         }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val originalRequest = chain.request()
+        val request = addPostHogTracingHeaders(chain.request())
 
-        try {
-            val response = chain.proceed(originalRequest)
+        val response = chain.proceed(request)
 
-            captureNetworkEvent(originalRequest, response)
+        captureNetworkEvent(request, response)
 
-            return response
-        } catch (e: Throwable) {
-            throw e
-        }
+        return response
+    }
+
+    private fun addPostHogTracingHeaders(request: Request): Request {
+        val config = currentPostHog.getConfig<PostHogConfig>() ?: return request
+
+        return addTracingHeadersToRequest(
+            request = request,
+            hostnames = config.addTracingHeaders,
+            distinctId = currentPostHog.distinctId(),
+            sessionId = currentPostHog.getSessionId()?.toString(),
+        )
     }
 
     private fun captureNetworkEvent(
@@ -83,4 +101,45 @@ public class PostHogOkHttpInterceptor(
         // its not guaranteed that the posthog instance is set
         events.capture(postHog)
     }
+}
+
+private const val POSTHOG_DISTINCT_ID_HEADER = "X-POSTHOG-DISTINCT-ID"
+private const val POSTHOG_SESSION_ID_HEADER = "X-POSTHOG-SESSION-ID"
+
+private fun addTracingHeadersToRequest(
+    request: Request,
+    hostnames: List<String>?,
+    distinctId: String,
+    sessionId: String?,
+): Request {
+    val normalizedHostnames = normalizeTracingHeaderHostnames(hostnames)
+    if (normalizedHostnames.isEmpty()) {
+        return request
+    }
+
+    val requestHost = request.url.host.lowercase()
+    if (!normalizedHostnames.contains(requestHost)) {
+        return request
+    }
+
+    val requestBuilder = request.newBuilder()
+
+    if (!sessionId.isNullOrBlank()) {
+        requestBuilder.header(POSTHOG_SESSION_ID_HEADER, sessionId)
+    }
+
+    if (distinctId.isNotBlank()) {
+        requestBuilder.header(POSTHOG_DISTINCT_ID_HEADER, distinctId)
+    }
+
+    return requestBuilder.build()
+}
+
+private fun normalizeTracingHeaderHostnames(hostnames: List<String>?): Set<String> {
+    return hostnames
+        ?.asSequence()
+        ?.map { it.trim().lowercase() }
+        ?.filter { it.isNotEmpty() }
+        ?.toSet()
+        ?: emptySet()
 }

--- a/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
@@ -112,6 +112,10 @@ private fun addTracingHeadersToRequest(
     distinctId: String,
     sessionId: String?,
 ): Request {
+    if (sessionId.isNullOrBlank() && distinctId.isBlank()) {
+        return request
+    }
+
     val normalizedHostnames = normalizeTracingHeaderHostnames(hostnames)
     if (normalizedHostnames.isEmpty()) {
         return request

--- a/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt
@@ -8,7 +8,7 @@ import okhttp3.Response
 
 /**
  * Interceptor that captures network telemetry for session replay and, when
- * [PostHogConfig.addTracingHeaders] is configured, injects PostHog tracing headers into matching
+ * [PostHogConfig.tracingHeaders] is configured, injects PostHog tracing headers into matching
  * OkHttp requests.
  *
  * Install this interceptor on each [okhttp3.OkHttpClient] whose requests should be captured or
@@ -50,7 +50,7 @@ public class PostHogOkHttpInterceptor(
 
         return addTracingHeadersToRequest(
             request = request,
-            hostnames = config.addTracingHeaders,
+            hostnames = config.tracingHeaders,
             distinctId = currentPostHog.distinctId(),
             sessionId = currentPostHog.getSessionId()?.toString(),
         )

--- a/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
@@ -81,8 +81,18 @@ internal class PostHogConfigTest {
     }
 
     @Test
-    fun `addTracingHeaders is not set by default`() {
-        assertNull(config.addTracingHeaders)
+    fun `tracingHeaders is not set by default`() {
+        assertNull(config.tracingHeaders)
+    }
+
+    @Test
+    fun `tracingHeaders copies assigned lists`() {
+        val tracingHeaders = mutableListOf("api.example.com")
+
+        config.tracingHeaders = tracingHeaders
+        tracingHeaders.add("other.example.com")
+
+        assertEquals(listOf("api.example.com"), config.tracingHeaders)
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
@@ -96,6 +96,16 @@ internal class PostHogConfigTest {
     }
 
     @Test
+    fun `tracingHeaders returns a snapshot`() {
+        config.tracingHeaders = listOf("api.example.com")
+
+        val tracingHeaders = config.tracingHeaders as MutableList<String>
+        tracingHeaders.add("other.example.com")
+
+        assertEquals(listOf("api.example.com"), config.tracingHeaders)
+    }
+
+    @Test
     fun `onFeatureFlags is not set by default`() {
         assertNull(config.onFeatureFlags)
     }

--- a/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogConfigTest.kt
@@ -81,6 +81,11 @@ internal class PostHogConfigTest {
     }
 
     @Test
+    fun `addTracingHeaders is not set by default`() {
+        assertNull(config.addTracingHeaders)
+    }
+
+    @Test
     fun `onFeatureFlags is not set by default`() {
         assertNull(config.onFeatureFlags)
     }

--- a/posthog/src/test/java/com/posthog/PostHogOkHttpInterceptorTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogOkHttpInterceptorTest.kt
@@ -1,0 +1,398 @@
+package com.posthog
+
+import com.posthog.internal.PostHogMemoryPreferences
+import com.posthog.internal.PostHogThreadFactory
+import okhttp3.Dns
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.net.InetAddress
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class PostHogOkHttpInterceptorTest {
+    private data class ExpectedHeaders(
+        val distinctId: String? = null,
+        val sessionId: String? = null,
+        val windowId: String? = null,
+    )
+
+    private data class HostMatchingCase(
+        val name: String,
+        val configHosts: List<String>?,
+        val requestHost: String,
+        val shouldInject: Boolean,
+    )
+
+    private data class HeaderMutationCase(
+        val name: String,
+        val configHosts: List<String>?,
+        val requestHost: String = PRIMARY_HOST,
+        val captureNetworkTelemetry: Boolean = false,
+        val endSessionBeforeRequest: Boolean = false,
+        val initialHeaders: ExpectedHeaders = ExpectedHeaders(),
+        val expectedHeaders: (PostHogInterface) -> ExpectedHeaders,
+    )
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    @Test
+    fun `host matching cases inject tracing headers as expected`() {
+        HOST_MATCHING_CASES.forEach { testCase ->
+            withTracingSut(addTracingHeaders = testCase.configHosts) { postHog ->
+                withServer { server ->
+                    server.enqueue(MockResponse().setBody("ok"))
+
+                    val client = newClient(postHog)
+                    try {
+                        executeRequest(client, server, testCase.requestHost)
+
+                        val recordedRequest = takeRecordedRequest(server)
+                        val expectedHeaders =
+                            if (testCase.shouldInject) {
+                                ExpectedHeaders(
+                                    distinctId = postHog.distinctId(),
+                                    sessionId = postHog.getSessionId()?.toString(),
+                                )
+                            } else {
+                                ExpectedHeaders()
+                            }
+
+                        assertHeaders(recordedRequest, expectedHeaders, testCase.name)
+                    } finally {
+                        client.shutdown()
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `tracing header mutation cases behave as expected`() {
+        HEADER_MUTATION_CASES.forEach { testCase ->
+            withTracingSut(addTracingHeaders = testCase.configHosts) { postHog ->
+                if (testCase.endSessionBeforeRequest) {
+                    postHog.endSession()
+                }
+
+                withServer { server ->
+                    server.enqueue(MockResponse().setBody("ok"))
+
+                    val client = newClient(postHog, captureNetworkTelemetry = testCase.captureNetworkTelemetry)
+                    try {
+                        executeRequest(
+                            client = client,
+                            server = server,
+                            host = testCase.requestHost,
+                            requestBuilder = requestBuilder(testCase.initialHeaders),
+                        )
+
+                        val recordedRequest = takeRecordedRequest(server)
+                        assertHeaders(recordedRequest, testCase.expectedHeaders(postHog), testCase.name)
+                    } finally {
+                        client.shutdown()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun assertHeaders(
+        recordedRequest: RecordedRequest,
+        expectedHeaders: ExpectedHeaders,
+        caseName: String,
+    ) {
+        assertEquals(
+            expectedHeaders.distinctId,
+            recordedRequest.getHeader(DISTINCT_ID_HEADER),
+            "$caseName: unexpected distinct id header",
+        )
+        assertEquals(
+            expectedHeaders.sessionId,
+            recordedRequest.getHeader(SESSION_ID_HEADER),
+            "$caseName: unexpected session id header",
+        )
+        assertEquals(
+            expectedHeaders.windowId,
+            recordedRequest.getHeader(WINDOW_ID_HEADER),
+            "$caseName: unexpected window id header",
+        )
+    }
+
+    private fun requestBuilder(initialHeaders: ExpectedHeaders): Request.Builder {
+        return Request.Builder().apply {
+            initialHeaders.distinctId?.let { header(DISTINCT_ID_HEADER, it) }
+            initialHeaders.sessionId?.let { header(SESSION_ID_HEADER, it) }
+            initialHeaders.windowId?.let { header(WINDOW_ID_HEADER, it) }
+        }
+    }
+
+    private fun executeRequest(
+        client: OkHttpClient,
+        server: MockWebServer,
+        host: String,
+        requestBuilder: Request.Builder = Request.Builder(),
+    ) {
+        val request =
+            requestBuilder
+                .url(server.url("/test").newBuilder().host(host).build())
+                .build()
+
+        client.newCall(request).execute().use { response ->
+            response.body?.string()
+        }
+    }
+
+    private fun takeRecordedRequest(server: MockWebServer): RecordedRequest {
+        return server.takeRequest(5, TimeUnit.SECONDS)
+            ?: error("Timed out waiting for request")
+    }
+
+    private fun newClient(
+        postHog: PostHogInterface,
+        captureNetworkTelemetry: Boolean = false,
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .dns(LOOPBACK_DNS)
+            .addInterceptor(
+                PostHogOkHttpInterceptor(
+                    captureNetworkTelemetry = captureNetworkTelemetry,
+                    postHog = postHog,
+                ),
+            )
+            .build()
+    }
+
+    private fun withServer(block: (MockWebServer) -> Unit) {
+        val server = MockWebServer()
+        server.start()
+        try {
+            block(server)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun withTracingSut(
+        addTracingHeaders: List<String>?,
+        block: (PostHogInterface) -> Unit,
+    ) {
+        val executors = TestExecutors()
+        val config =
+            PostHogConfig(API_KEY, "http://localhost").apply {
+                this.addTracingHeaders = addTracingHeaders
+                this.storagePrefix = tmpDir.newFolder().absolutePath
+                this.replayStoragePrefix = tmpDir.newFolder().absolutePath
+                this.cachePreferences = PostHogMemoryPreferences()
+                this.preloadFeatureFlags = false
+                this.remoteConfig = false
+            }
+
+        val postHog =
+            PostHog.withInternal(
+                config,
+                executors.queue,
+                executors.replay,
+                executors.featureFlags,
+                executors.cachedEvents,
+                reloadFeatureFlags = false,
+            )
+
+        try {
+            block(postHog)
+        } finally {
+            postHog.close()
+            executors.shutdown()
+        }
+    }
+
+    private class TestExecutors {
+        val queue: ScheduledExecutorService = scheduledExecutor("TestQueue")
+        val replay: ScheduledExecutorService = scheduledExecutor("TestReplayQueue")
+        val featureFlags: ScheduledExecutorService = scheduledExecutor("TestRemoteConfig")
+        val cachedEvents: ScheduledExecutorService = scheduledExecutor("TestCachedEvents")
+
+        fun shutdown() {
+            queue.shutdownAndAwaitTermination()
+            replay.shutdownAndAwaitTermination()
+            featureFlags.shutdownAndAwaitTermination()
+            cachedEvents.shutdownAndAwaitTermination()
+        }
+    }
+
+    private companion object {
+        private const val PRIMARY_HOST = "api.example.com"
+        private const val OTHER_HOST = "other.example.com"
+        private const val SUBDOMAIN_HOST = "sub.api.example.com"
+
+        private const val DISTINCT_ID_HEADER = "X-POSTHOG-DISTINCT-ID"
+        private const val SESSION_ID_HEADER = "X-POSTHOG-SESSION-ID"
+        private const val WINDOW_ID_HEADER = "X-POSTHOG-WINDOW-ID"
+
+        private val HOST_MATCHING_CASES =
+            listOf(
+                HostMatchingCase(
+                    name = "injects headers for an exact host match",
+                    configHosts = listOf(PRIMARY_HOST),
+                    requestHost = PRIMARY_HOST,
+                    shouldInject = true,
+                ),
+                HostMatchingCase(
+                    name = "normalizes configured hostnames",
+                    configHosts = listOf("  API.EXAMPLE.COM  "),
+                    requestHost = PRIMARY_HOST,
+                    shouldInject = true,
+                ),
+                HostMatchingCase(
+                    name = "injects headers when any configured host matches",
+                    configHosts = listOf(OTHER_HOST, PRIMARY_HOST),
+                    requestHost = PRIMARY_HOST,
+                    shouldInject = true,
+                ),
+                HostMatchingCase(
+                    name = "ignores blank configured hostnames",
+                    configHosts = listOf(" ", "\t", PRIMARY_HOST),
+                    requestHost = PRIMARY_HOST,
+                    shouldInject = true,
+                ),
+                HostMatchingCase(
+                    name = "does not inject headers for an empty host list",
+                    configHosts = emptyList(),
+                    requestHost = PRIMARY_HOST,
+                    shouldInject = false,
+                ),
+                HostMatchingCase(
+                    name = "does not inject headers when tracing headers are disabled",
+                    configHosts = null,
+                    requestHost = PRIMARY_HOST,
+                    shouldInject = false,
+                ),
+                HostMatchingCase(
+                    name = "does not inject headers for subdomains when only the parent host is configured",
+                    configHosts = listOf(PRIMARY_HOST),
+                    requestHost = SUBDOMAIN_HOST,
+                    shouldInject = false,
+                ),
+                HostMatchingCase(
+                    name = "does not inject headers for unlisted hosts",
+                    configHosts = listOf(PRIMARY_HOST),
+                    requestHost = OTHER_HOST,
+                    shouldInject = false,
+                ),
+            )
+
+        private val HEADER_MUTATION_CASES =
+            listOf(
+                HeaderMutationCase(
+                    name = "injects headers even when network telemetry capture is disabled",
+                    configHosts = listOf(PRIMARY_HOST),
+                    captureNetworkTelemetry = false,
+                    expectedHeaders = { postHog ->
+                        ExpectedHeaders(
+                            distinctId = postHog.distinctId(),
+                            sessionId = postHog.getSessionId()?.toString(),
+                        )
+                    },
+                ),
+                HeaderMutationCase(
+                    name = "injects headers when network telemetry capture is enabled",
+                    configHosts = listOf(PRIMARY_HOST),
+                    captureNetworkTelemetry = true,
+                    expectedHeaders = { postHog ->
+                        ExpectedHeaders(
+                            distinctId = postHog.distinctId(),
+                            sessionId = postHog.getSessionId()?.toString(),
+                        )
+                    },
+                ),
+                HeaderMutationCase(
+                    name = "overwrites existing tracing headers on matching hosts",
+                    configHosts = listOf(PRIMARY_HOST),
+                    initialHeaders =
+                        ExpectedHeaders(
+                            distinctId = "existing-distinct-id",
+                            sessionId = "existing-session-id",
+                        ),
+                    expectedHeaders = { postHog ->
+                        ExpectedHeaders(
+                            distinctId = postHog.distinctId(),
+                            sessionId = postHog.getSessionId()?.toString(),
+                        )
+                    },
+                ),
+                HeaderMutationCase(
+                    name = "keeps the distinct id header but omits the session header when the session has ended",
+                    configHosts = listOf(PRIMARY_HOST),
+                    endSessionBeforeRequest = true,
+                    expectedHeaders = { postHog ->
+                        ExpectedHeaders(distinctId = postHog.distinctId())
+                    },
+                ),
+                HeaderMutationCase(
+                    name = "does not touch existing tracing headers on unlisted hosts",
+                    configHosts = listOf(PRIMARY_HOST),
+                    requestHost = OTHER_HOST,
+                    initialHeaders =
+                        ExpectedHeaders(
+                            distinctId = "existing-distinct-id",
+                            sessionId = "existing-session-id",
+                        ),
+                    expectedHeaders = {
+                        ExpectedHeaders(
+                            distinctId = "existing-distinct-id",
+                            sessionId = "existing-session-id",
+                        )
+                    },
+                ),
+                HeaderMutationCase(
+                    name = "does not touch existing tracing headers when tracing header config is disabled",
+                    configHosts = null,
+                    initialHeaders =
+                        ExpectedHeaders(
+                            distinctId = "existing-distinct-id",
+                            sessionId = "existing-session-id",
+                        ),
+                    expectedHeaders = {
+                        ExpectedHeaders(
+                            distinctId = "existing-distinct-id",
+                            sessionId = "existing-session-id",
+                        )
+                    },
+                ),
+            )
+
+        private val LOOPBACK_DNS =
+            object : Dns {
+                override fun lookup(hostname: String): List<InetAddress> {
+                    return when (hostname) {
+                        PRIMARY_HOST,
+                        OTHER_HOST,
+                        SUBDOMAIN_HOST,
+                        -> {
+                            listOf(InetAddress.getByAddress(hostname, byteArrayOf(127.toByte(), 0, 0, 1)))
+                        }
+
+                        else -> Dns.SYSTEM.lookup(hostname)
+                    }
+                }
+            }
+    }
+}
+
+private fun scheduledExecutor(name: String): ScheduledExecutorService {
+    return Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory(name))
+}
+
+private fun OkHttpClient.shutdown() {
+    dispatcher.executorService.shutdown()
+    connectionPool.evictAll()
+}

--- a/posthog/src/test/java/com/posthog/PostHogOkHttpInterceptorTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogOkHttpInterceptorTest.kt
@@ -47,7 +47,7 @@ internal class PostHogOkHttpInterceptorTest {
     @Test
     fun `host matching cases inject tracing headers as expected`() {
         HOST_MATCHING_CASES.forEach { testCase ->
-            withTracingSut(addTracingHeaders = testCase.configHosts) { postHog ->
+            withTracingSut(tracingHeaders = testCase.configHosts) { postHog ->
                 withServer { server ->
                     server.enqueue(MockResponse().setBody("ok"))
 
@@ -78,7 +78,7 @@ internal class PostHogOkHttpInterceptorTest {
     @Test
     fun `tracing header mutation cases behave as expected`() {
         HEADER_MUTATION_CASES.forEach { testCase ->
-            withTracingSut(addTracingHeaders = testCase.configHosts) { postHog ->
+            withTracingSut(tracingHeaders = testCase.configHosts) { postHog ->
                 if (testCase.endSessionBeforeRequest) {
                     postHog.endSession()
                 }
@@ -183,13 +183,13 @@ internal class PostHogOkHttpInterceptorTest {
 
     @Suppress("DEPRECATION")
     private fun withTracingSut(
-        addTracingHeaders: List<String>?,
+        tracingHeaders: List<String>?,
         block: (PostHogInterface) -> Unit,
     ) {
         val executors = TestExecutors()
         val config =
             PostHogConfig(API_KEY, "http://localhost").apply {
-                this.addTracingHeaders = addTracingHeaders
+                this.tracingHeaders = tracingHeaders
                 this.storagePrefix = tmpDir.newFolder().absolutePath
                 this.replayStoragePrefix = tmpDir.newFolder().absolutePath
                 this.cachePreferences = PostHogMemoryPreferences()


### PR DESCRIPTION
## :bulb: Motivation and Context

Add Android support for PostHog tracing headers on outgoing OkHttp requests, matching the recent iOS work and bringing the Android SDK closer to browser SDK parity for request correlation.

This adds a configurable `addTracingHeaders` host list and injects `X-POSTHOG-DISTINCT-ID` and `X-POSTHOG-SESSION-ID` on exact hostname matches via `PostHogOkHttpInterceptor`.

## :green_heart: How did you test it?

- Added `PostHogOkHttpInterceptorTest` coverage for:
  - exact host matches
  - hostname normalization
  - unlisted/subdomain non-matches
  - behavior with telemetry capture enabled/disabled
  - existing-header overwrite behavior
  - ended-session behavior
- Added default config coverage in `PostHogConfigTest`
- Ran:
  - `./gradlew :posthog:test --tests "com.posthog.PostHogOkHttpInterceptorTest" --tests "com.posthog.PostHogConfigTest"`
  - `./gradlew spotlessKotlinCheck -PspotlessFiles='posthog/src/main/java/com/posthog/PostHogConfig.kt,posthog/src/main/java/com/posthog/PostHogOkHttpInterceptor.kt,posthog/src/test/java/com/posthog/PostHogConfigTest.kt,posthog/src/test/java/com/posthog/PostHogOkHttpInterceptorTest.kt'`
  - `make api`
  - `./gradlew apiCheck`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
