### PR TITLE
fix(server): align FeatureFlagCacheKey shape across put and get paths

### DIFF
--- a/.changeset/fix-legacy-cache-key-shape.md
+++ b/.changeset/fix-legacy-cache-key-shape.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Fix the legacy `isFeatureEnabled` / `getFeatureFlag` flow so it stops emitting `$feature_flag_called` events with a spurious `$feature_flag_error: "unknown_error"` after a successful evaluation. `FeatureFlagCacheKey` is now built with the same shape (`flagKeys` and `disableGeoip` included) on every read path, matching what `getFeatureFlagsFromRemote` writes when called from the legacy flow. Affects `getFeatureFlagsFromCache`, `getFeatureFlagError`, `getFeatureFlagDetails`, `getRequestId`, and `getEvaluatedAt`.

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -220,6 +220,8 @@ internal class PostHogFeatureFlags(
                 groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
+                flagKeys = null,
+                disableGeoip = false,
             )
 
         return cache.get(cacheKey)
@@ -648,6 +650,8 @@ internal class PostHogFeatureFlags(
                 groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
+                flagKeys = null,
+                disableGeoip = false,
             )
         return cache.getEntry(cacheKey)?.requestId
     }
@@ -670,6 +674,8 @@ internal class PostHogFeatureFlags(
                 groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
+                flagKeys = null,
+                disableGeoip = false,
             )
         return cache.getEntry(cacheKey)?.evaluatedAt
     }
@@ -705,6 +711,8 @@ internal class PostHogFeatureFlags(
                 groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
+                flagKeys = null,
+                disableGeoip = false,
             )
         return cache.getEntry(cacheKey)?.flags?.get(key)
     }
@@ -824,6 +832,8 @@ internal class PostHogFeatureFlags(
                 groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
+                flagKeys = null,
+                disableGeoip = false,
             )
 
         val entry = cache.getEntry(cacheKey) ?: return FeatureFlagError.UNKNOWN_ERROR

--- a/posthog-server/src/test/java/com/posthog/server/internal/FeatureFlagErrorTrackingTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FeatureFlagErrorTrackingTest.kt
@@ -253,4 +253,37 @@ internal class FeatureFlagErrorTrackingTest {
 
         assertEquals(FeatureFlagError.UNKNOWN_ERROR, error)
     }
+
+    @Test
+    fun `getFeatureFlagError returns null after a successful legacy getFeatureFlag`() {
+        // Regression: getFeatureFlagError used a 4-field cache key while
+        // getFeatureFlagsFromRemote stored under a 6-field key (with the
+        // flagKeys/disableGeoip added in 2.5.0), causing every legacy
+        // lookup to miss and return UNKNOWN_ERROR even after a successful
+        // evaluation.
+        val flagsResponse = createFlagsResponse("test-flag", enabled = true)
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val flagValue =
+            remoteConfig.getFeatureFlag(
+                key = "test-flag",
+                defaultValue = false,
+                distinctId = "test-user",
+            )
+
+        val error =
+            remoteConfig.getFeatureFlagError(
+                key = "test-flag",
+                distinctId = "test-user",
+            )
+
+        assertEquals(true, flagValue)
+        assertNull(error)
+        mockServer.shutdown()
+    }
 }

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -19,6 +19,7 @@ import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -1391,6 +1392,37 @@ internal class PostHogFeatureFlagsTest {
         val result = featureFlags.getFeatureFlag("test-flag-v2", false, "test-user")
         assertEquals(true, result)
 
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlagDetails returns the flag after a successful legacy getFeatureFlag`() {
+        // Regression: getFeatureFlagDetails used a 4-field cache key while
+        // getFeatureFlagsFromRemote stored under a 6-field key (with the
+        // flagKeys/disableGeoip added in 2.5.0), causing every legacy
+        // lookup to miss and return null even after a successful evaluation.
+        val flagsResponse = createFlagsResponse("test-flag", enabled = true)
+        val mockServer = createMockHttp(jsonResponse(flagsResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        remoteConfig.getFeatureFlag(
+            key = "test-flag",
+            defaultValue = false,
+            distinctId = "test-user",
+        )
+
+        val details =
+            remoteConfig.getFeatureFlagDetails(
+                key = "test-flag",
+                distinctId = "test-user",
+            )
+
+        assertNotNull(details)
+        assertEquals(true, details.enabled)
         mockServer.shutdown()
     }
 }


### PR DESCRIPTION
Closes #514.

## Problem

`getFeatureFlagsFromRemote` writes the cache under a 6-field `FeatureFlagCacheKey` including the new (in 2.5.0) `flagKeys` and `disableGeoip` fields. Several legacy read sites still construct the key with only the original four fields:

- `getFeatureFlagsFromCache` (called by `resolveFeatureFlag` for `isFeatureEnabled` / `getFeatureFlag`)
- `getFeatureFlagError`
- `getFeatureFlagDetails`
- `getRequestId`
- `getEvaluatedAt`

PUT shape ≠ GET shape → cache misses on every legacy read → `getFeatureFlagError` returns `UNKNOWN_ERROR` via its `?: return FeatureFlagError.UNKNOWN_ERROR` fallback, and `$feature_flag_called` events emitted from legacy code paths carry a spurious `$feature_flag_error: "unknown_error"` even after a successful evaluation.

Repro: with `posthog-server` 2.5.0 / 2.5.1, define a boolean flag at 100% of all users with no targeting properties, then call `posthog.isFeatureEnabled(distinctId, key, options)`. The `$feature_flag_called` event sent to PostHog carries `$feature_flag_error: "unknown_error"` even though the flag resolved successfully.

## Fix

Inline `flagKeys = null, disableGeoip = false` at each of the five legacy read sites. This matches the defaults that `getFeatureFlagsFromRemote` uses when called from the legacy `resolveFeatureFlag` flow (which never passes those parameters), so the GET keys now equal the PUT keys for the legacy flow.

The `evaluateFlags()` path is unaffected — it already builds the 6-field key consistently on both sides.

## Regression tests

Added alongside the existing tests for each function — two new cases that fail on `main` without this change and pass with it:

- `FeatureFlagErrorTrackingTest.getFeatureFlagError returns null after a successful legacy getFeatureFlag` — currently returns `UNKNOWN_ERROR`.
- `PostHogFeatureFlagsTest.getFeatureFlagDetails returns the flag after a successful legacy getFeatureFlag` — currently returns null.

## Validation

`./gradlew :posthog-server:test` → 379 tests, 0 failures, 0 errors (includes the two new cases).