### PR TITLE
release: android gradle plugin with version info

### DIFF
--- a/.changeset/clear-hats-march.md
+++ b/.changeset/clear-hats-march.md
@@ -1,0 +1,5 @@
+---
+"posthog-android-gradle-plugin": minor
+---
+
+Attach release info (`applicationId`, `versionName`, `versionCode`) to proguard mapping uploads via the new posthog-cli `--release-name`, `--release-version`, and `--build` flags.


### PR DESCRIPTION
## :bulb: Motivation and Context
https://github.com/PostHog/posthog-android/pull/491 used the wrong package name for the release so this wasnt released yet

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

<!-- For more details check RELEASING.md -->
