### PR TITLE
refactor(server): Drop redundant equals/hashCode from data classes

### DIFF
--- a/.changeset/sour-icons-study.md
+++ b/.changeset/sour-icons-study.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Remove redundant equals/hashCode from FeatureFlag-related data classes.

--- a/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheEntry.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheEntry.kt
@@ -27,28 +27,4 @@ internal data class FeatureFlagCacheEntry(
     fun isExpired(currentTime: Long = System.currentTimeMillis()): Boolean {
         return currentTime >= expiresAt
     }
-
-    override fun hashCode(): Int {
-        var result = flags?.hashCode() ?: 0
-        result = 31 * result + (timestamp xor (timestamp ushr 32)).toInt()
-        result = 31 * result + (expiresAt xor (expiresAt ushr 32)).toInt()
-        result = 31 * result + (requestId?.hashCode() ?: 0)
-        result = 31 * result + (evaluatedAt?.hashCode() ?: 0)
-        result = 31 * result + (error?.hashCode() ?: 0)
-        return result
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is FeatureFlagCacheEntry) return false
-
-        if (flags != other.flags) return false
-        if (timestamp != other.timestamp) return false
-        if (expiresAt != other.expiresAt) return false
-        if (requestId != other.requestId) return false
-        if (evaluatedAt != other.evaluatedAt) return false
-        if (error != other.error) return false
-
-        return true
-    }
 }

--- a/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheKey.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FeatureFlagCacheKey.kt
@@ -8,24 +8,4 @@ internal data class FeatureFlagCacheKey(
     val groups: Map<String, String>?,
     val personProperties: Map<String, Any?>?,
     val groupProperties: Map<String, Map<String, Any?>>?,
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is FeatureFlagCacheKey) return false
-
-        if (distinctId != other.distinctId) return false
-        if (groups != other.groups) return false
-        if (personProperties != other.personProperties) return false
-        if (groupProperties != other.groupProperties) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = distinctId?.hashCode() ?: 0
-        result = 31 * result + (groups?.hashCode() ?: 0)
-        result = 31 * result + (personProperties?.hashCode() ?: 0)
-        result = 31 * result + (groupProperties?.hashCode() ?: 0)
-        return result
-    }
-}
+)


### PR DESCRIPTION
## :bulb: Motivation and Context

FeatureFlagCacheEntry and FeatureFlagCacheKey are data classes. Kotlin auto-generates equals() and hashCode(). 
The manual overrides duplicated this logic and required manual updates whenever fields were added (see commits 472cc44 and 74b4f49 in FeatureFlagCacheEntry). 
Removing them reduces the maintenance surface and makes the code more Kotlin idiomatic.

## :green_heart: How did you test it?

- Unit tests
- Compiler checks

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
