### PR TITLE
ci: test shared changeset-hygiene workflow [SIMULATION]

### DIFF
--- a/.changeset/hygiene-test-simulation.md
+++ b/.changeset/hygiene-test-simulation.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+[SIMULATION — DO NOT MERGE] Verifying the shared changeset-hygiene workflow. Code change is in `posthog-android-gradle-plugin/` but this changeset declares `posthog-android`. The workflow comment should call this out.

--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -1,0 +1,21 @@
+name: 'Changeset hygiene'
+
+on:
+    pull_request:
+        branches: [main]
+        types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+concurrency:
+    group: changeset-hygiene-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
+
+jobs:
+    check:
+        # NOTE: pinned to feat/changeset-hygiene for testing — change to @main once merged.
+        uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@feat/changeset-hygiene
+        with:
+            script-ref: feat/changeset-hygiene

--- a/posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md
+++ b/posthog-android-gradle-plugin/SIMULATION_DELETE_BEFORE_MERGE.md
@@ -1,0 +1,8 @@
+# Changeset hygiene simulation marker
+
+This file exists only to verify the new shared `changeset-hygiene` workflow in
+PostHog/.github. It's a no-op file inside `posthog-android-gradle-plugin/`
+paired with a changeset declaring a different package — the workflow should
+post a sticky comment flagging the mismatch.
+
+Delete this file (and the matching changeset) before merging.


### PR DESCRIPTION
## :bulb: Motivation and Context

**Draft / test — do not merge.** Verifies the new shared workflow at `PostHog/.github/.github/workflows/changeset-hygiene.yml@feat/changeset-hygiene` (PR coming in that repo separately).

This PR contains:
- A tiny caller workflow at `.github/workflows/changeset-hygiene.yml` that delegates to the shared one.
- A simulated mismatch: a marker file inside `posthog-android-gradle-plugin/` paired with a changeset declaring `posthog-android` (the wrong package), to trigger the warning.

Once the shared workflow is verified end-to-end here and on a parallel posthog-js test PR, the plan is:
1. Merge `PostHog/.github@feat/changeset-hygiene` → `main`.
2. Update this caller's `uses:` ref from `@feat/changeset-hygiene` → `@main`, drop the `script-ref` input, remove the simulation files, mark ready for review.
3. Same for posthog-js, where the caller PR also deletes `check-posthog-major-version.yml` (the shared workflow takes over that responsibility via the `forbidden-major-packages: posthog-js` input).

## :green_heart: How did you test it?

- Local dry-run of the shared script (`~/Develop/posthog-dotgithub/.github/scripts/check-changeset-coverage.mjs`) against this branch's diff — produces the expected `<!-- changeset-hygiene -->` sticky comment with the mismatch sections.
- This PR is the live integration test.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
