### PR TITLE
chore: sign release workflow commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         permissions:
             contents: write
         outputs:
-            committed: ${{ steps.commit-version-bump.outputs.committed }}
+            committed: ${{ steps.check-changes.outputs.committed }}
         steps:
             - name: Notify Slack - Approved
               continue-on-error: true
@@ -112,21 +112,26 @@ jobs:
                   sed -i "s/^serverVersion=.*/serverVersion=$SERVER_VERSION/" gradle.properties
                   sed -i "s/^androidPluginVersion=.*/androidPluginVersion=$PLUGIN_VERSION/" posthog-android-gradle-plugin/gradle.properties
 
+            - name: Check for version bump changes
+              id: check-changes
+              run: |
+                if [ -z "$(git status --porcelain)" ]; then
+                  echo "No changes to commit"
+                  echo "committed=false" >> "$GITHUB_OUTPUT"
+                else
+                  echo "committed=true" >> "$GITHUB_OUTPUT"
+                fi
+
             - name: Commit version bump
               id: commit-version-bump
-              run: |
-                  git add -A
-                  if git diff --staged --quiet; then
-                    echo "No changes to commit"
-                    echo "committed=false" >> "$GITHUB_OUTPUT"
-                  else
-                    git commit -m "chore: update versions and changelogs [version bump] [skip ci]"
-                    git push origin main
-                    echo "committed=true" >> "$GITHUB_OUTPUT"
-                  fi
+              if: steps.check-changes.outputs.committed == 'true'
+              uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+              with:
+                commit_message: "chore: update versions and changelogs [version bump] [skip ci]"
+                repo: ${{ github.repository }}
+                branch: main
               env:
-                  GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
-
+                GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
             - name: Notify Slack - Failed
               continue-on-error: true
               if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         permissions:
             contents: write
         outputs:
-            committed: ${{ steps.check-changes.outputs.committed }}
+            committed: ${{ steps.commit-version-bump.outputs.commit-hash != '' }}
         steps:
             - name: Notify Slack - Approved
               continue-on-error: true


### PR DESCRIPTION
## :bulb: Motivation and Context

Release workflows commit version bump changes during automated releases. Raw `git commit` / `git push` can fail in repositories that require verified commit signatures, so the workflow should use `planetscale/ghcommit-action`, matching other SDK release workflows.

## :green_heart: How did you test it?

- Parsed the updated workflow YAML successfully.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
