### PR TITLE
feat(surveys): add survey translations support

### DIFF
--- a/.changeset/survey-translations.md
+++ b/.changeset/survey-translations.md
@@ -1,0 +1,8 @@
+---
+"posthog": minor
+"posthog-android": minor
+---
+
+Add survey translations support. Surveys can carry per-language overrides for user-visible strings via a `translations` map keyed by language code. At display time the SDK resolves a language (init override → person property `"language"` → device locale), applies any matching translation onto the display model, and stamps the matched key as `$survey_language` on every survey event when a translation actually took effect.
+
+Configure via `PostHogSurveysConfig.overrideDisplayLanguage`. Matching is case-insensitive with a base-language fallback (e.g. `"pt-BR"` falls back to `"pt"`).

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -243,8 +243,6 @@ public class PostHogSurveysIntegration(
             return
         }
 
-        // Resolve the survey display language and apply translations once. The resulting
-        // matchedKey is stamped onto all three survey events as $survey_language.
         val displayLanguage = resolveDisplayLanguage()
         val translations = resolveSurveyTranslations(survey, displayLanguage)
         val resolvedLanguage = translations.matchedKey
@@ -598,12 +596,6 @@ public class PostHogSurveysIntegration(
     // Lifecycle management
     private var isStarted: Boolean = false
 
-    /**
-     * Resolves the language to use for the next survey display. Priority chain:
-     *   1. `PostHogSurveysConfig.overrideDisplayLanguage`
-     *   2. The `"language"` person property persisted by identify()
-     *   3. The device locale (BCP-47 tag, e.g. "en-US")
-     */
     private fun resolveDisplayLanguage(): String? {
         val override = config.surveysConfig.overrideDisplayLanguage
         val personProperties = readPersistedPersonProperties(config)

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -11,8 +11,11 @@ import com.posthog.internal.formatISO8601Date
 import com.posthog.internal.parseISO8601Date
 import com.posthog.internal.surveys.PostHogSurveysHandler
 import com.posthog.internal.surveys.canActivateRepeatedly
+import com.posthog.internal.surveys.detectSurveyLanguage
 import com.posthog.internal.surveys.hasEvents
 import com.posthog.internal.surveys.hasWaitPeriodPassed
+import com.posthog.internal.surveys.readPersistedPersonProperties
+import com.posthog.internal.surveys.resolveSurveyTranslations
 import com.posthog.surveys.OnPostHogSurveyClosed
 import com.posthog.surveys.OnPostHogSurveyResponse
 import com.posthog.surveys.OnPostHogSurveyShown
@@ -29,6 +32,7 @@ import com.posthog.surveys.SurveyQuestion
 import com.posthog.surveys.SurveyQuestionBranching
 import com.posthog.surveys.SurveyType
 import java.util.Date
+import java.util.Locale
 
 public class PostHogSurveysIntegration(
     context: Context,
@@ -239,7 +243,18 @@ public class PostHogSurveysIntegration(
             return
         }
 
-        val displaySurvey = PostHogDisplaySurvey.toDisplaySurvey(survey)
+        // Resolve the survey display language and apply translations once. The resulting
+        // matchedKey is stamped onto all three survey events as $survey_language.
+        val displayLanguage = resolveDisplayLanguage()
+        val translations = resolveSurveyTranslations(survey, displayLanguage)
+        val resolvedLanguage = translations.matchedKey
+
+        val displaySurvey =
+            PostHogDisplaySurvey.toDisplaySurvey(
+                survey,
+                surveyTranslation = translations.survey,
+                questionTranslations = translations.questions,
+            )
 
         // Store the original survey for branching logic
         val originalSurvey = survey
@@ -252,13 +267,14 @@ public class PostHogSurveysIntegration(
                 synchronized(activeSurveyLock) {
                     if (activeSurvey == null) {
                         activeSurvey = originalSurvey
+                        activeSurveyLanguage = resolvedLanguage
                         activeSurveyCompleted = false
                         currentSurveyResponses.clear()
                     }
                 }
 
                 // Send survey shown event
-                sendSurveyShownEvent(originalSurvey)
+                sendSurveyShownEvent(originalSurvey, resolvedLanguage)
 
                 // Clear up event-activated surveys if this survey has events
                 if (hasEvents(originalSurvey)) {
@@ -299,7 +315,7 @@ public class PostHogSurveysIntegration(
                 }
             }
 
-            responsesToSend?.let { sendSurveySentEvent(originalSurvey, it) }
+            responsesToSend?.let { sendSurveySentEvent(originalSurvey, it, resolvedLanguage) }
 
             nextQuestion
         }
@@ -321,13 +337,14 @@ public class PostHogSurveysIntegration(
                 wasSurveyCompleted = activeSurveyCompleted
 
                 activeSurvey = null
+                activeSurveyLanguage = null
                 activeSurveyCompleted = false
                 currentSurveyResponses.clear()
             }
 
             // Send survey dismissed event if survey was not completed
             if (!wasSurveyCompleted) {
-                sendSurveyDismissedEvent(originalSurvey, surveyResponses)
+                sendSurveyDismissedEvent(originalSurvey, surveyResponses, resolvedLanguage)
             }
 
             // Mark survey as seen
@@ -572,9 +589,28 @@ public class PostHogSurveysIntegration(
 
     // Active survey tracking
     private var activeSurvey: Survey? = null
+    private var activeSurveyLanguage: String? = null
 
     // Lifecycle management
     private var isStarted: Boolean = false
+
+    /**
+     * Resolves the language to use for the next survey display. Priority chain:
+     *   1. `PostHogSurveysConfig.overrideDisplayLanguage`
+     *   2. The `"language"` person property persisted by identify()
+     *   3. The device locale (BCP-47 tag, e.g. "en-US")
+     */
+    private fun resolveDisplayLanguage(): String? {
+        val override = config.surveysConfig.overrideDisplayLanguage
+        val personProperties = readPersistedPersonProperties(config)
+        val deviceLocale =
+            try {
+                Locale.getDefault().toLanguageTag()
+            } catch (_: Throwable) {
+                null
+            }
+        return detectSurveyLanguage(override, personProperties, deviceLocale)
+    }
 
     /**
      * Checks if we can show the next survey.
@@ -631,6 +667,7 @@ public class PostHogSurveysIntegration(
     private fun clearActiveSurvey() {
         synchronized(activeSurveyLock) {
             activeSurvey = null
+            activeSurveyLanguage = null
             activeSurveyCompleted = false
             currentSurveyResponses.clear()
         }
@@ -641,10 +678,14 @@ public class PostHogSurveysIntegration(
     /**
      * Sends a "survey shown" event to PostHog instance
      */
-    private fun sendSurveyShownEvent(survey: Survey) {
+    private fun sendSurveyShownEvent(
+        survey: Survey,
+        language: String?,
+    ) {
         sendSurveyEvent(
             event = "survey shown",
             survey = survey,
+            language = language,
         )
     }
 
@@ -657,6 +698,7 @@ public class PostHogSurveysIntegration(
     private fun sendSurveySentEvent(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
+        language: String?,
     ) {
         val additionalProperties =
             buildSurveyResponseProperties(survey, responses) +
@@ -671,6 +713,7 @@ public class PostHogSurveysIntegration(
             event = "survey sent",
             survey = survey,
             additionalProperties = additionalProperties,
+            language = language,
         )
     }
 
@@ -680,6 +723,7 @@ public class PostHogSurveysIntegration(
     private fun sendSurveyDismissedEvent(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
+        language: String?,
     ) {
         val additionalProperties =
             buildSurveyResponseProperties(survey, responses) +
@@ -695,6 +739,7 @@ public class PostHogSurveysIntegration(
             event = "survey dismissed",
             survey = survey,
             additionalProperties = additionalProperties,
+            language = language,
         )
     }
 
@@ -736,6 +781,7 @@ public class PostHogSurveysIntegration(
         event: String,
         survey: Survey,
         additionalProperties: Map<String, Any> = emptyMap(),
+        language: String? = null,
     ) {
         val postHog =
             postHog ?: run {
@@ -744,6 +790,9 @@ public class PostHogSurveysIntegration(
 
         val properties = getBaseSurveyEventProperties(survey).toMutableMap()
         properties.putAll(additionalProperties)
+        if (!language.isNullOrEmpty()) {
+            properties["\$survey_language"] = language
+        }
 
         postHog.capture(event, properties = properties)
     }

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -248,12 +248,13 @@ public class PostHogSurveysIntegration(
         val displayLanguage = resolveDisplayLanguage()
         val translations = resolveSurveyTranslations(survey, displayLanguage)
         val resolvedLanguage = translations.matchedKey
+        val resolvedQuestionTranslations = translations.questions
 
         val displaySurvey =
             PostHogDisplaySurvey.toDisplaySurvey(
                 survey,
                 surveyTranslation = translations.survey,
-                questionTranslations = translations.questions,
+                questionTranslations = resolvedQuestionTranslations,
             )
 
         // Store the original survey for branching logic
@@ -268,6 +269,7 @@ public class PostHogSurveysIntegration(
                     if (activeSurvey == null) {
                         activeSurvey = originalSurvey
                         activeSurveyLanguage = resolvedLanguage
+                        activeSurveyQuestionTranslations = resolvedQuestionTranslations
                         activeSurveyCompleted = false
                         currentSurveyResponses.clear()
                     }
@@ -315,7 +317,7 @@ public class PostHogSurveysIntegration(
                 }
             }
 
-            responsesToSend?.let { sendSurveySentEvent(originalSurvey, it, resolvedLanguage) }
+            responsesToSend?.let { sendSurveySentEvent(originalSurvey, it, resolvedLanguage, resolvedQuestionTranslations) }
 
             nextQuestion
         }
@@ -338,13 +340,14 @@ public class PostHogSurveysIntegration(
 
                 activeSurvey = null
                 activeSurveyLanguage = null
+                activeSurveyQuestionTranslations = null
                 activeSurveyCompleted = false
                 currentSurveyResponses.clear()
             }
 
             // Send survey dismissed event if survey was not completed
             if (!wasSurveyCompleted) {
-                sendSurveyDismissedEvent(originalSurvey, surveyResponses, resolvedLanguage)
+                sendSurveyDismissedEvent(originalSurvey, surveyResponses, resolvedLanguage, resolvedQuestionTranslations)
             }
 
             // Mark survey as seen
@@ -590,6 +593,7 @@ public class PostHogSurveysIntegration(
     // Active survey tracking
     private var activeSurvey: Survey? = null
     private var activeSurveyLanguage: String? = null
+    private var activeSurveyQuestionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>? = null
 
     // Lifecycle management
     private var isStarted: Boolean = false
@@ -668,6 +672,7 @@ public class PostHogSurveysIntegration(
         synchronized(activeSurveyLock) {
             activeSurvey = null
             activeSurveyLanguage = null
+            activeSurveyQuestionTranslations = null
             activeSurveyCompleted = false
             currentSurveyResponses.clear()
         }
@@ -699,9 +704,10 @@ public class PostHogSurveysIntegration(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
         language: String?,
+        questionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>?,
     ) {
         val additionalProperties =
-            buildSurveyResponseProperties(survey, responses) +
+            buildSurveyResponseProperties(survey, responses, questionTranslations) +
                 mapOf(
                     "\$set" to
                         mapOf(
@@ -724,9 +730,10 @@ public class PostHogSurveysIntegration(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
         language: String?,
+        questionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>?,
     ) {
         val additionalProperties =
-            buildSurveyResponseProperties(survey, responses) +
+            buildSurveyResponseProperties(survey, responses, questionTranslations) +
                 mapOf(
                     "\$survey_partially_completed" to surveyHasResponses(responses),
                     "\$set" to
@@ -746,6 +753,7 @@ public class PostHogSurveysIntegration(
     private fun buildSurveyResponseProperties(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
+        questionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>?,
     ): Map<String, Any> {
         val responsesProperties =
             responses.mapNotNull { (key, response) ->
@@ -758,7 +766,10 @@ public class PostHogSurveysIntegration(
             survey.questions.mapIndexed { index, question ->
                 mutableMapOf<String, Any>().apply {
                     question.id?.let { put("id", it) }
-                    question.question?.let { put("question", it) }
+                    // Use translated question text (if applied) so $survey_questions matches what the user saw.
+                    val translatedText = questionTranslations?.getOrNull(index)?.question
+                    val effectiveQuestion = translatedText ?: question.question
+                    effectiveQuestion?.let { put("question", it) }
 
                     val responseKey =
                         question.id?.takeIf { it.isNotEmpty() }?.let(::getQuestionIdResponseKey)

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -266,8 +266,6 @@ public class PostHogSurveysIntegration(
                 synchronized(activeSurveyLock) {
                     if (activeSurvey == null) {
                         activeSurvey = originalSurvey
-                        activeSurveyLanguage = resolvedLanguage
-                        activeSurveyQuestionTranslations = resolvedQuestionTranslations
                         activeSurveyCompleted = false
                         currentSurveyResponses.clear()
                     }
@@ -337,8 +335,6 @@ public class PostHogSurveysIntegration(
                 wasSurveyCompleted = activeSurveyCompleted
 
                 activeSurvey = null
-                activeSurveyLanguage = null
-                activeSurveyQuestionTranslations = null
                 activeSurveyCompleted = false
                 currentSurveyResponses.clear()
             }
@@ -590,8 +586,6 @@ public class PostHogSurveysIntegration(
 
     // Active survey tracking
     private var activeSurvey: Survey? = null
-    private var activeSurveyLanguage: String? = null
-    private var activeSurveyQuestionTranslations: List<SurveyQuestionTranslation?>? = null
 
     // Lifecycle management
     private var isStarted: Boolean = false
@@ -658,8 +652,6 @@ public class PostHogSurveysIntegration(
     private fun clearActiveSurvey() {
         synchronized(activeSurveyLock) {
             activeSurvey = null
-            activeSurveyLanguage = null
-            activeSurveyQuestionTranslations = null
             activeSurveyCompleted = false
             currentSurveyResponses.clear()
         }

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -14,7 +14,6 @@ import com.posthog.internal.surveys.canActivateRepeatedly
 import com.posthog.internal.surveys.detectSurveyLanguage
 import com.posthog.internal.surveys.hasEvents
 import com.posthog.internal.surveys.hasWaitPeriodPassed
-import com.posthog.internal.surveys.readPersistedPersonProperties
 import com.posthog.internal.surveys.resolveSurveyTranslations
 import com.posthog.surveys.OnPostHogSurveyClosed
 import com.posthog.surveys.OnPostHogSurveyResponse
@@ -30,6 +29,7 @@ import com.posthog.surveys.SurveyMatchType
 import com.posthog.surveys.SurveyPropertyFilter
 import com.posthog.surveys.SurveyQuestion
 import com.posthog.surveys.SurveyQuestionBranching
+import com.posthog.surveys.SurveyQuestionTranslation
 import com.posthog.surveys.SurveyType
 import java.util.Date
 import java.util.Locale
@@ -591,20 +591,15 @@ public class PostHogSurveysIntegration(
     // Active survey tracking
     private var activeSurvey: Survey? = null
     private var activeSurveyLanguage: String? = null
-    private var activeSurveyQuestionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>? = null
+    private var activeSurveyQuestionTranslations: List<SurveyQuestionTranslation?>? = null
 
     // Lifecycle management
     private var isStarted: Boolean = false
 
     private fun resolveDisplayLanguage(): String? {
         val override = config.surveysConfig.overrideDisplayLanguage
-        val personProperties = readPersistedPersonProperties(config)
-        val deviceLocale =
-            try {
-                Locale.getDefault().toLanguageTag()
-            } catch (_: Throwable) {
-                null
-            }
+        val personProperties = config.remoteConfigHolder?.getPersonPropertiesForFlags()
+        val deviceLocale = Locale.getDefault().toLanguageTag()
         return detectSurveyLanguage(override, personProperties, deviceLocale)
     }
 
@@ -696,7 +691,7 @@ public class PostHogSurveysIntegration(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
         language: String?,
-        questionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>?,
+        questionTranslations: List<SurveyQuestionTranslation?>?,
     ) {
         val additionalProperties =
             buildSurveyResponseProperties(survey, responses, questionTranslations) +
@@ -722,7 +717,7 @@ public class PostHogSurveysIntegration(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
         language: String?,
-        questionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>?,
+        questionTranslations: List<SurveyQuestionTranslation?>?,
     ) {
         val additionalProperties =
             buildSurveyResponseProperties(survey, responses, questionTranslations) +
@@ -745,7 +740,7 @@ public class PostHogSurveysIntegration(
     private fun buildSurveyResponseProperties(
         survey: Survey,
         responses: Map<String, PostHogSurveyResponse>,
-        questionTranslations: List<com.posthog.surveys.SurveyQuestionTranslation?>?,
+        questionTranslations: List<SurveyQuestionTranslation?>?,
     ): Map<String, Any> {
         val responsesProperties =
             responses.mapNotNull { (key, response) ->

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysTranslationsTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysTranslationsTest.kt
@@ -1,0 +1,228 @@
+package com.posthog.android.surveys
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.posthog.PostHogConfig
+import com.posthog.android.PostHogFake
+import com.posthog.internal.PostHogSerializer
+import com.posthog.surveys.OnPostHogSurveyClosed
+import com.posthog.surveys.OnPostHogSurveyResponse
+import com.posthog.surveys.OnPostHogSurveyShown
+import com.posthog.surveys.PostHogDisplaySurvey
+import com.posthog.surveys.PostHogSurveyResponse
+import com.posthog.surveys.PostHogSurveysDelegate
+import com.posthog.surveys.Survey
+import com.posthog.surveys.SurveyQuestion
+import com.posthog.surveys.SurveyQuestionTranslation
+import com.posthog.surveys.SurveyTranslation
+import com.posthog.surveys.SurveyType
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+internal class PostHogSurveysTranslationsTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+    private val serializer = PostHogSerializer(PostHogConfig("test-api-key"))
+
+    private class RecordingDelegate : PostHogSurveysDelegate {
+        var shownSurvey: PostHogDisplaySurvey? = null
+        var onSurveyShown: OnPostHogSurveyShown? = null
+        var onSurveyResponse: OnPostHogSurveyResponse? = null
+        var onSurveyClosed: OnPostHogSurveyClosed? = null
+
+        override fun renderSurvey(
+            survey: PostHogDisplaySurvey,
+            onSurveyShown: OnPostHogSurveyShown,
+            onSurveyResponse: OnPostHogSurveyResponse,
+            onSurveyClosed: OnPostHogSurveyClosed,
+        ) {
+            shownSurvey = survey
+            this.onSurveyShown = onSurveyShown
+            this.onSurveyResponse = onSurveyResponse
+            this.onSurveyClosed = onSurveyClosed
+        }
+
+        override fun cleanupSurveys() {}
+    }
+
+    private fun createIntegration(
+        delegate: RecordingDelegate,
+        overrideLanguage: String? = null,
+    ): Pair<PostHogSurveysIntegration, PostHogFake> {
+        val config =
+            PostHogConfig("test-api-key").apply {
+                surveys = true
+                surveysConfig.surveysDelegate = delegate
+                surveysConfig.overrideDisplayLanguage = overrideLanguage
+            }
+
+        val integration = PostHogSurveysIntegration(context, config)
+        val postHog = PostHogFake()
+        integration.install(postHog)
+
+        return integration to postHog
+    }
+
+    private fun createQuestion(
+        id: String,
+        question: String,
+        translations: Map<String, SurveyQuestionTranslation>? = null,
+    ): SurveyQuestion {
+        val map =
+            mutableMapOf<String, Any?>(
+                "id" to id,
+                "type" to "open",
+                "question" to question,
+                "description" to null,
+                "descriptionContentType" to "text",
+                "optional" to false,
+                "buttonText" to null,
+                "branching" to null,
+            )
+        if (translations != null) {
+            map["translations"] =
+                translations.mapValues { (_, t) ->
+                    mapOf(
+                        "question" to t.question,
+                        "description" to t.description,
+                        "buttonText" to t.buttonText,
+                        "link" to t.link,
+                        "lowerBoundLabel" to t.lowerBoundLabel,
+                        "upperBoundLabel" to t.upperBoundLabel,
+                        "choices" to t.choices,
+                    )
+                }
+        }
+        return checkNotNull(
+            serializer.deserializeList<SurveyQuestion>(listOf(map))?.firstOrNull(),
+        )
+    }
+
+    private fun createSurveyWithTranslations(
+        questionTranslations: Map<String, SurveyQuestionTranslation>? = null,
+        surveyTranslations: Map<String, SurveyTranslation>? = null,
+    ): Survey {
+        return Survey(
+            id = "translated-survey",
+            name = "Original Name",
+            type = SurveyType.POPOVER,
+            questions = listOf(createQuestion("q-1", "Original question?", questionTranslations)),
+            description = null,
+            featureFlagKeys = null,
+            linkedFlagKey = null,
+            targetingFlagKey = null,
+            internalTargetingFlagKey = null,
+            conditions = null,
+            appearance = null,
+            currentIteration = null,
+            currentIterationStartDate = null,
+            startDate = java.util.Date(),
+            endDate = null,
+            schedule = null,
+            translations = surveyTranslations,
+        )
+    }
+
+    @Test
+    fun `survey events include survey_language when override matches translation`() {
+        val delegate = RecordingDelegate()
+        val (integration, postHog) =
+            createIntegration(
+                delegate,
+                overrideLanguage = "fr",
+            )
+        val survey =
+            createSurveyWithTranslations(
+                questionTranslations = mapOf("fr" to SurveyQuestionTranslation(question = "Question traduite?")),
+            )
+
+        integration.showSurvey(survey)
+        val shownSurvey = assertNotNull(delegate.shownSurvey)
+
+        // Translated text reaches the delegate
+        assertEquals("Question traduite?", shownSurvey.questions[0].question)
+
+        // survey shown event has $survey_language
+        assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
+        assertEquals("survey shown", postHog.event)
+        assertEquals("fr", postHog.properties?.get("\$survey_language"))
+
+        // survey sent event has $survey_language and translated question text in $survey_questions
+        assertNotNull(delegate.onSurveyResponse).invoke(shownSurvey, 0, PostHogSurveyResponse.Text("Response"))
+        assertEquals("survey sent", postHog.event)
+        assertEquals("fr", postHog.properties?.get("\$survey_language"))
+
+        @Suppress("UNCHECKED_CAST")
+        val questions = postHog.properties?.get("\$survey_questions") as? List<Map<String, Any>>
+        assertEquals("Question traduite?", questions?.firstOrNull()?.get("question"))
+    }
+
+    @Test
+    fun `survey dismissed includes survey_language when translation applied`() {
+        val delegate = RecordingDelegate()
+        val (integration, postHog) =
+            createIntegration(
+                delegate,
+                overrideLanguage = "pt-BR",
+            )
+        val survey =
+            createSurveyWithTranslations(
+                // Question translation only under "pt" — base-language fallback applies
+                questionTranslations = mapOf("pt" to SurveyQuestionTranslation(question = "Pergunta?")),
+            )
+
+        integration.showSurvey(survey)
+        val shownSurvey = assertNotNull(delegate.shownSurvey)
+        assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
+        assertNotNull(delegate.onSurveyClosed).invoke(shownSurvey)
+
+        assertEquals("survey dismissed", postHog.event)
+        // matchedKey is the original-cased dictionary key, not the request
+        assertEquals("pt", postHog.properties?.get("\$survey_language"))
+    }
+
+    @Test
+    fun `survey events omit survey_language when no translation matches`() {
+        val delegate = RecordingDelegate()
+        val (integration, postHog) =
+            createIntegration(
+                delegate,
+                overrideLanguage = "ja",
+            )
+        val survey =
+            createSurveyWithTranslations(
+                questionTranslations = mapOf("fr" to SurveyQuestionTranslation(question = "Bonjour?")),
+            )
+
+        integration.showSurvey(survey)
+        val shownSurvey = assertNotNull(delegate.shownSurvey)
+
+        // No translation applied — UI shows original
+        assertEquals("Original question?", shownSurvey.questions[0].question)
+
+        assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
+        assertNull(postHog.properties?.get("\$survey_language"))
+
+        assertNotNull(delegate.onSurveyResponse).invoke(shownSurvey, 0, PostHogSurveyResponse.Text("Hi"))
+        assertNull(postHog.properties?.get("\$survey_language"))
+    }
+
+    @Test
+    fun `survey without translations omits survey_language even when language override set`() {
+        val delegate = RecordingDelegate()
+        val (integration, postHog) =
+            createIntegration(
+                delegate,
+                overrideLanguage = "fr",
+            )
+        val survey = createSurveyWithTranslations() // no translations
+
+        integration.showSurvey(survey)
+        val shownSurvey = assertNotNull(delegate.shownSurvey)
+        assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
+        assertNull(postHog.properties?.get("\$survey_language"))
+    }
+}

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysTranslationsTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysTranslationsTest.kt
@@ -12,11 +12,9 @@ import com.posthog.surveys.PostHogDisplaySurvey
 import com.posthog.surveys.PostHogSurveyResponse
 import com.posthog.surveys.PostHogSurveysDelegate
 import com.posthog.surveys.Survey
-import com.posthog.surveys.SurveyQuestion
-import com.posthog.surveys.SurveyQuestionTranslation
-import com.posthog.surveys.SurveyTranslation
-import com.posthog.surveys.SurveyType
 import org.junit.runner.RunWith
+import java.io.StringReader
+import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -66,64 +64,10 @@ internal class PostHogSurveysTranslationsTest {
         return integration to postHog
     }
 
-    private fun createQuestion(
-        id: String,
-        question: String,
-        translations: Map<String, SurveyQuestionTranslation>? = null,
-    ): SurveyQuestion {
-        val map =
-            mutableMapOf<String, Any?>(
-                "id" to id,
-                "type" to "open",
-                "question" to question,
-                "description" to null,
-                "descriptionContentType" to "text",
-                "optional" to false,
-                "buttonText" to null,
-                "branching" to null,
-            )
-        if (translations != null) {
-            map["translations"] =
-                translations.mapValues { (_, t) ->
-                    mapOf(
-                        "question" to t.question,
-                        "description" to t.description,
-                        "buttonText" to t.buttonText,
-                        "link" to t.link,
-                        "lowerBoundLabel" to t.lowerBoundLabel,
-                        "upperBoundLabel" to t.upperBoundLabel,
-                        "choices" to t.choices,
-                    )
-                }
-        }
-        return checkNotNull(
-            serializer.deserializeList<SurveyQuestion>(listOf(map))?.firstOrNull(),
-        )
-    }
-
-    private fun createSurveyWithTranslations(
-        questionTranslations: Map<String, SurveyQuestionTranslation>? = null,
-        surveyTranslations: Map<String, SurveyTranslation>? = null,
-    ): Survey {
-        return Survey(
-            id = "translated-survey",
-            name = "Original Name",
-            type = SurveyType.POPOVER,
-            questions = listOf(createQuestion("q-1", "Original question?", questionTranslations)),
-            description = null,
-            featureFlagKeys = null,
-            linkedFlagKey = null,
-            targetingFlagKey = null,
-            internalTargetingFlagKey = null,
-            conditions = null,
-            appearance = null,
-            currentIteration = null,
-            currentIterationStartDate = null,
-            startDate = java.util.Date(),
-            endDate = null,
-            schedule = null,
-            translations = surveyTranslations,
-        )
+    private fun decodeSurvey(json: String): Survey {
+        val survey = serializer.deserialize<Survey>(StringReader(json))
+        // Round-trip the survey through copy() so startDate is set to now (matching constructor pattern)
+        return survey.copy(startDate = Date())
     }
 
     @Test
@@ -134,12 +78,8 @@ internal class PostHogSurveysTranslationsTest {
                 delegate,
                 overrideLanguage = "fr",
             )
-        val survey =
-            createSurveyWithTranslations(
-                questionTranslations = mapOf("fr" to SurveyQuestionTranslation(question = "Question traduite?")),
-            )
 
-        integration.showSurvey(survey)
+        integration.showSurvey(decodeSurvey(SURVEY_WITH_FR_QUESTION_TRANSLATION))
         val shownSurvey = assertNotNull(delegate.shownSurvey)
 
         // Translated text reaches the delegate
@@ -161,26 +101,21 @@ internal class PostHogSurveysTranslationsTest {
     }
 
     @Test
-    fun `survey dismissed includes survey_language when translation applied`() {
+    fun `survey dismissed includes survey_language when translation applied via base language fallback`() {
         val delegate = RecordingDelegate()
         val (integration, postHog) =
             createIntegration(
                 delegate,
                 overrideLanguage = "pt-BR",
             )
-        val survey =
-            createSurveyWithTranslations(
-                // Question translation only under "pt" — base-language fallback applies
-                questionTranslations = mapOf("pt" to SurveyQuestionTranslation(question = "Pergunta?")),
-            )
 
-        integration.showSurvey(survey)
+        integration.showSurvey(decodeSurvey(SURVEY_WITH_PT_QUESTION_TRANSLATION))
         val shownSurvey = assertNotNull(delegate.shownSurvey)
         assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
         assertNotNull(delegate.onSurveyClosed).invoke(shownSurvey)
 
         assertEquals("survey dismissed", postHog.event)
-        // matchedKey is the original-cased dictionary key, not the request
+        // matchedKey is the original-cased dictionary key, not the requested target
         assertEquals("pt", postHog.properties?.get("\$survey_language"))
     }
 
@@ -192,12 +127,8 @@ internal class PostHogSurveysTranslationsTest {
                 delegate,
                 overrideLanguage = "ja",
             )
-        val survey =
-            createSurveyWithTranslations(
-                questionTranslations = mapOf("fr" to SurveyQuestionTranslation(question = "Bonjour?")),
-            )
 
-        integration.showSurvey(survey)
+        integration.showSurvey(decodeSurvey(SURVEY_WITH_FR_QUESTION_TRANSLATION))
         val shownSurvey = assertNotNull(delegate.shownSurvey)
 
         // No translation applied — UI shows original
@@ -211,18 +142,124 @@ internal class PostHogSurveysTranslationsTest {
     }
 
     @Test
-    fun `survey without translations omits survey_language even when language override set`() {
+    fun `survey without translations omits survey_language even when override is set`() {
         val delegate = RecordingDelegate()
         val (integration, postHog) =
             createIntegration(
                 delegate,
                 overrideLanguage = "fr",
             )
-        val survey = createSurveyWithTranslations() // no translations
 
-        integration.showSurvey(survey)
+        integration.showSurvey(decodeSurvey(SURVEY_WITHOUT_TRANSLATIONS))
         val shownSurvey = assertNotNull(delegate.shownSurvey)
         assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
         assertNull(postHog.properties?.get("\$survey_language"))
+    }
+
+    private companion object {
+        private val SURVEY_WITH_FR_QUESTION_TRANSLATION =
+            """
+            {
+              "id": "translated-survey",
+              "name": "Original Name",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "appearance": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": "2025-01-01T00:00:00.000Z",
+              "end_date": null,
+              "schedule": null,
+              "questions": [
+                {
+                  "id": "q-1",
+                  "type": "open",
+                  "question": "Original question?",
+                  "description": null,
+                  "descriptionContentType": "text",
+                  "optional": false,
+                  "buttonText": null,
+                  "branching": null,
+                  "translations": {
+                    "fr": { "question": "Question traduite?" }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        private val SURVEY_WITH_PT_QUESTION_TRANSLATION =
+            """
+            {
+              "id": "translated-survey",
+              "name": "Original Name",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "appearance": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": "2025-01-01T00:00:00.000Z",
+              "end_date": null,
+              "schedule": null,
+              "questions": [
+                {
+                  "id": "q-1",
+                  "type": "open",
+                  "question": "Original question?",
+                  "description": null,
+                  "descriptionContentType": "text",
+                  "optional": false,
+                  "buttonText": null,
+                  "branching": null,
+                  "translations": {
+                    "pt": { "question": "Pergunta?" }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        private val SURVEY_WITHOUT_TRANSLATIONS =
+            """
+            {
+              "id": "translated-survey",
+              "name": "Original Name",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "appearance": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": "2025-01-01T00:00:00.000Z",
+              "end_date": null,
+              "schedule": null,
+              "questions": [
+                {
+                  "id": "q-1",
+                  "type": "open",
+                  "question": "Original question?",
+                  "description": null,
+                  "descriptionContentType": "text",
+                  "optional": false,
+                  "buttonText": null,
+                  "branching": null
+                }
+              ]
+            }
+            """.trimIndent()
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysTranslationsTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysTranslationsTest.kt
@@ -156,6 +156,29 @@ internal class PostHogSurveysTranslationsTest {
         assertNull(postHog.properties?.get("\$survey_language"))
     }
 
+    @Test
+    fun `events omit survey_language when translation matches but values are identical`() {
+        // Translation dictionary lookup succeeds (target "fr" matches the "fr" key) but
+        // the translated values are identical to the originals, so nothing actually
+        // changed on screen and no $survey_language should be stamped on events.
+        val delegate = RecordingDelegate()
+        val (integration, postHog) =
+            createIntegration(
+                delegate,
+                overrideLanguage = "fr",
+            )
+
+        integration.showSurvey(decodeSurvey(SURVEY_WITH_NOOP_TRANSLATION))
+        val shownSurvey = assertNotNull(delegate.shownSurvey)
+        assertNotNull(delegate.onSurveyShown).invoke(shownSurvey)
+        assertEquals("survey shown", postHog.event)
+        assertNull(postHog.properties?.get("\$survey_language"))
+
+        assertNotNull(delegate.onSurveyResponse).invoke(shownSurvey, 0, PostHogSurveyResponse.Text("ok"))
+        assertEquals("survey sent", postHog.event)
+        assertNull(postHog.properties?.get("\$survey_language"))
+    }
+
     private companion object {
         private val SURVEY_WITH_FR_QUESTION_TRANSLATION =
             """
@@ -223,6 +246,42 @@ internal class PostHogSurveysTranslationsTest {
                   "branching": null,
                   "translations": {
                     "pt": { "question": "Pergunta?" }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        private val SURVEY_WITH_NOOP_TRANSLATION =
+            """
+            {
+              "id": "translated-survey",
+              "name": "Original Name",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "appearance": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": "2025-01-01T00:00:00.000Z",
+              "end_date": null,
+              "schedule": null,
+              "questions": [
+                {
+                  "id": "q-1",
+                  "type": "open",
+                  "question": "Original question?",
+                  "description": null,
+                  "descriptionContentType": "text",
+                  "optional": false,
+                  "buttonText": null,
+                  "branching": null,
+                  "translations": {
+                    "fr": { "question": "Original question?" }
                   }
                 }
               ]

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -1349,6 +1349,31 @@ public final class com/posthog/internal/surveys/PostHogSurveysHandler$DefaultImp
 	public static synthetic fun onEvent$default (Lcom/posthog/internal/surveys/PostHogSurveysHandler;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
+public final class com/posthog/internal/surveys/ResolvedSurveyTranslations {
+	public fun <init> (Ljava/lang/String;Lcom/posthog/surveys/SurveyTranslation;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/posthog/surveys/SurveyTranslation;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lcom/posthog/surveys/SurveyTranslation;Ljava/util/List;)Lcom/posthog/internal/surveys/ResolvedSurveyTranslations;
+	public static synthetic fun copy$default (Lcom/posthog/internal/surveys/ResolvedSurveyTranslations;Ljava/lang/String;Lcom/posthog/surveys/SurveyTranslation;Ljava/util/List;ILjava/lang/Object;)Lcom/posthog/internal/surveys/ResolvedSurveyTranslations;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMatchedKey ()Ljava/lang/String;
+	public final fun getQuestions ()Ljava/util/List;
+	public final fun getSurvey ()Lcom/posthog/surveys/SurveyTranslation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/posthog/internal/surveys/SurveyLanguageDetectionKt {
+	public static final fun detectSurveyLanguage (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun findBestTranslationMatch (Ljava/util/Map;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun readPersistedPersonProperties (Lcom/posthog/PostHogConfig;)Ljava/util/Map;
+}
+
+public final class com/posthog/internal/surveys/SurveyTranslationApplierKt {
+	public static final fun resolveSurveyTranslations (Lcom/posthog/surveys/Survey;Ljava/lang/String;)Lcom/posthog/internal/surveys/ResolvedSurveyTranslations;
+}
+
 public final class com/posthog/internal/surveys/SurveyUtilsKt {
 	public static final fun canActivateRepeatedly (Lcom/posthog/surveys/Survey;)Z
 	public static final fun hasEvents (Lcom/posthog/surveys/Survey;)Z
@@ -1435,7 +1460,8 @@ public final class com/posthog/surveys/PostHogDisplaySurvey {
 }
 
 public final class com/posthog/surveys/PostHogDisplaySurvey$Companion {
-	public final fun toDisplaySurvey (Lcom/posthog/surveys/Survey;)Lcom/posthog/surveys/PostHogDisplaySurvey;
+	public final fun toDisplaySurvey (Lcom/posthog/surveys/Survey;Lcom/posthog/surveys/SurveyTranslation;Ljava/util/List;)Lcom/posthog/surveys/PostHogDisplaySurvey;
+	public static synthetic fun toDisplaySurvey$default (Lcom/posthog/surveys/PostHogDisplaySurvey$Companion;Lcom/posthog/surveys/Survey;Lcom/posthog/surveys/SurveyTranslation;Ljava/util/List;ILjava/lang/Object;)Lcom/posthog/surveys/PostHogDisplaySurvey;
 }
 
 public final class com/posthog/surveys/PostHogDisplaySurveyAppearance {
@@ -1581,7 +1607,9 @@ public final class com/posthog/surveys/PostHogSurveyResponse$Text : com/posthog/
 
 public final class com/posthog/surveys/PostHogSurveysConfig {
 	public fun <init> ()V
+	public final fun getOverrideDisplayLanguage ()Ljava/lang/String;
 	public final fun getSurveysDelegate ()Lcom/posthog/surveys/PostHogSurveysDelegate;
+	public final fun setOverrideDisplayLanguage (Ljava/lang/String;)V
 	public final fun setSurveysDelegate (Lcom/posthog/surveys/PostHogSurveysDelegate;)V
 }
 
@@ -1622,7 +1650,8 @@ public final class com/posthog/surveys/SingleSurveyQuestion : com/posthog/survey
 }
 
 public final class com/posthog/surveys/Survey {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/posthog/surveys/SurveyConditions;
 	public final fun component11 ()Lcom/posthog/surveys/SurveyAppearance;
@@ -1631,6 +1660,7 @@ public final class com/posthog/surveys/Survey {
 	public final fun component14 ()Ljava/util/Date;
 	public final fun component15 ()Ljava/util/Date;
 	public final fun component16 ()Lcom/posthog/surveys/SurveySchedule;
+	public final fun component17 ()Ljava/util/Map;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/posthog/surveys/SurveyType;
 	public final fun component4 ()Ljava/util/List;
@@ -1639,8 +1669,8 @@ public final class com/posthog/surveys/Survey {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;)Lcom/posthog/surveys/Survey;
-	public static synthetic fun copy$default (Lcom/posthog/surveys/Survey;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;ILjava/lang/Object;)Lcom/posthog/surveys/Survey;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;Ljava/util/Map;)Lcom/posthog/surveys/Survey;
+	public static synthetic fun copy$default (Lcom/posthog/surveys/Survey;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyType;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/surveys/SurveyConditions;Lcom/posthog/surveys/SurveyAppearance;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lcom/posthog/surveys/SurveySchedule;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/surveys/Survey;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppearance ()Lcom/posthog/surveys/SurveyAppearance;
 	public final fun getConditions ()Lcom/posthog/surveys/SurveyConditions;
@@ -1657,6 +1687,7 @@ public final class com/posthog/surveys/Survey {
 	public final fun getSchedule ()Lcom/posthog/surveys/SurveySchedule;
 	public final fun getStartDate ()Ljava/util/Date;
 	public final fun getTargetingFlagKey ()Ljava/lang/String;
+	public final fun getTranslations ()Ljava/util/Map;
 	public final fun getType ()Lcom/posthog/surveys/SurveyType;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1855,6 +1886,7 @@ public class com/posthog/surveys/SurveyQuestion {
 	public final fun getId ()Ljava/lang/String;
 	public final fun getOptional ()Ljava/lang/Boolean;
 	public final fun getQuestion ()Ljava/lang/String;
+	public final fun getTranslations ()Ljava/util/Map;
 	public final fun getType ()Lcom/posthog/surveys/SurveyQuestionType;
 }
 
@@ -1893,6 +1925,31 @@ public final class com/posthog/surveys/SurveyQuestionBranchingType : java/lang/E
 
 public final class com/posthog/surveys/SurveyQuestionBranchingType$Companion {
 	public final fun fromValue (Ljava/lang/String;)Lcom/posthog/surveys/SurveyQuestionBranchingType;
+}
+
+public final class com/posthog/surveys/SurveyQuestionTranslation {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/posthog/surveys/SurveyQuestionTranslation;
+	public static synthetic fun copy$default (Lcom/posthog/surveys/SurveyQuestionTranslation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/posthog/surveys/SurveyQuestionTranslation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getButtonText ()Ljava/lang/String;
+	public final fun getChoices ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getLink ()Ljava/lang/String;
+	public final fun getLowerBoundLabel ()Ljava/lang/String;
+	public final fun getQuestion ()Ljava/lang/String;
+	public final fun getUpperBoundLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/posthog/surveys/SurveyQuestionType : java/lang/Enum {
@@ -1953,6 +2010,25 @@ public final class com/posthog/surveys/SurveyTextContentType : java/lang/Enum {
 
 public final class com/posthog/surveys/SurveyTextContentType$Companion {
 	public final fun fromValue (Ljava/lang/String;)Lcom/posthog/surveys/SurveyTextContentType;
+}
+
+public final class com/posthog/surveys/SurveyTranslation {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/posthog/surveys/SurveyTranslation;
+	public static synthetic fun copy$default (Lcom/posthog/surveys/SurveyTranslation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/posthog/surveys/SurveyTranslation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getThankYouMessageCloseButtonText ()Ljava/lang/String;
+	public final fun getThankYouMessageDescription ()Ljava/lang/String;
+	public final fun getThankYouMessageHeader ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/posthog/surveys/SurveyType : java/lang/Enum {

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -865,6 +865,7 @@ public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/intern
 	public fun getFeatureFlagResult (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/FeatureFlagResult;
 	public fun getFeatureFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
 	public final fun getFlagDetails (Ljava/lang/String;)Lcom/posthog/internal/FeatureFlag;
+	public final fun getPersonPropertiesForFlags ()Ljava/util/Map;
 	public final fun getRecordingMinimumDurationMs ()Ljava/lang/Long;
 	public fun getRequestId (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/String;
 	public final fun getSessionRecordingSampleRate ()Ljava/lang/Double;
@@ -1367,7 +1368,6 @@ public final class com/posthog/internal/surveys/ResolvedSurveyTranslations {
 public final class com/posthog/internal/surveys/SurveyLanguageDetectionKt {
 	public static final fun detectSurveyLanguage (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun findBestTranslationMatch (Ljava/util/Map;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun readPersistedPersonProperties (Lcom/posthog/PostHogConfig;)Ljava/util/Map;
 }
 
 public final class com/posthog/internal/surveys/SurveyTranslationApplierKt {

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -1092,7 +1092,8 @@ public class PostHogRemoteConfig(
         }
     }
 
-    private fun getPersonPropertiesForFlags(): Map<String, Any> {
+    @PostHogInternal
+    public fun getPersonPropertiesForFlags(): Map<String, Any> {
         synchronized(personPropertiesForFlagsLock) {
             val properties = mutableMapOf<String, Any>()
 

--- a/posthog/src/main/java/com/posthog/internal/surveys/ResolvedSurveyTranslations.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/ResolvedSurveyTranslations.kt
@@ -1,0 +1,19 @@
+package com.posthog.internal.surveys
+
+import com.posthog.PostHogInternal
+import com.posthog.surveys.Survey
+import com.posthog.surveys.SurveyQuestionTranslation
+import com.posthog.surveys.SurveyTranslation
+
+/**
+ * [matchedKey] is the original-cased key from a `translations` dictionary that drove
+ * the change (preferring the survey-level key when both survey and question matched),
+ * or `null` when no user-visible field actually changed. [questions] is indexed
+ * positionally against [Survey.questions].
+ */
+@PostHogInternal
+public data class ResolvedSurveyTranslations(
+    val matchedKey: String?,
+    val survey: SurveyTranslation?,
+    val questions: List<SurveyQuestionTranslation?>,
+)

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyLanguageDetection.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyLanguageDetection.kt
@@ -1,0 +1,76 @@
+package com.posthog.internal.surveys
+
+import com.posthog.PostHogConfig
+import com.posthog.PostHogInternal
+
+/**
+ * Resolves the language code to use for survey translation, in priority order:
+ *
+ *  1. Explicit SDK override (`PostHogSurveysConfig.overrideDisplayLanguage`).
+ *  2. The `"language"` key of the persisted person properties (set via `identify(..., { language: "fr" })`).
+ *  3. The device locale.
+ *
+ * Returns the first non-blank string from that chain, or `null` if all three are empty.
+ */
+@PostHogInternal
+public fun detectSurveyLanguage(
+    overrideLanguage: String?,
+    personProperties: Map<String, Any?>?,
+    deviceLocale: String?,
+): String? {
+    overrideLanguage?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+
+    val personLanguage = personProperties?.get(PERSON_PROPERTY_LANGUAGE) as? String
+    personLanguage?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+
+    deviceLocale?.trim()?.takeIf { it.isNotEmpty() }?.let { return it }
+
+    return null
+}
+
+/**
+ * Finds the best matching translation key in [translations] for [targetLanguage].
+ *
+ * Matching is case-insensitive. If no exact match is found and the target contains a
+ * region suffix (e.g. `pt-BR`), the base language (e.g. `pt`) is tried as a fallback.
+ *
+ * Returns the original-cased key from [translations] (so it can be reported verbatim
+ * as `$survey_language`), or `null` if no match.
+ */
+@PostHogInternal
+public fun <T> findBestTranslationMatch(
+    translations: Map<String, T>?,
+    targetLanguage: String?,
+): String? {
+    if (translations.isNullOrEmpty() || targetLanguage.isNullOrBlank()) return null
+
+    val normalizedTarget = targetLanguage.lowercase()
+
+    translations.keys.firstOrNull { it.lowercase() == normalizedTarget }?.let { return it }
+
+    val hyphenIndex = normalizedTarget.indexOf('-')
+    if (hyphenIndex > 0) {
+        val base = normalizedTarget.substring(0, hyphenIndex)
+        translations.keys.firstOrNull { it.lowercase() == base }?.let { return it }
+    }
+
+    return null
+}
+
+/**
+ * Reads the persisted person properties dictionary written by `identify()` and
+ * `setPersonPropertiesForFlags()`. Returns an empty map when nothing is persisted.
+ *
+ * NOTE: the storage key here intentionally duplicates the value of the (internal)
+ * `PostHogPreferences.PERSON_PROPERTIES_FOR_FLAGS` constant. Keeping it local avoids
+ * widening the SDK's internal preference key API surface.
+ */
+@PostHogInternal
+public fun readPersistedPersonProperties(config: PostHogConfig): Map<String, Any?> {
+    val raw = config.cachePreferences?.getValue(PERSON_PROPERTIES_FOR_FLAGS_KEY) ?: return emptyMap()
+    @Suppress("UNCHECKED_CAST")
+    return (raw as? Map<String, Any?>) ?: emptyMap()
+}
+
+private const val PERSON_PROPERTY_LANGUAGE = "language"
+private const val PERSON_PROPERTIES_FOR_FLAGS_KEY = "personPropertiesForFlags"

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyLanguageDetection.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyLanguageDetection.kt
@@ -1,6 +1,5 @@
 package com.posthog.internal.surveys
 
-import com.posthog.PostHogConfig
 import com.posthog.PostHogInternal
 
 /**
@@ -57,20 +56,4 @@ public fun <T> findBestTranslationMatch(
     return null
 }
 
-/**
- * Reads the persisted person properties dictionary written by `identify()` and
- * `setPersonPropertiesForFlags()`. Returns an empty map when nothing is persisted.
- *
- * NOTE: the storage key here intentionally duplicates the value of the (internal)
- * `PostHogPreferences.PERSON_PROPERTIES_FOR_FLAGS` constant. Keeping it local avoids
- * widening the SDK's internal preference key API surface.
- */
-@PostHogInternal
-public fun readPersistedPersonProperties(config: PostHogConfig): Map<String, Any?> {
-    val raw = config.cachePreferences?.getValue(PERSON_PROPERTIES_FOR_FLAGS_KEY) ?: return emptyMap()
-    @Suppress("UNCHECKED_CAST")
-    return (raw as? Map<String, Any?>) ?: emptyMap()
-}
-
 private const val PERSON_PROPERTY_LANGUAGE = "language"
-private const val PERSON_PROPERTIES_FOR_FLAGS_KEY = "personPropertiesForFlags"

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyLanguageDetection.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyLanguageDetection.kt
@@ -44,13 +44,13 @@ public fun <T> findBestTranslationMatch(
     if (translations.isNullOrEmpty() || targetLanguage.isNullOrBlank()) return null
 
     val normalizedTarget = targetLanguage.lowercase()
+    val findKey = { target: String -> translations.keys.firstOrNull { it.lowercase() == target } }
 
-    translations.keys.firstOrNull { it.lowercase() == normalizedTarget }?.let { return it }
+    findKey(normalizedTarget)?.let { return it }
 
     val hyphenIndex = normalizedTarget.indexOf('-')
     if (hyphenIndex > 0) {
-        val base = normalizedTarget.substring(0, hyphenIndex)
-        translations.keys.firstOrNull { it.lowercase() == base }?.let { return it }
+        findKey(normalizedTarget.substring(0, hyphenIndex))?.let { return it }
     }
 
     return null

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
@@ -1,0 +1,121 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.posthog.internal.surveys
+
+import com.posthog.PostHogInternal
+import com.posthog.surveys.LinkSurveyQuestion
+import com.posthog.surveys.MultipleSurveyQuestion
+import com.posthog.surveys.RatingSurveyQuestion
+import com.posthog.surveys.SingleSurveyQuestion
+import com.posthog.surveys.Survey
+import com.posthog.surveys.SurveyQuestion
+import com.posthog.surveys.SurveyQuestionTranslation
+import com.posthog.surveys.SurveyTranslation
+
+/**
+ * Outcome of resolving translations for one survey at display time.
+ *
+ * @property matchedKey the original-cased key from a `translations` dictionary that drove
+ *   the change (preferring the survey-level key when both survey and question matched).
+ *   `null` when no translation was applied at all.
+ * @property survey the (possibly translated) survey-level fields. `null` when no
+ *   survey-level translation matched.
+ * @property questions per-question translation, indexed positionally against
+ *   [Survey.questions]. Each element is `null` when no translation applied to that question.
+ */
+@PostHogInternal
+public data class ResolvedSurveyTranslations(
+    val matchedKey: String?,
+    val survey: SurveyTranslation?,
+    val questions: List<SurveyQuestionTranslation?>,
+)
+
+/**
+ * Resolves which translations should be applied to [survey] given the user's
+ * [targetLanguage]. Tracks whether the resolution actually changed any user-visible
+ * field; if not, [ResolvedSurveyTranslations.matchedKey] is `null` so callers don't
+ * mistakenly stamp `$survey_language` onto events.
+ */
+@PostHogInternal
+public fun resolveSurveyTranslations(
+    survey: Survey,
+    targetLanguage: String?,
+): ResolvedSurveyTranslations {
+    val empty =
+        ResolvedSurveyTranslations(
+            matchedKey = null,
+            survey = null,
+            questions = survey.questions.map { null },
+        )
+    if (targetLanguage.isNullOrBlank()) return empty
+
+    val surveyKey = findBestTranslationMatch(survey.translations, targetLanguage)
+    val surveyTranslation = surveyKey?.let { survey.translations?.get(it) }
+    val surveyChanged = surveyTranslation != null && surveyTranslationChangesAnything(survey, surveyTranslation)
+
+    val questionMatches: List<Pair<String?, SurveyQuestionTranslation?>> =
+        survey.questions.map { question ->
+            val key = findBestTranslationMatch(question.translations, targetLanguage)
+            val translation = key?.let { question.translations?.get(it) }
+            val changes = translation != null && questionTranslationChangesAnything(question, translation)
+            if (changes) key to translation else null to null
+        }
+
+    val anyQuestionChanged = questionMatches.any { it.second != null }
+
+    if (!surveyChanged && !anyQuestionChanged) return empty
+
+    val matchedKey =
+        when {
+            surveyChanged -> surveyKey
+            else -> questionMatches.firstNotNullOfOrNull { it.first }
+        }
+
+    return ResolvedSurveyTranslations(
+        matchedKey = matchedKey,
+        survey = if (surveyChanged) surveyTranslation else null,
+        questions = questionMatches.map { it.second },
+    )
+}
+
+private fun surveyTranslationChangesAnything(
+    survey: Survey,
+    translation: SurveyTranslation,
+): Boolean {
+    if (translation.name != null && translation.name != survey.name) return true
+    val appearance = survey.appearance
+    if (translation.thankYouMessageHeader != null && translation.thankYouMessageHeader != appearance?.thankYouMessageHeader) return true
+    if (translation.thankYouMessageDescription != null &&
+        translation.thankYouMessageDescription != appearance?.thankYouMessageDescription
+    ) {
+        return true
+    }
+    if (translation.thankYouMessageCloseButtonText != null &&
+        translation.thankYouMessageCloseButtonText != appearance?.thankYouMessageCloseButtonText
+    ) {
+        return true
+    }
+    return false
+}
+
+private fun questionTranslationChangesAnything(
+    question: SurveyQuestion,
+    translation: SurveyQuestionTranslation,
+): Boolean {
+    if (translation.question != null && translation.question != question.question) return true
+    if (translation.description != null && translation.description != question.description) return true
+    if (translation.buttonText != null && translation.buttonText != question.buttonText) return true
+    when (question) {
+        is LinkSurveyQuestion ->
+            if (translation.link != null && translation.link != question.link) return true
+        is RatingSurveyQuestion -> {
+            if (translation.lowerBoundLabel != null && translation.lowerBoundLabel != question.lowerBoundLabel) return true
+            if (translation.upperBoundLabel != null && translation.upperBoundLabel != question.upperBoundLabel) return true
+        }
+        is SingleSurveyQuestion ->
+            if (translation.choices != null && translation.choices != question.choices) return true
+        is MultipleSurveyQuestion ->
+            if (translation.choices != null && translation.choices != question.choices) return true
+    }
+    return false
+}

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
@@ -13,15 +13,10 @@ import com.posthog.surveys.SurveyQuestionTranslation
 import com.posthog.surveys.SurveyTranslation
 
 /**
- * Outcome of resolving translations for one survey at display time.
- *
- * @property matchedKey the original-cased key from a `translations` dictionary that drove
- *   the change (preferring the survey-level key when both survey and question matched).
- *   `null` when no translation was applied at all.
- * @property survey the (possibly translated) survey-level fields. `null` when no
- *   survey-level translation matched.
- * @property questions per-question translation, indexed positionally against
- *   [Survey.questions]. Each element is `null` when no translation applied to that question.
+ * [matchedKey] is the original-cased key from a `translations` dictionary that drove
+ * the change (preferring the survey-level key when both survey and question matched),
+ * or `null` when no user-visible field actually changed. [questions] is indexed
+ * positionally against [Survey.questions].
  */
 @PostHogInternal
 public data class ResolvedSurveyTranslations(
@@ -31,10 +26,9 @@ public data class ResolvedSurveyTranslations(
 )
 
 /**
- * Resolves which translations should be applied to [survey] given the user's
- * [targetLanguage]. Tracks whether the resolution actually changed any user-visible
- * field; if not, [ResolvedSurveyTranslations.matchedKey] is `null` so callers don't
- * mistakenly stamp `$survey_language` onto events.
+ * Returns a non-null [ResolvedSurveyTranslations.matchedKey] only when applying the
+ * matched translation would actually change a user-visible field — so callers don't
+ * stamp `$survey_language` onto events when nothing on screen changed.
  */
 @PostHogInternal
 public fun resolveSurveyTranslations(

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
@@ -1,5 +1,3 @@
-@file:Suppress("ktlint:standard:filename")
-
 package com.posthog.internal.surveys
 
 import com.posthog.PostHogInternal
@@ -11,19 +9,6 @@ import com.posthog.surveys.Survey
 import com.posthog.surveys.SurveyQuestion
 import com.posthog.surveys.SurveyQuestionTranslation
 import com.posthog.surveys.SurveyTranslation
-
-/**
- * [matchedKey] is the original-cased key from a `translations` dictionary that drove
- * the change (preferring the survey-level key when both survey and question matched),
- * or `null` when no user-visible field actually changed. [questions] is indexed
- * positionally against [Survey.questions].
- */
-@PostHogInternal
-public data class ResolvedSurveyTranslations(
-    val matchedKey: String?,
-    val survey: SurveyTranslation?,
-    val questions: List<SurveyQuestionTranslation?>,
-)
 
 /**
  * Returns a non-null [ResolvedSurveyTranslations.matchedKey] only when applying the

--- a/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/SurveyTranslationApplier.kt
@@ -47,28 +47,31 @@ public fun resolveSurveyTranslations(
     val surveyTranslation = surveyKey?.let { survey.translations?.get(it) }
     val surveyChanged = surveyTranslation != null && surveyTranslationChangesAnything(survey, surveyTranslation)
 
-    val questionMatches: List<Pair<String?, SurveyQuestionTranslation?>> =
+    var firstQuestionKey: String? = null
+    val questionTranslations =
         survey.questions.map { question ->
             val key = findBestTranslationMatch(question.translations, targetLanguage)
             val translation = key?.let { question.translations?.get(it) }
             val changes = translation != null && questionTranslationChangesAnything(question, translation)
-            if (changes) key to translation else null to null
+            if (changes) {
+                if (firstQuestionKey == null) firstQuestionKey = key
+                translation
+            } else {
+                null
+            }
         }
 
-    val anyQuestionChanged = questionMatches.any { it.second != null }
+    if (!surveyChanged && firstQuestionKey == null) return empty
 
-    if (!surveyChanged && !anyQuestionChanged) return empty
-
-    val matchedKey =
-        when {
-            surveyChanged -> surveyKey
-            else -> questionMatches.firstNotNullOfOrNull { it.first }
-        }
+    // Prefer the survey-level key if it actually drove a change; otherwise fall back to
+    // whichever question's translation key did. In the common case both refer to the
+    // same target language and the choice is purely cosmetic.
+    val matchedKey = if (surveyChanged) surveyKey else firstQuestionKey
 
     return ResolvedSurveyTranslations(
         matchedKey = matchedKey,
         survey = if (surveyChanged) surveyTranslation else null,
-        questions = questionMatches.map { it.second },
+        questions = questionTranslations,
     )
 }
 

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurvey.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurvey.kt
@@ -23,13 +23,8 @@ public data class PostHogDisplaySurvey(
 ) {
     public companion object {
         /**
-         * Creates a PostHogDisplaySurvey from a Survey object.
-         *
-         * @param survey The Survey object to convert.
-         * @param surveyTranslation Optional resolved survey-level translation overrides.
-         * @param questionTranslations Optional per-question translation overrides, indexed
-         *   positionally against `survey.questions`. When provided, must be the same length
-         *   as `survey.questions`; `null` entries leave the question untranslated.
+         * When provided, [questionTranslations] is indexed positionally against
+         * [Survey.questions]; `null` entries leave the corresponding question untranslated.
          */
         public fun toDisplaySurvey(
             survey: Survey,

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurvey.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurvey.kt
@@ -23,17 +23,34 @@ public data class PostHogDisplaySurvey(
 ) {
     public companion object {
         /**
-         * Creates a PostHogDisplaySurvey from a Survey object
+         * Creates a PostHogDisplaySurvey from a Survey object.
          *
-         * @param survey The Survey object to convert
-         * @return A new PostHogDisplaySurvey instance
+         * @param survey The Survey object to convert.
+         * @param surveyTranslation Optional resolved survey-level translation overrides.
+         * @param questionTranslations Optional per-question translation overrides, indexed
+         *   positionally against `survey.questions`. When provided, must be the same length
+         *   as `survey.questions`; `null` entries leave the question untranslated.
          */
-        public fun toDisplaySurvey(survey: Survey): PostHogDisplaySurvey {
+        public fun toDisplaySurvey(
+            survey: Survey,
+            surveyTranslation: SurveyTranslation? = null,
+            questionTranslations: List<SurveyQuestionTranslation?>? = null,
+        ): PostHogDisplaySurvey {
+            val translatedQuestions =
+                survey.questions.mapIndexedNotNull { index, question ->
+                    PostHogDisplaySurveyQuestion.fromSurveyQuestion(
+                        question,
+                        questionTranslations?.getOrNull(index),
+                    )
+                }
             return PostHogDisplaySurvey(
                 id = survey.id,
-                name = survey.name,
-                questions = survey.questions.mapNotNull { PostHogDisplaySurveyQuestion.fromSurveyQuestion(it) },
-                appearance = survey.appearance?.let { PostHogDisplaySurveyAppearance.fromSurveyAppearance(it) },
+                name = surveyTranslation?.name ?: survey.name,
+                questions = translatedQuestions,
+                appearance =
+                    survey.appearance?.let {
+                        PostHogDisplaySurveyAppearance.fromSurveyAppearance(it, surveyTranslation)
+                    },
                 startDate = survey.startDate,
                 endDate = survey.endDate,
             )

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurvey.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurvey.kt
@@ -23,8 +23,14 @@ public data class PostHogDisplaySurvey(
 ) {
     public companion object {
         /**
-         * When provided, [questionTranslations] is indexed positionally against
-         * [Survey.questions]; `null` entries leave the corresponding question untranslated.
+         * Creates a PostHogDisplaySurvey from a Survey object.
+         *
+         * @param survey The Survey object to convert.
+         * @param surveyTranslation Optional resolved survey-level translation. When
+         *   provided, overrides the survey `name` and `thankYouMessage*` fields.
+         * @param questionTranslations Optional per-question translations, indexed
+         *   positionally against [Survey.questions]. `null` entries leave the
+         *   corresponding question untranslated.
          */
         public fun toDisplaySurvey(
             survey: Survey,

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyAppearance.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyAppearance.kt
@@ -44,12 +44,13 @@ public data class PostHogDisplaySurveyAppearance(
 ) {
     internal companion object {
         /**
-         * Creates a PostHogDisplaySurveyAppearance from a SurveyAppearance object
-         *
-         * @param appearance The SurveyAppearance object to convert
-         * @return A new PostHogDisplaySurveyAppearance instance
+         * Creates a PostHogDisplaySurveyAppearance from a SurveyAppearance object,
+         * applying the optional survey-level translation when provided.
          */
-        internal fun fromSurveyAppearance(appearance: SurveyAppearance): PostHogDisplaySurveyAppearance {
+        internal fun fromSurveyAppearance(
+            appearance: SurveyAppearance,
+            translation: SurveyTranslation? = null,
+        ): PostHogDisplaySurveyAppearance {
             val thankYouContentType =
                 if (appearance.thankYouMessageDescriptionContentType?.value == "html") {
                     PostHogDisplaySurveyTextContentType.HTML
@@ -72,10 +73,10 @@ public data class PostHogDisplaySurveyAppearance(
                 inputTextColor = appearance.inputTextColor,
                 placeholder = appearance.placeholder,
                 displayThankYouMessage = appearance.displayThankYouMessage ?: false,
-                thankYouMessageHeader = appearance.thankYouMessageHeader,
-                thankYouMessageDescription = appearance.thankYouMessageDescription,
+                thankYouMessageHeader = translation?.thankYouMessageHeader ?: appearance.thankYouMessageHeader,
+                thankYouMessageDescription = translation?.thankYouMessageDescription ?: appearance.thankYouMessageDescription,
                 thankYouMessageDescriptionContentType = thankYouContentType,
-                thankYouMessageCloseButtonText = appearance.thankYouMessageCloseButtonText,
+                thankYouMessageCloseButtonText = translation?.thankYouMessageCloseButtonText ?: appearance.thankYouMessageCloseButtonText,
             )
         }
     }

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyAppearance.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyAppearance.kt
@@ -43,10 +43,6 @@ public data class PostHogDisplaySurveyAppearance(
     val thankYouMessageCloseButtonText: String? = null,
 ) {
     internal companion object {
-        /**
-         * Creates a PostHogDisplaySurveyAppearance from a SurveyAppearance object,
-         * applying the optional survey-level translation when provided.
-         */
         internal fun fromSurveyAppearance(
             appearance: SurveyAppearance,
             translation: SurveyTranslation? = null,

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyAppearance.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyAppearance.kt
@@ -43,6 +43,13 @@ public data class PostHogDisplaySurveyAppearance(
     val thankYouMessageCloseButtonText: String? = null,
 ) {
     internal companion object {
+        /**
+         * Creates a PostHogDisplaySurveyAppearance from a SurveyAppearance.
+         *
+         * @param appearance The SurveyAppearance object to convert.
+         * @param translation Optional resolved survey-level translation. When present,
+         *   overrides the `thankYouMessage*` fields; field-level fallback applies.
+         */
         internal fun fromSurveyAppearance(
             appearance: SurveyAppearance,
             translation: SurveyTranslation? = null,

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyQuestion.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyQuestion.kt
@@ -19,10 +19,6 @@ public open class PostHogDisplaySurveyQuestion(
     public val buttonText: String?,
 ) {
     internal companion object {
-        /**
-         * Creates a display question from a survey question, applying the optional
-         * per-question translation when provided.
-         */
         internal fun fromSurveyQuestion(
             question: SurveyQuestion,
             translation: SurveyQuestionTranslation? = null,

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyQuestion.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyQuestion.kt
@@ -20,14 +20,17 @@ public open class PostHogDisplaySurveyQuestion(
 ) {
     internal companion object {
         /**
-         * Creates a display question from a survey question
-         *
-         * @param question The survey question to convert
-         * @return A display question or null if the question type is not supported
+         * Creates a display question from a survey question, applying the optional
+         * per-question translation when provided.
          */
-        internal fun fromSurveyQuestion(question: SurveyQuestion): PostHogDisplaySurveyQuestion? {
+        internal fun fromSurveyQuestion(
+            question: SurveyQuestion,
+            translation: SurveyQuestionTranslation? = null,
+        ): PostHogDisplaySurveyQuestion? {
             val id = question.id ?: ""
-            val questionText = question.question ?: return null
+            val questionText = translation?.question ?: question.question ?: return null
+            val description = translation?.description ?: question.description
+            val buttonText = translation?.buttonText ?: question.buttonText
             val isOptional = question.optional ?: false
             val contentType =
                 question.descriptionContentType?.let {
@@ -42,34 +45,23 @@ public open class PostHogDisplaySurveyQuestion(
                     PostHogDisplayOpenQuestion(
                         id = id,
                         question = questionText,
-                        questionDescription = question.description,
+                        questionDescription = description,
                         questionDescriptionContentType = contentType,
                         isOptional = isOptional,
-                        buttonText = question.buttonText,
+                        buttonText = buttonText,
                     )
 
                 SurveyQuestionType.LINK -> {
-                    if (question is LinkSurveyQuestion) {
-                        PostHogDisplayLinkQuestion(
-                            id = id,
-                            question = questionText,
-                            questionDescription = question.description,
-                            questionDescriptionContentType = contentType,
-                            isOptional = isOptional,
-                            buttonText = question.buttonText,
-                            link = question.link,
-                        )
-                    } else {
-                        PostHogDisplayLinkQuestion(
-                            id = id,
-                            question = questionText,
-                            questionDescription = question.description,
-                            questionDescriptionContentType = contentType,
-                            isOptional = isOptional,
-                            buttonText = question.buttonText,
-                            link = null,
-                        )
-                    }
+                    val originalLink = (question as? LinkSurveyQuestion)?.link
+                    PostHogDisplayLinkQuestion(
+                        id = id,
+                        question = questionText,
+                        questionDescription = description,
+                        questionDescriptionContentType = contentType,
+                        isOptional = isOptional,
+                        buttonText = buttonText,
+                        link = translation?.link ?: originalLink,
+                    )
                 }
 
                 SurveyQuestionType.RATING -> {
@@ -92,101 +84,63 @@ public open class PostHogDisplaySurveyQuestion(
                         PostHogDisplayRatingQuestion(
                             id = id,
                             question = questionText,
-                            questionDescription = question.description,
+                            questionDescription = description,
                             questionDescriptionContentType = contentType,
                             isOptional = isOptional,
-                            buttonText = question.buttonText,
+                            buttonText = buttonText,
                             ratingType = ratingType,
                             scaleLowerBound = scaleLower,
                             scaleUpperBound = scaleUpper,
-                            lowerBoundLabel = question.lowerBoundLabel ?: "",
-                            upperBoundLabel = question.upperBoundLabel ?: "",
+                            lowerBoundLabel = translation?.lowerBoundLabel ?: question.lowerBoundLabel ?: "",
+                            upperBoundLabel = translation?.upperBoundLabel ?: question.upperBoundLabel ?: "",
                         )
                     } else {
                         PostHogDisplayRatingQuestion(
                             id = id,
                             question = questionText,
-                            questionDescription = question.description,
+                            questionDescription = description,
                             questionDescriptionContentType = contentType,
                             isOptional = isOptional,
-                            buttonText = question.buttonText,
+                            buttonText = buttonText,
                             ratingType = PostHogDisplaySurveyRatingType.NUMBER,
                             scaleLowerBound = 1,
                             scaleUpperBound = 5,
-                            lowerBoundLabel = "",
-                            upperBoundLabel = "",
+                            lowerBoundLabel = translation?.lowerBoundLabel ?: "",
+                            upperBoundLabel = translation?.upperBoundLabel ?: "",
                         )
                     }
                 }
 
                 SurveyQuestionType.SINGLE_CHOICE -> {
-                    val choices =
-                        if (question is SingleSurveyQuestion) {
-                            question.choices ?: emptyList()
-                        } else {
-                            emptyList()
-                        }
-
-                    val hasOpenChoice =
-                        if (question is SingleSurveyQuestion) {
-                            question.hasOpenChoice ?: false
-                        } else {
-                            false
-                        }
-
-                    val shuffleOptions =
-                        if (question is SingleSurveyQuestion) {
-                            question.shuffleOptions ?: false
-                        } else {
-                            false
-                        }
-
+                    val single = question as? SingleSurveyQuestion
+                    val choices = translation?.choices ?: single?.choices ?: emptyList()
                     PostHogDisplayChoiceQuestion(
                         id = id,
                         question = questionText,
-                        questionDescription = question.description,
+                        questionDescription = description,
                         questionDescriptionContentType = contentType,
                         isOptional = isOptional,
-                        buttonText = question.buttonText,
+                        buttonText = buttonText,
                         choices = choices,
-                        hasOpenChoice = hasOpenChoice,
-                        shuffleOptions = shuffleOptions,
+                        hasOpenChoice = single?.hasOpenChoice ?: false,
+                        shuffleOptions = single?.shuffleOptions ?: false,
                         isMultipleChoice = false,
                     )
                 }
 
                 SurveyQuestionType.MULTIPLE_CHOICE -> {
-                    val choices =
-                        if (question is MultipleSurveyQuestion) {
-                            question.choices ?: emptyList()
-                        } else {
-                            emptyList()
-                        }
-
-                    val hasOpenChoice =
-                        if (question is MultipleSurveyQuestion) {
-                            question.hasOpenChoice ?: false
-                        } else {
-                            false
-                        }
-
-                    val shuffleOptions =
-                        if (question is MultipleSurveyQuestion) {
-                            question.shuffleOptions ?: false
-                        } else {
-                            false
-                        }
-
+                    val multiple = question as? MultipleSurveyQuestion
+                    val choices = translation?.choices ?: multiple?.choices ?: emptyList()
                     PostHogDisplayChoiceQuestion(
                         id = id,
                         question = questionText,
-                        questionDescription = question.description,
+                        questionDescription = description,
                         questionDescriptionContentType = contentType,
                         isOptional = isOptional,
-                        buttonText = question.buttonText,
+                        buttonText = buttonText,
                         choices = choices,
-                        hasOpenChoice = hasOpenChoice,
-                        shuffleOptions = shuffleOptions,
+                        hasOpenChoice = multiple?.hasOpenChoice ?: false,
+                        shuffleOptions = multiple?.shuffleOptions ?: false,
                         isMultipleChoice = true,
                     )
                 }

--- a/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyQuestion.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogDisplaySurveyQuestion.kt
@@ -19,6 +19,14 @@ public open class PostHogDisplaySurveyQuestion(
     public val buttonText: String?,
 ) {
     internal companion object {
+        /**
+         * Creates a display question from a survey question.
+         *
+         * @param question The survey question to convert.
+         * @param translation Optional resolved per-question translation. Field-level
+         *   fallback applies — `null` values defer to the original question.
+         * @return A display question, or `null` if the question type is not supported.
+         */
         internal fun fromSurveyQuestion(
             question: SurveyQuestion,
             translation: SurveyQuestionTranslation? = null,

--- a/posthog/src/main/java/com/posthog/surveys/PostHogSurveysConfig.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogSurveysConfig.kt
@@ -12,4 +12,20 @@ public class PostHogSurveysConfig {
      * Defaults to [PostHogSurveysDefaultDelegate] which provides logging but no UI at the moment.
      */
     public var surveysDelegate: PostHogSurveysDelegate = PostHogSurveysDefaultDelegate()
+
+    /**
+     * Optional explicit override for the language used when rendering surveys.
+     *
+     * When set, surveys with matching entries in [Survey.translations] will be rendered
+     * in this language regardless of the device locale or any `language` person property.
+     *
+     * Format: a language tag such as "fr", "pt-BR", "zh-CN". Matching is case-insensitive
+     * and falls back to the base language (e.g. "pt" if "pt-BR" is requested but only "pt"
+     * is provided).
+     *
+     * Blank or null values are treated as unset.
+     *
+     * Default: `null`.
+     */
+    public var overrideDisplayLanguage: String? = null
 }

--- a/posthog/src/main/java/com/posthog/surveys/Survey.kt
+++ b/posthog/src/main/java/com/posthog/surveys/Survey.kt
@@ -28,4 +28,9 @@ public data class Survey(
     @SerializedName("end_date")
     val endDate: Date?,
     val schedule: SurveySchedule?,
+    /**
+     * Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
+     * Applied at display time based on the resolved survey display language.
+     */
+    val translations: Map<String, SurveyTranslation>? = null,
 )

--- a/posthog/src/main/java/com/posthog/surveys/Survey.kt
+++ b/posthog/src/main/java/com/posthog/surveys/Survey.kt
@@ -28,9 +28,5 @@ public data class Survey(
     @SerializedName("end_date")
     val endDate: Date?,
     val schedule: SurveySchedule?,
-    /**
-     * Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
-     * Applied at display time based on the resolved survey display language.
-     */
     val translations: Map<String, SurveyTranslation>? = null,
 )

--- a/posthog/src/main/java/com/posthog/surveys/SurveyQuestion.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyQuestion.kt
@@ -9,6 +9,12 @@ public open class SurveyQuestion {
     public val optional: Boolean? = null
     public val buttonText: String? = null
     public val branching: SurveyQuestionBranching? = null
+
+    /**
+     * Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
+     * Applied at display time based on the resolved survey display language.
+     */
+    public val translations: Map<String, SurveyQuestionTranslation>? = null
 }
 
 public class OpenSurveyQuestion : SurveyQuestion()

--- a/posthog/src/main/java/com/posthog/surveys/SurveyQuestion.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyQuestion.kt
@@ -9,11 +9,6 @@ public open class SurveyQuestion {
     public val optional: Boolean? = null
     public val buttonText: String? = null
     public val branching: SurveyQuestionBranching? = null
-
-    /**
-     * Optional localized overrides keyed by language code (e.g. "fr", "pt-BR").
-     * Applied at display time based on the resolved survey display language.
-     */
     public val translations: Map<String, SurveyQuestionTranslation>? = null
 }
 

--- a/posthog/src/main/java/com/posthog/surveys/SurveyQuestionTranslation.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyQuestionTranslation.kt
@@ -1,14 +1,11 @@
 package com.posthog.surveys
 
 /**
- * Localized overrides for a survey question's user-visible strings.
- *
- * Attached to [SurveyQuestion.translations] as a map keyed by language code (e.g. "fr", "pt-BR").
- * All fields are optional — missing fields fall back to the original question value.
+ * Localized overrides for a survey question.
  *
  * Fields are a superset across question types: `link` only applies to link questions,
- * `lowerBoundLabel` / `upperBoundLabel` only to rating questions, and `choices` only to
- * single/multiple choice questions. Irrelevant fields are ignored for other types.
+ * `lowerBoundLabel` / `upperBoundLabel` only to rating questions, and `choices` only
+ * to single/multiple choice questions. Irrelevant fields are ignored for other types.
  */
 public data class SurveyQuestionTranslation(
     val question: String? = null,

--- a/posthog/src/main/java/com/posthog/surveys/SurveyQuestionTranslation.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyQuestionTranslation.kt
@@ -1,0 +1,21 @@
+package com.posthog.surveys
+
+/**
+ * Localized overrides for a survey question's user-visible strings.
+ *
+ * Attached to [SurveyQuestion.translations] as a map keyed by language code (e.g. "fr", "pt-BR").
+ * All fields are optional — missing fields fall back to the original question value.
+ *
+ * Fields are a superset across question types: `link` only applies to link questions,
+ * `lowerBoundLabel` / `upperBoundLabel` only to rating questions, and `choices` only to
+ * single/multiple choice questions. Irrelevant fields are ignored for other types.
+ */
+public data class SurveyQuestionTranslation(
+    val question: String? = null,
+    val description: String? = null,
+    val buttonText: String? = null,
+    val link: String? = null,
+    val lowerBoundLabel: String? = null,
+    val upperBoundLabel: String? = null,
+    val choices: List<String>? = null,
+)

--- a/posthog/src/main/java/com/posthog/surveys/SurveyTranslation.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyTranslation.kt
@@ -1,0 +1,17 @@
+package com.posthog.surveys
+
+/**
+ * Localized overrides for a survey's user-visible strings.
+ *
+ * Attached to [Survey.translations] as a map keyed by language code (e.g. "fr", "pt-BR").
+ * All fields are optional — missing fields fall back to the original survey value.
+ *
+ * Note: the survey-level `description` is intentionally NOT translatable here.
+ * It is only used for internal previews and never rendered to end users.
+ */
+public data class SurveyTranslation(
+    val name: String? = null,
+    val thankYouMessageHeader: String? = null,
+    val thankYouMessageDescription: String? = null,
+    val thankYouMessageCloseButtonText: String? = null,
+)

--- a/posthog/src/main/java/com/posthog/surveys/SurveyTranslation.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyTranslation.kt
@@ -1,13 +1,10 @@
 package com.posthog.surveys
 
 /**
- * Localized overrides for a survey's user-visible strings.
+ * Localized overrides for a survey, keyed by language code (e.g. "fr", "pt-BR").
  *
- * Attached to [Survey.translations] as a map keyed by language code (e.g. "fr", "pt-BR").
- * All fields are optional — missing fields fall back to the original survey value.
- *
- * Note: the survey-level `description` is intentionally NOT translatable here.
- * It is only used for internal previews and never rendered to end users.
+ * The survey-level `description` is intentionally NOT translatable — it is only
+ * used for internal previews and never rendered to end users.
  */
 public data class SurveyTranslation(
     val name: String? = null,

--- a/posthog/src/test/java/com/posthog/surveys/SurveyLanguageDetectionTest.kt
+++ b/posthog/src/test/java/com/posthog/surveys/SurveyLanguageDetectionTest.kt
@@ -1,0 +1,119 @@
+package com.posthog.surveys
+
+import com.posthog.internal.surveys.detectSurveyLanguage
+import com.posthog.internal.surveys.findBestTranslationMatch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class SurveyLanguageDetectionTest {
+    @Test
+    fun `detectSurveyLanguage prefers explicit override`() {
+        val result =
+            detectSurveyLanguage(
+                overrideLanguage = "fr",
+                personProperties = mapOf("language" to "de"),
+                deviceLocale = "en-US",
+            )
+        assertEquals("fr", result)
+    }
+
+    @Test
+    fun `detectSurveyLanguage trims override whitespace`() {
+        val result =
+            detectSurveyLanguage(
+                overrideLanguage = "  pt-BR  ",
+                personProperties = null,
+                deviceLocale = "en-US",
+            )
+        assertEquals("pt-BR", result)
+    }
+
+    @Test
+    fun `detectSurveyLanguage falls back to person property when override blank`() {
+        val result =
+            detectSurveyLanguage(
+                overrideLanguage = "   ",
+                personProperties = mapOf("language" to "de"),
+                deviceLocale = "en-US",
+            )
+        assertEquals("de", result)
+    }
+
+    @Test
+    fun `detectSurveyLanguage falls back to device locale when both override and person prop blank`() {
+        val result =
+            detectSurveyLanguage(
+                overrideLanguage = null,
+                personProperties = mapOf("other" to "value"),
+                deviceLocale = "en-US",
+            )
+        assertEquals("en-US", result)
+    }
+
+    @Test
+    fun `detectSurveyLanguage returns null when nothing is set`() {
+        val result =
+            detectSurveyLanguage(
+                overrideLanguage = null,
+                personProperties = null,
+                deviceLocale = null,
+            )
+        assertNull(result)
+    }
+
+    @Test
+    fun `detectSurveyLanguage ignores non-string person language`() {
+        val result =
+            detectSurveyLanguage(
+                overrideLanguage = null,
+                personProperties = mapOf("language" to 42),
+                deviceLocale = "en-US",
+            )
+        assertEquals("en-US", result)
+    }
+
+    @Test
+    fun `findBestTranslationMatch returns exact match`() {
+        val translations = mapOf("fr" to "x", "pt-BR" to "y")
+        assertEquals("fr", findBestTranslationMatch(translations, "fr"))
+        assertEquals("pt-BR", findBestTranslationMatch(translations, "pt-BR"))
+    }
+
+    @Test
+    fun `findBestTranslationMatch is case insensitive and preserves original key casing`() {
+        val translations = mapOf("Fr" to "x", "PT-br" to "y")
+        assertEquals("Fr", findBestTranslationMatch(translations, "fr"))
+        assertEquals("PT-br", findBestTranslationMatch(translations, "PT-BR"))
+    }
+
+    @Test
+    fun `findBestTranslationMatch falls back to base language when target has hyphen`() {
+        val translations = mapOf("pt" to "x")
+        assertEquals("pt", findBestTranslationMatch(translations, "pt-BR"))
+    }
+
+    @Test
+    fun `findBestTranslationMatch prefers exact match over base language`() {
+        val translations = mapOf("pt" to "base", "pt-BR" to "exact")
+        assertEquals("pt-BR", findBestTranslationMatch(translations, "pt-BR"))
+    }
+
+    @Test
+    fun `findBestTranslationMatch does not fall back when target has no hyphen`() {
+        val translations = mapOf("pt-BR" to "x")
+        assertNull(findBestTranslationMatch(translations, "pt"))
+    }
+
+    @Test
+    fun `findBestTranslationMatch returns null for empty inputs`() {
+        val empty = emptyMap<String, String>()
+        val nullMap: Map<String, String>? = null
+        val single = mapOf("fr" to "x")
+        assertNull(findBestTranslationMatch(empty, "fr"))
+        assertNull(findBestTranslationMatch(nullMap, "fr"))
+        assertNull(findBestTranslationMatch(single, null))
+        assertNull(findBestTranslationMatch(single, ""))
+        assertNull(findBestTranslationMatch(single, "  "))
+    }
+}

--- a/posthog/src/test/java/com/posthog/surveys/SurveyTranslationsTest.kt
+++ b/posthog/src/test/java/com/posthog/surveys/SurveyTranslationsTest.kt
@@ -1,0 +1,303 @@
+package com.posthog.surveys
+
+import com.posthog.API_KEY
+import com.posthog.PostHogConfig
+import com.posthog.internal.PostHogSerializer
+import com.posthog.internal.surveys.resolveSurveyTranslations
+import java.io.StringReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+internal class SurveyTranslationsTest {
+    private val serializer: PostHogSerializer = PostHogSerializer(PostHogConfig(API_KEY))
+
+    private fun decodeSurvey(json: String): Survey {
+        return serializer.deserialize<Survey>(StringReader(json))
+    }
+
+    @Test
+    fun `survey decodes translations field`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val translations = survey.translations
+        assertNotNull(translations)
+        assertEquals("Bonjour", translations["fr"]?.name)
+        assertEquals("Merci!", translations["fr"]?.thankYouMessageHeader)
+        assertEquals("Obrigado", translations["pt"]?.thankYouMessageHeader)
+    }
+
+    @Test
+    fun `question decodes translations field including choices`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val ratingQuestion = survey.questions[0] as RatingSurveyQuestion
+        val ratingTranslations = ratingQuestion.translations
+        assertNotNull(ratingTranslations)
+        assertEquals("Comment etait-ce?", ratingTranslations["fr"]?.question)
+        assertEquals("Mauvais", ratingTranslations["fr"]?.lowerBoundLabel)
+
+        val choiceQuestion = survey.questions[1] as SingleSurveyQuestion
+        val choiceTranslations = choiceQuestion.translations
+        assertNotNull(choiceTranslations)
+        assertEquals(listOf("Un", "Deux"), choiceTranslations["fr"]?.choices)
+    }
+
+    @Test
+    fun `resolveSurveyTranslations returns empty when target language is null`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val resolved = resolveSurveyTranslations(survey, null)
+        assertNull(resolved.matchedKey)
+        assertNull(resolved.survey)
+        assertTrue(resolved.questions.all { it == null })
+    }
+
+    @Test
+    fun `resolveSurveyTranslations matches exact language`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val resolved = resolveSurveyTranslations(survey, "fr")
+        assertEquals("fr", resolved.matchedKey)
+        assertEquals("Bonjour", resolved.survey?.name)
+        assertEquals("Comment etait-ce?", resolved.questions[0]?.question)
+        assertEquals(listOf("Un", "Deux"), resolved.questions[1]?.choices)
+    }
+
+    @Test
+    fun `resolveSurveyTranslations falls back to base language`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val resolved = resolveSurveyTranslations(survey, "pt-BR")
+        // survey-level translations only had "pt", not "pt-BR" — should fall back
+        assertEquals("pt", resolved.matchedKey)
+        assertEquals("Obrigado", resolved.survey?.thankYouMessageHeader)
+    }
+
+    @Test
+    fun `resolveSurveyTranslations is case insensitive and returns original key casing`() {
+        val survey = decodeSurvey(SURVEY_WITH_MIXED_CASE_TRANSLATIONS_JSON)
+        val resolved = resolveSurveyTranslations(survey, "FR")
+        // Original survey-level key was "Fr"
+        assertEquals("Fr", resolved.matchedKey)
+    }
+
+    @Test
+    fun `resolveSurveyTranslations returns null matchedKey when translations exist but do not match`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val resolved = resolveSurveyTranslations(survey, "ja")
+        assertNull(resolved.matchedKey)
+        assertNull(resolved.survey)
+        assertTrue(resolved.questions.all { it == null })
+    }
+
+    @Test
+    fun `resolveSurveyTranslations returns null matchedKey when translation field present but identical`() {
+        // When the translation has all the same values, nothing actually changes — matchedKey is null
+        val survey = decodeSurvey(SURVEY_WITH_NOOP_TRANSLATION_JSON)
+        val resolved = resolveSurveyTranslations(survey, "fr")
+        assertNull(resolved.matchedKey)
+    }
+
+    @Test
+    fun `survey without translations field decodes safely`() {
+        val survey = decodeSurvey(SURVEY_WITHOUT_TRANSLATIONS_JSON)
+        assertNull(survey.translations)
+        assertNull(survey.questions[0].translations)
+        val resolved = resolveSurveyTranslations(survey, "fr")
+        assertNull(resolved.matchedKey)
+    }
+
+    @Test
+    fun `display survey applies translation fields with fallback to original`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val resolved = resolveSurveyTranslations(survey, "fr")
+
+        val display =
+            PostHogDisplaySurvey.toDisplaySurvey(
+                survey,
+                surveyTranslation = resolved.survey,
+                questionTranslations = resolved.questions,
+            )
+
+        // Translated survey-level name
+        assertEquals("Bonjour", display.name)
+        // Translated rating question text + bound labels
+        val rating = display.questions[0] as PostHogDisplayRatingQuestion
+        assertEquals("Comment etait-ce?", rating.question)
+        assertEquals("Mauvais", rating.lowerBoundLabel)
+        // upperBoundLabel was not translated — falls back to original
+        assertEquals("Great", rating.upperBoundLabel)
+        // Translated choices
+        val choice = display.questions[1] as PostHogDisplayChoiceQuestion
+        assertEquals(listOf("Un", "Deux"), choice.choices)
+        // Translated thank you message
+        assertEquals("Merci!", display.appearance?.thankYouMessageHeader)
+    }
+
+    @Test
+    fun `display survey without translations renders original fields`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val display = PostHogDisplaySurvey.toDisplaySurvey(survey)
+
+        assertEquals("Hello", display.name)
+        val rating = display.questions[0] as PostHogDisplayRatingQuestion
+        assertEquals("How was it?", rating.question)
+        assertEquals("Bad", rating.lowerBoundLabel)
+        assertEquals("Great", rating.upperBoundLabel)
+        val choice = display.questions[1] as PostHogDisplayChoiceQuestion
+        assertEquals(listOf("One", "Two"), choice.choices)
+        assertEquals("Thanks!", display.appearance?.thankYouMessageHeader)
+    }
+
+    @Test
+    fun `resolveSurveyTranslations does not mutate the original survey`() {
+        val survey = decodeSurvey(SURVEY_WITH_TRANSLATIONS_JSON)
+        val originalName = survey.name
+        val originalQuestionText = survey.questions[0].question
+        val originalChoices = (survey.questions[1] as SingleSurveyQuestion).choices
+
+        resolveSurveyTranslations(survey, "fr")
+
+        assertEquals(originalName, survey.name)
+        assertEquals(originalQuestionText, survey.questions[0].question)
+        assertSame(originalChoices, (survey.questions[1] as SingleSurveyQuestion).choices)
+    }
+
+    companion object {
+        private val SURVEY_WITH_TRANSLATIONS_JSON =
+            """
+            {
+              "id": "s1",
+              "name": "Hello",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": null,
+              "end_date": null,
+              "schedule": null,
+              "appearance": {
+                "thankYouMessageHeader": "Thanks!",
+                "thankYouMessageDescription": "We appreciate it",
+                "thankYouMessageCloseButtonText": "Close",
+                "borderColor": "#000"
+              },
+              "translations": {
+                "fr": {
+                  "name": "Bonjour",
+                  "thankYouMessageHeader": "Merci!"
+                },
+                "pt": {
+                  "thankYouMessageHeader": "Obrigado"
+                }
+              },
+              "questions": [
+                {
+                  "type": "rating",
+                  "id": "q1",
+                  "question": "How was it?",
+                  "description": null,
+                  "scale": 5,
+                  "display": "number",
+                  "lowerBoundLabel": "Bad",
+                  "upperBoundLabel": "Great",
+                  "translations": {
+                    "fr": { "question": "Comment etait-ce?", "lowerBoundLabel": "Mauvais" }
+                  }
+                },
+                {
+                  "type": "single_choice",
+                  "id": "q2",
+                  "question": "Pick one",
+                  "choices": ["One", "Two"],
+                  "translations": {
+                    "fr": { "choices": ["Un", "Deux"] }
+                  }
+                }
+              ]
+            }
+            """.trimIndent()
+
+        private val SURVEY_WITH_MIXED_CASE_TRANSLATIONS_JSON =
+            """
+            {
+              "id": "s2",
+              "name": "Hello",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": null,
+              "end_date": null,
+              "schedule": null,
+              "appearance": null,
+              "translations": {
+                "Fr": { "name": "Salut" }
+              },
+              "questions": [
+                { "type": "open", "id": "q1", "question": "Free text", "description": null }
+              ]
+            }
+            """.trimIndent()
+
+        private val SURVEY_WITH_NOOP_TRANSLATION_JSON =
+            """
+            {
+              "id": "s3",
+              "name": "Hello",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": null,
+              "end_date": null,
+              "schedule": null,
+              "appearance": null,
+              "translations": {
+                "fr": { "name": "Hello" }
+              },
+              "questions": [
+                { "type": "open", "id": "q1", "question": "Free text", "description": null }
+              ]
+            }
+            """.trimIndent()
+
+        private val SURVEY_WITHOUT_TRANSLATIONS_JSON =
+            """
+            {
+              "id": "s4",
+              "name": "Hello",
+              "type": "popover",
+              "description": null,
+              "feature_flag_keys": null,
+              "linked_flag_key": null,
+              "targeting_flag_key": null,
+              "internal_targeting_flag_key": null,
+              "conditions": null,
+              "current_iteration": null,
+              "current_iteration_start_date": null,
+              "start_date": null,
+              "end_date": null,
+              "schedule": null,
+              "appearance": null,
+              "questions": [
+                { "type": "open", "id": "q1", "question": "Free text", "description": null }
+              ]
+            }
+            """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Summary
Brings the posthog-js / posthog-react-native survey translations feature to the native SDK. Surveys can carry per-language overrides for user-visible strings via a `translations` map keyed by language code. At display time the SDK resolves a language (init override → person property `language` → device locale), applies any matching translation onto the display model, and stamps the matched key as `$survey_language` on every survey event when a translation actually took effect.

- Wire model: `translations` on `Survey` and on each `SurveyQuestion` subtype.
- Config: `PostHogSurveysConfig.overrideDisplayLanguage` (init option).
- Matching: case-insensitive exact match with base-language fallback (`pt-BR` → `pt`); returns the original-cased dict key for event reporting.
- Resolution: only stamps `matchedKey` when at least one user-visible field actually changed.
- Event threading: `survey shown`, `survey sent`, `survey dismissed` all carry `$survey_language` when matched; `$survey_questions` reflects translated text.

Companion PR: PostHog/posthog-ios#601

## Test plan
All tests pass in CI. New coverage:
- Wire-format decoding round-trip (Gson + serializer).
- Matching algorithm: exact, case-insensitive, base-language fallback, no-match, no-fallback-without-hyphen.
- Priority chain: override → person prop → device locale.
- Display model translation with field-level fallback to original.
- Integration: `$survey_language` present on all three events when matched, absent otherwise; translated text in `$survey_questions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*