### PR TITLE
ci: warn when changesets don't cover modified packages [SIMULATION]

### DIFF
--- a/.changeset/coverage-check-simulation.md
+++ b/.changeset/coverage-check-simulation.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+[SIMULATION — DO NOT MERGE] Intentional package mismatch to verify the new Changeset coverage workflow. The code change is in `posthog-android-gradle-plugin/`, but this changeset declares `posthog-android`. The workflow comment should call this out.

--- a/.changeset/coverage-check-simulation.md
+++ b/.changeset/coverage-check-simulation.md
@@ -1,5 +1,0 @@
----
-"posthog-android": patch
----
-
-[SIMULATION — DO NOT MERGE] Intentional package mismatch to verify the new Changeset coverage workflow. The code change is in `posthog-android-gradle-plugin/`, but this changeset declares `posthog-android`. The workflow comment should call this out.

--- a/.github/workflows/changeset-coverage.yml
+++ b/.github/workflows/changeset-coverage.yml
@@ -36,7 +36,7 @@ jobs:
 
             - name: Post sticky PR comment
               if: steps.coverage.outputs.body != ''
-              uses: marocchino/sticky-pull-request-comment@v2
+              uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
               with:
                   header: changeset-coverage
                   message: ${{ steps.coverage.outputs.body }}

--- a/.github/workflows/changeset-coverage.yml
+++ b/.github/workflows/changeset-coverage.yml
@@ -40,3 +40,10 @@ jobs:
               with:
                   header: changeset-coverage
                   message: ${{ steps.coverage.outputs.body }}
+
+            - name: Delete stale sticky PR comment
+              if: steps.coverage.outputs.body == ''
+              uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+              with:
+                  header: changeset-coverage
+                  delete: true

--- a/.github/workflows/changeset-coverage.yml
+++ b/.github/workflows/changeset-coverage.yml
@@ -1,0 +1,42 @@
+name: 'Changeset coverage'
+
+on:
+    pull_request:
+        branches: [main]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+concurrency:
+    group: changeset-coverage-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    check:
+        name: Check changeset coverage
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  fetch-depth: 0
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+
+            - name: Compute coverage report
+              id: coverage
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              run: node scripts/check-changeset-coverage.mjs >> "$GITHUB_OUTPUT"
+
+            - name: Post sticky PR comment
+              if: steps.coverage.outputs.body != ''
+              uses: marocchino/sticky-pull-request-comment@v2
+              with:
+                  header: changeset-coverage
+                  message: ${{ steps.coverage.outputs.body }}

--- a/.github/workflows/changeset-coverage.yml
+++ b/.github/workflows/changeset-coverage.yml
@@ -23,10 +23,10 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha }}
                   fetch-depth: 0
 
-            - name: Setup Node
-              uses: actions/setup-node@v4
+            - name: Setup environment
+              uses: ./.github/actions/setup
               with:
-                  node-version: 22
+                  install: false
 
             - name: Compute coverage report
               id: coverage

--- a/posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md
+++ b/posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md
@@ -1,8 +1,0 @@
-# Changeset coverage simulation marker
-
-This file exists only to verify the new `Changeset coverage` workflow.
-It is a no-op file inside `posthog-android-gradle-plugin/` paired with a
-changeset that declares a different package — the workflow should post a
-PR comment flagging the mismatch.
-
-Delete this file (and the matching changeset) before merging.

--- a/posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md
+++ b/posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md
@@ -1,0 +1,8 @@
+# Changeset coverage simulation marker
+
+This file exists only to verify the new `Changeset coverage` workflow.
+It is a no-op file inside `posthog-android-gradle-plugin/` paired with a
+changeset that declares a different package — the workflow should post a
+PR comment flagging the mismatch.
+
+Delete this file (and the matching changeset) before merging.

--- a/scripts/check-changeset-coverage.mjs
+++ b/scripts/check-changeset-coverage.mjs
@@ -84,45 +84,57 @@ const declaredList = [...declared]
     .map(([n, b]) => `- \`${n}\` — ${b}`)
     .join('\n');
 
