### PR TITLE
chore: trigger releases from main changesets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,5 @@
 ### If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
 
 <!-- For more details check RELEASING.md -->

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.changeset/**'
+      - '.changeset/*.md'
   workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
@@ -120,7 +120,7 @@ jobs:
                     echo "No changes to commit"
                     echo "committed=false" >> "$GITHUB_OUTPUT"
                   else
-                    git commit -m "chore: update versions and changelogs [version bump]"
+                    git commit -m "chore: update versions and changelogs [version bump] [skip ci]"
                     git push origin main
                     echo "committed=true" >> "$GITHUB_OUTPUT"
                   fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,14 @@ permissions:
     contents: read
 
 on:
-    pull_request:
-        types: [closed]
-        branches: [main]
-    workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.changeset/**'
+  workflow_dispatch:
 
 # Concurrency control: only one release process can run at a time
-# This prevents race conditions if multiple PRs with 'release' label merge simultaneously
+# This prevents race conditions if multiple releasable changesets merge simultaneously
 concurrency:
     group: release
     cancel-in-progress: false
@@ -19,12 +20,6 @@ jobs:
     check-changesets:
         name: Check for changesets
         runs-on: ubuntu-latest
-        # Run when PR with 'release' label is merged to main, or when manually triggered
-        if: |
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'pull_request'
-             && github.event.pull_request.merged == true
-             && contains(github.event.pull_request.labels.*.name, 'release'))
         outputs:
             has-changesets: ${{ steps.check.outputs.has-changesets }}
         steps:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,119 +1,45 @@
 # Releasing
 
-Releases are managed with [changesets](https://github.com/changesets/changesets).
+This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
 
-## Creating a changeset
+## How to Release
 
-Before submitting a PR, create a changeset by running:
+### 1. Add a Changeset
+
+When making a change that should be released, add a changeset:
 
 ```bash
 pnpm changeset
 ```
 
-The CLI will prompt you to select the affected package(s) and the type of version bump (patch, minor, major).
-A changeset file will be generated in the `.changeset/` directory — commit it with your PR.
+This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
 
-## Release process
+### 2. Merge the Pull Request
 
-Add a `release` label to your PR. When the PR is merged to `main`, the release workflow will automatically:
+After review, merge the PR to `main`. No GitHub release label is required.
 
-1. Bump versions based on changesets
-2. Update changelogs in each package subfolder (e.g. `posthog/CHANGELOG.md`, `posthog-android/CHANGELOG.md`)
-3. Commit version updates directly to `main`
-4. Publish packages to Maven Central
-5. Create Git tags and GitHub releases
+A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
 
-All of this happens automatically when the PR is merged — no manual tagging or release creation needed!
+1. Checks for pending changesets
+2. Notifies the client libraries team in Slack for approval
+3. Waits for approval from a maintainer via the GitHub `Release` environment
+4. The workflow applies Changesets, syncs Gradle/plugin versions, publishes packages, tags the release, and creates a GitHub Release.
+5. Notifies Slack when the release completes or fails
 
-## Dependency order
+### Manual Trigger
 
-Packages are released sequentially in the following order to respect transitive dependencies:
+You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
 
-1. **posthog** (core) — must be released first
-2. **posthog-android** — depends on posthog core
-3. **posthog-server** — depends on posthog core
-4. **posthog-android-gradle-plugin**
+## Version Bumping
 
-If `posthog-android` or `posthog-server` have pending changes, ensure `posthog` (core) is released first (or has no pending changes). The release workflow handles this by running packages sequentially with `max-parallel: 1`.
+Changesets determines the next version from the committed changeset files:
 
-## Tag naming convention
+- **patch**: bug fixes, documentation updates, and internal changes
+- **minor**: backwards-compatible features
+- **major**: breaking changes
 
-Tags are created automatically by the release workflow:
+## Troubleshooting
 
-- `core-v3.23.0` → posthog core module
-- `android-v3.23.0` → posthog-android module
-- `server-v1.0.1` → posthog-server module
-- `androidPlugin-v1.0.1` → posthog-android-gradle-plugin module
+### No changesets found
 
-## Rotating Sonatype User Token
-
-The release workflow uses a Sonatype user token for authentication when publishing to Maven Central.
-
-1. **Generate a new user token**:
-   - Go to [Maven Central Repository](https://central.sonatype.com/usertoken)
-   - Log in with PostHog credentials
-   - Generate a new user token
-   - Copy the username and password values
-
-2. **Update GitHub org secrets**:
-   - Request temporary access if needed
-   - Go to [Org Settings > Secrets and variables > Actions](https://github.com/organizations/PostHog/settings/secrets/actions) — target the desired repository only
-   - Update `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` from previous step
-
-3. **Revoke the old token (previous owner)**:
-   - Go to [Maven Central Repository](https://central.sonatype.com/usertoken)
-   - Revoke any previous tokens used
-
-```yaml
-env:
-   SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-   SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-```
-
-These environment variables are used in [PostHogPublishConfig.kt](https://github.com/PostHog/posthog-android/blob/main/buildSrc/src/main/java/PostHogPublishConfig.kt):
-
-```kotlin
-val sonatypeUsername = System.getenv("SONATYPE_USERNAME")
-val sonatypePassword = System.getenv("SONATYPE_PASSWORD")
-```
-
-## Rotating GPG
-
-The release workflow uses a GPG key to sign artifacts when publishing to Maven Central.
-
-1. **Generate a new GPG key**:
-   - Follow [this](https://central.sonatype.org/publish/requirements/gpg/) tutorial
-   - `gpg --full-generate-key`
-   - Use your PostHog email
-   - A strong password (save in your password manager)
-   - Default key type: RSA and RSA
-   - Length: 4096
-   - Remove expiration
-   - After creation, save the revocation certificate in your password manager
-   - Upload the key to a [public server](https://central.sonatype.org/publish/requirements/gpg/#distributing-your-public-key)
-   - `gpg --keyserver keys.openpgp.org --send-keys $ID`
-   - Visit the keyserver URL and confirm email
-   - Export the private key (ASCII armored) — `gpg --export-secret-keys --armor $ID`
-
-2. **Update GitHub org secrets**:
-   - Request temporary access if needed
-   - Go to [Org Settings > Secrets and variables > Actions](https://github.com/organizations/PostHog/settings/secrets/actions) — target the desired repository only
-   - Update `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` from previous step
-
-3. **Revoke the old GPG key (previous owner)**:
-   - Go to [GPG Keychain](https://gpgtools.org/)
-   - Revoke the GPG key
-   - Update the key to a public server after revoking
-
-```yaml
-env:
-   GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-```
-
-These environment variables are used in [PostHogPublishConfig.kt](https://github.com/PostHog/posthog-android/blob/main/buildSrc/src/main/java/PostHogPublishConfig.kt):
-
-```kotlin
-val privateKey = System.getenv("GPG_PRIVATE_KEY")
-val password = System.getenv("GPG_PASSPHRASE")
-```
+If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,45 +1,119 @@
 # Releasing
 
-This repository uses [Changesets](https://github.com/changesets/changesets) for version management and an automated GitHub Actions workflow for releases.
+Releases are managed with [changesets](https://github.com/changesets/changesets).
 
-## How to Release
+## Creating a changeset
 
-### 1. Add a Changeset
-
-When making a change that should be released, add a changeset:
+Before submitting a PR, create a changeset by running:
 
 ```bash
 pnpm changeset
 ```
 
-This prompts you to select the version bump (`patch`, `minor`, or `major`) and write a short release summary. Commit the generated file in `.changeset/` with your pull request.
+The CLI will prompt you to select the affected package(s) and the type of version bump (patch, minor, major).
+A changeset file will be generated in the `.changeset/` directory — commit it with your PR.
 
-### 2. Merge the Pull Request
+## Release process
 
-After review, merge the PR to `main`. No GitHub release label is required.
+When a PR with a changeset is merged to `main`, the release workflow will automatically run on the push to `main` and:
 
-A push to `main` that includes `.changeset/**` changes automatically starts the release workflow. The workflow then:
+1. Bump versions based on changesets
+2. Update changelogs in each package subfolder (e.g. `posthog/CHANGELOG.md`, `posthog-android/CHANGELOG.md`)
+3. Commit version updates directly to `main`
+4. Publish packages to Maven Central
+5. Create Git tags and GitHub releases
 
-1. Checks for pending changesets
-2. Notifies the client libraries team in Slack for approval
-3. Waits for approval from a maintainer via the GitHub `Release` environment
-4. The workflow applies Changesets, syncs Gradle/plugin versions, publishes packages, tags the release, and creates a GitHub Release.
-5. Notifies Slack when the release completes or fails
+All of this happens automatically when the PR is merged — no release label, manual tagging, or manual release creation needed!
 
-### Manual Trigger
+## Dependency order
 
-You can also manually trigger the release workflow from the Actions tab with `workflow_dispatch`. Manual runs still require pending changesets.
+Packages are released sequentially in the following order to respect transitive dependencies:
 
-## Version Bumping
+1. **posthog** (core) — must be released first
+2. **posthog-android** — depends on posthog core
+3. **posthog-server** — depends on posthog core
+4. **posthog-android-gradle-plugin**
 
-Changesets determines the next version from the committed changeset files:
+If `posthog-android` or `posthog-server` have pending changes, ensure `posthog` (core) is released first (or has no pending changes). The release workflow handles this by running packages sequentially with `max-parallel: 1`.
 
-- **patch**: bug fixes, documentation updates, and internal changes
-- **minor**: backwards-compatible features
-- **major**: breaking changes
+## Tag naming convention
 
-## Troubleshooting
+Tags are created automatically by the release workflow:
 
-### No changesets found
+- `core-v3.23.0` → posthog core module
+- `android-v3.23.0` → posthog-android module
+- `server-v1.0.1` → posthog-server module
+- `androidPlugin-v1.0.1` → posthog-android-gradle-plugin module
 
-If the release workflow reports that no changesets were found, make sure your PR includes at least one releasable `.changeset/*.md` file.
+## Rotating Sonatype User Token
+
+The release workflow uses a Sonatype user token for authentication when publishing to Maven Central.
+
+1. **Generate a new user token**:
+   - Go to [Maven Central Repository](https://central.sonatype.com/usertoken)
+   - Log in with PostHog credentials
+   - Generate a new user token
+   - Copy the username and password values
+
+2. **Update GitHub org secrets**:
+   - Request temporary access if needed
+   - Go to [Org Settings > Secrets and variables > Actions](https://github.com/organizations/PostHog/settings/secrets/actions) — target the desired repository only
+   - Update `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` from previous step
+
+3. **Revoke the old token (previous owner)**:
+   - Go to [Maven Central Repository](https://central.sonatype.com/usertoken)
+   - Revoke any previous tokens used
+
+```yaml
+env:
+   SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+   SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+```
+
+These environment variables are used in [PostHogPublishConfig.kt](https://github.com/PostHog/posthog-android/blob/main/buildSrc/src/main/java/PostHogPublishConfig.kt):
+
+```kotlin
+val sonatypeUsername = System.getenv("SONATYPE_USERNAME")
+val sonatypePassword = System.getenv("SONATYPE_PASSWORD")
+```
+
+## Rotating GPG
+
+The release workflow uses a GPG key to sign artifacts when publishing to Maven Central.
+
+1. **Generate a new GPG key**:
+   - Follow [this](https://central.sonatype.org/publish/requirements/gpg/) tutorial
+   - `gpg --full-generate-key`
+   - Use your PostHog email
+   - A strong password (save in your password manager)
+   - Default key type: RSA and RSA
+   - Length: 4096
+   - Remove expiration
+   - After creation, save the revocation certificate in your password manager
+   - Upload the key to a [public server](https://central.sonatype.org/publish/requirements/gpg/#distributing-your-public-key)
+   - `gpg --keyserver keys.openpgp.org --send-keys $ID`
+   - Visit the keyserver URL and confirm email
+   - Export the private key (ASCII armored) — `gpg --export-secret-keys --armor $ID`
+
+2. **Update GitHub org secrets**:
+   - Request temporary access if needed
+   - Go to [Org Settings > Secrets and variables > Actions](https://github.com/organizations/PostHog/settings/secrets/actions) — target the desired repository only
+   - Update `GPG_PRIVATE_KEY` and `GPG_PASSPHRASE` from previous step
+
+3. **Revoke the old GPG key (previous owner)**:
+   - Go to [GPG Keychain](https://gpgtools.org/)
+   - Revoke the GPG key
+   - Update the key to a public server after revoking
+
+```yaml
+env:
+   GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+   GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+```
+
+These environment variables are used in [PostHogPublishConfig.kt](https://github.com/PostHog/posthog-android/blob/main/buildSrc/src/main/java/PostHogPublishConfig.kt):
+
+```kotlin
+val privateKey = System.getenv("GPG_PRIVATE_KEY")
+val password = System.getenv("GPG_PASSPHRASE")
+```


### PR DESCRIPTION
## :bulb: Motivation and Context
Standardize SDK releases so they are triggered by pushes to `main` containing release changesets, rather than by PR labels or `pull_request.closed` events.

## Changes
- Updated the release workflow to run on `push` to `main` for `.changeset/**`, while keeping manual `workflow_dispatch`
- Removed release-label and bump-label checks from the release flow
- Added `[skip ci]` to release version-bump commits and narrowed release path filters to changeset markdown files to avoid re-triggering release workflows on consumed changeset deletions
- Updated the PR checklist and only the release-label parts of the release docs so new release changes use Changesets instead of GitHub labels, while preserving the existing Android release details

## :green_heart: How did you test it?
- Parsed the updated release workflow YAML locally
- Verified the release workflow no longer references `pull_request`, PR labels, or bump labels
- Verified PR templates no longer ask for release labels

## :pencil: Checklist
- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file (not needed for this release-process-only change)