### PR TITLE
chore: add gradle-plugin changeset for proguard release info

### DIFF
--- a/.changeset/proguard-upload-release-info-gradle-plugin.md
+++ b/.changeset/proguard-upload-release-info-gradle-plugin.md
@@ -1,0 +1,5 @@
+---
+"posthog-android-gradle-plugin": minor
+---
+
+Attach release info (`applicationId`, `versionName`, `versionCode`) to proguard mapping uploads via the new posthog-cli `--release-name`, `--release-version`, and `--build` flags.


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to #491. That PR's changeset incorrectly targeted `posthog-android` (the SDK) instead of `posthog-android-gradle-plugin` (the package the code change actually belongs to). As a result, the gradle plugin never got a release for the proguard release-info change — it's still at [1.1.0](https://central.sonatype.com/search?q=posthog-android-gradle-plugin), while the SDK got a misattributed `3.42.0` minor bump describing a feature it doesn't contain.

This PR adds a corrective changeset so the next version bump publishes the gradle plugin with the proguard release-info change.

No code changes — the implementation already landed in 8b447c1.

## :green_heart: How did you test it?

- Confirmed `posthog-android-gradle-plugin/CHANGELOG.md` ends at `1.1.0` with no entry for the proguard release-info change.
- Confirmed `.changeset/` had no pending entries before this PR.
- Verified the new changeset frontmatter targets `posthog-android-gradle-plugin` (matching the `name` field in `posthog-android-gradle-plugin/package.json`).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
- [x] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