-const lines = [];
 if (missing.length === 0 && extra.length === 0) {
-    lines.push('### Changeset coverage looks good ✅');
-    lines.push('');
-    lines.push("This PR's changesets cover every modified workspace package.");
-    lines.push('');
-    lines.push('**Declared:**');
-    lines.push(declaredList || '_(none)_');
-} else {
-    lines.push('### Possible changeset mismatch ⚠️');
-    lines.push('');
-    lines.push("This is informational — the PR is not blocked. You can ignore it if the mismatch is intentional.");
-    lines.push('');
-    if (missing.length > 0) {
-        lines.push('**Modified in this PR but not in any changeset:**');
-        for (const n of missing) lines.push(`- \`${n}\``);
-        lines.push('');
-        lines.push(
-            'If this package should ship the change, add it to the changeset frontmatter:',
-        );
-        lines.push('');
-        lines.push('```');
-        lines.push('---');
-        for (const n of missing) lines.push(`"${n}": patch`);
-        lines.push('---');
-        lines.push('```');
-        lines.push('');
-    }
-    if (extra.length > 0) {
-        lines.push('**Declared in a changeset but no source files modified:**');
-        for (const n of extra) lines.push(`- \`${n}\``);
-        lines.push('');
-        lines.push(
-            'Double-check this is intentional — for example, releasing a previously-merged change.',
-        );
-        lines.push('');
-    }
-    lines.push('**Changesets in this PR:**');
-    lines.push(declaredList || '_(none)_');
+    // Coverage matches — no comment needed. Workflow will delete any stale one.
+    writeOutput('');
+    process.exit(0);
 }
 
-writeOutput(lines.join('\n'));
+const summary = (() => {
+    if (missing.length && extra.length) {
+        return 'Possible changeset mismatch — modified and declared packages differ';
+    }
+    if (missing.length === 1) {
+        return `\`${missing[0]}\` is modified but not declared in any changeset`;
+    }
+    if (missing.length > 1) {
+        return `${missing.length} packages modified but not declared in any changeset`;
+    }
+    if (extra.length === 1) {
+        return `Changeset declares \`${extra[0]}\` but no source files in that package changed`;
+    }
+    return 'Changesets declare packages with no source changes in this PR';
+})();
+
+const inner = [];
+inner.push(
+    'This is informational — the PR is not blocked. Click the triangle above to collapse, or push a fix and this comment will auto-delete.',
+);
+inner.push('');
+if (missing.length > 0) {
+    inner.push('**Modified in this PR but not in any changeset:**');
+    for (const n of missing) inner.push(`- \`${n}\``);
+    inner.push('');
+    inner.push('If this package should ship the change, add it to the changeset frontmatter:');
+    inner.push('');
+    inner.push('```');
+    inner.push('---');
+    for (const n of missing) inner.push(`"${n}": patch`);
+    inner.push('---');
+    inner.push('```');
+    inner.push('');
+}
+if (extra.length > 0) {
+    inner.push('**Declared in a changeset but no source files modified:**');
+    for (const n of extra) inner.push(`- \`${n}\``);
+    inner.push('');
+    inner.push(
+        'Double-check this is intentional — for example, releasing a previously-merged change.',
+    );
+    inner.push('');
+}
+inner.push('**Changesets in this PR:**');
+inner.push(declaredList || '_(none)_');
+
+const body = `<details open>\n<summary>⚠️ ${summary}</summary>\n\n${inner.join('\n')}\n\n</details>`;
+writeOutput(body);

--- a/scripts/check-changeset-coverage.mjs
+++ b/scripts/check-changeset-coverage.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Compares packages modified in this PR against packages declared in any
+// changeset added/modified in this PR. Writes a markdown comment body to
+// stdout in GITHUB_OUTPUT format. Never exits non-zero — the workflow only
+// uses this to surface a warning, not to gate the PR.
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const baseRef = process.env.BASE_REF || 'main';
+
+const sh = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
+
+// 1. Workspace package directories → package names.
+const workspaceFile = readFileSync('pnpm-workspace.yaml', 'utf8');
+const pkgDirs = [...workspaceFile.matchAll(/^\s*-\s*"([^"]+)"\s*$/gm)].map((m) => m[1]);
+const dirToName = {};
+for (const dir of pkgDirs) {
+    const pj = join(dir, 'package.json');
+    if (!existsSync(pj)) continue;
+    const name = JSON.parse(readFileSync(pj, 'utf8')).name;
+    if (name) dirToName[dir] = name;
+}
+const knownNames = new Set(Object.values(dirToName));
+
+// 2. Diff vs base.
+const mergeBase = sh(`git merge-base origin/${baseRef} HEAD`);
+const changedFiles = sh(`git diff --name-only ${mergeBase}...HEAD`).split('\n').filter(Boolean);
+
+// 3. Map changed files → affected packages.
+const ignoreSuffixes = ['/CHANGELOG.md', '/package.json'];
+const affected = new Set();
+for (const file of changedFiles) {
+    if (file.startsWith('.changeset/')) continue;
+    if (ignoreSuffixes.some((s) => file.endsWith(s))) continue;
+    for (const [dir, name] of Object.entries(dirToName)) {
+        if (file === dir || file.startsWith(dir + '/')) {
+            affected.add(name);
+            break;
+        }
+    }
+}
+
+// 4. Find changeset files added or modified in this PR.
+const changesetFiles = sh(
+    `git diff --name-only --diff-filter=AM ${mergeBase}...HEAD -- .changeset/`,
+)
+    .split('\n')
+    .filter((f) => f.endsWith('.md') && !f.endsWith('README.md'));
+
+const writeOutput = (body) => {
+    if (!body) {
+        process.stdout.write('body=\n');
+    } else {
+        process.stdout.write(`body<<CHANGESET_COVERAGE_EOF\n${body}\nCHANGESET_COVERAGE_EOF\n`);
+    }
+};
+
+if (changesetFiles.length === 0) {
+    writeOutput('');
+    process.exit(0);
+}
+
+// 5. Parse frontmatter from each changeset file.
+const declared = new Map();
+for (const file of changesetFiles) {
+    if (!existsSync(file)) continue;
+    const content = readFileSync(file, 'utf8');
+    const fm = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fm) continue;
+    for (const line of fm[1].split(/\r?\n/)) {
+        const m = line.match(/^\s*"?([^"\s:]+)"?\s*:\s*(patch|minor|major)\s*$/);
+        if (m) declared.set(m[1], m[2]);
+    }
+}
+
+// 6. Compare.
+const missing = [...affected].filter((n) => !declared.has(n)).sort();
+const extra = [...declared.keys()].filter((n) => !affected.has(n) && knownNames.has(n)).sort();
+
+const declaredList = [...declared]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([n, b]) => `- \`${n}\` — ${b}`)
+    .join('\n');
+
+const lines = [];
+if (missing.length === 0 && extra.length === 0) {
+    lines.push('### Changeset coverage looks good ✅');
+    lines.push('');
+    lines.push("This PR's changesets cover every modified workspace package.");
+    lines.push('');
+    lines.push('**Declared:**');
+    lines.push(declaredList || '_(none)_');
+} else {
+    lines.push('### Possible changeset mismatch ⚠️');
+    lines.push('');
+    lines.push("This is informational — the PR is not blocked. You can ignore it if the mismatch is intentional.");
+    lines.push('');
+    if (missing.length > 0) {
+        lines.push('**Modified in this PR but not in any changeset:**');
+        for (const n of missing) lines.push(`- \`${n}\``);
+        lines.push('');
+        lines.push(
+            'If this package should ship the change, add it to the changeset frontmatter:',
+        );
+        lines.push('');
+        lines.push('```');
+        lines.push('---');
+        for (const n of missing) lines.push(`"${n}": patch`);
+        lines.push('---');
+        lines.push('```');
+        lines.push('');
+    }
+    if (extra.length > 0) {
+        lines.push('**Declared in a changeset but no source files modified:**');
+        for (const n of extra) lines.push(`- \`${n}\``);
+        lines.push('');
+        lines.push(
+            'Double-check this is intentional — for example, releasing a previously-merged change.',
+        );
+        lines.push('');
+    }
+    lines.push('**Changesets in this PR:**');
+    lines.push(declaredList || '_(none)_');
+}
+
+writeOutput(lines.join('\n'));

--- a/scripts/check-changeset-coverage.mjs
+++ b/scripts/check-changeset-coverage.mjs
@@ -6,21 +6,23 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
 const baseRef = process.env.BASE_REF || 'main';
 
 const sh = (cmd) => execSync(cmd, { encoding: 'utf8' }).trim();
 
-// 1. Workspace package directories → package names.
-const workspaceFile = readFileSync('pnpm-workspace.yaml', 'utf8');
-const pkgDirs = [...workspaceFile.matchAll(/^\s*-\s*"([^"]+)"\s*$/gm)].map((m) => m[1]);
+// 1. Workspace package directories → package names. Use pnpm itself as the
+//    source of truth so we handle globs, exclusions, and the catalog correctly.
+const cwd = process.cwd();
+const workspaceListing = JSON.parse(sh('pnpm m ls --json --depth=-1'));
 const dirToName = {};
-for (const dir of pkgDirs) {
-    const pj = join(dir, 'package.json');
-    if (!existsSync(pj)) continue;
-    const name = JSON.parse(readFileSync(pj, 'utf8')).name;
-    if (name) dirToName[dir] = name;
+for (const entry of workspaceListing) {
+    if (!entry.name) continue; // workspace root has no name field
+    if (entry.path === cwd) continue;
+    const relPath = entry.path.startsWith(cwd + '/')
+        ? entry.path.slice(cwd.length + 1)
+        : entry.path;
+    dirToName[relPath] = entry.name;
 }
 const knownNames = new Set(Object.values(dirToName));
 


### PR DESCRIPTION
## :bulb: Motivation and Context

**Draft / simulation — do not merge as-is.**

Adds a non-blocking CI workflow that compares packages modified in a PR against packages declared in any changeset added/modified in that PR, and posts a sticky comment if they don't line up. Designed to catch the class of mistake that caused #491 → #507: changeset frontmatter pointing at the wrong package.

This PR also intentionally simulates that mistake so the workflow's comment can be observed end-to-end:

- **Code change** (the marker file) is in `posthog-android-gradle-plugin/`
- **Changeset** declares `"posthog-android": patch`
- The workflow should post a comment flagging both directions of the mismatch

When validation is done, the simulation files (`.changeset/coverage-check-simulation.md` and `posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md`) get deleted, leaving just the workflow + script.

## What the workflow does

- Triggers on `pull_request` against `main`.
- Parses `pnpm-workspace.yaml` and each package's `package.json` to map directories → package names.
- Diffs against the merge base; collects packages where any non-`CHANGELOG.md`/`package.json` source file changed.
- Reads frontmatter of any `.changeset/*.md` added or modified in the PR.
- Renders a markdown report and posts (or updates) a sticky PR comment via `marocchino/sticky-pull-request-comment`.
- **Never fails the build** — exits 0 in every case. Skipping the check = don't add a changeset.

## :green_heart: How did you test it?

- Dry-ran `scripts/check-changeset-coverage.mjs` locally on this branch — it correctly identified `posthog-android-gradle-plugin` as modified-but-undeclared and `posthog-android` as declared-but-unmodified.
- The simulation in this PR is the integration test — once CI runs, the sticky comment should appear with the same content.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages

(The changeset present in this PR is part of the simulation, not a real release. No `release` label.)

## Follow-ups before this is mergeable

- Pin `marocchino/sticky-pull-request-comment@v2` to a SHA (the rest of the codebase pins third-party actions to SHA).
- Delete the two simulation files.
- Optional: add the workflow to required-checks-but-warn-only docs if PostHog has any.
