### PR TITLE
fix(server): adapt legacy V1 /flags response into the V4 shape

### DIFF
--- a/.changeset/fix-legacy-flags-response-shape.md
+++ b/.changeset/fix-legacy-flags-response-shape.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Fix `isFeatureEnabled` / `getFeatureFlag` returning the caller-supplied default value for flags that are enabled, when the `/flags` server response only populates the legacy `featureFlags` map and leaves `flags` empty. `PostHogFeatureFlags.getFeatureFlagsFromRemote` now adapts the V1 response into the rich `FeatureFlag` map the rest of the SDK consumes, so legacy method reads and snapshot-derived `$feature_flag_called` events see a consistent shape.

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -4,6 +4,7 @@ import com.posthog.FeatureFlagResult
 import com.posthog.PostHogConfig
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.internal.FeatureFlag
+import com.posthog.internal.FeatureFlagMetadata
 import com.posthog.internal.FlagDefinition
 import com.posthog.internal.PostHogApi
 import com.posthog.internal.PostHogApiError
@@ -311,7 +312,11 @@ internal class PostHogFeatureFlags(
                     flagKeys = flagKeys,
                     disableGeoip = disableGeoip,
                 )
-            val flags = response?.flags
+            // V4 responses carry the rich FeatureFlag map directly on `flags`. V1
+            // responses (some self-hosted deployments, older endpoint versions) only
+            // populate the legacy `featureFlags` map; adapt them so legacy methods
+            // and snapshot reads see a consistent shape.
+            val flags = response?.flags ?: adaptLegacyFlags(response)
             cache.put(
                 cacheKey,
                 flags,
@@ -340,6 +345,41 @@ internal class PostHogFeatureFlags(
             config.logger.log("Loading remote feature flags failed: $e")
             cache.put(cacheKey, null, error = FeatureFlagError.UNKNOWN_ERROR)
             null
+        }
+    }
+
+    /**
+     * Adapt a legacy V1 `/flags` response (only the `featureFlags` map populated)
+     * into the rich `Map<String, FeatureFlag>` shape that the rest of the SDK
+     * reads from `response.flags`. Returns null when the legacy map is absent
+     * too, so the caller falls through to its existing null handling.
+     *
+     * - `featureFlags["key"] = true | false` → boolean flag; `enabled` matches.
+     * - `featureFlags["key"] = "variant-name"` → multi-variant; `enabled = true`,
+     *   `variant = "variant-name"` (mirrors the server's V4 semantics).
+     */
+    private fun adaptLegacyFlags(response: PostHogFlagsResponse?): Map<String, FeatureFlag>? {
+        val legacy = response?.featureFlags ?: return null
+        val payloads = response.featureFlagPayloads ?: emptyMap()
+        return legacy.mapValues { (key, value) ->
+            val (enabled, variant) =
+                when (value) {
+                    is Boolean -> value to null
+                    is String -> true to value
+                    else -> false to null
+                }
+            FeatureFlag(
+                key = key,
+                enabled = enabled,
+                variant = variant,
+                metadata =
+                    FeatureFlagMetadata(
+                        id = 0,
+                        payload = payloads[key]?.toString(),
+                        version = 0,
+                    ),
+                reason = null,
+            )
         }
     }
 

--- a/posthog-server/src/test/java/com/posthog/server/PostHogTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogTest.kt
@@ -648,4 +648,45 @@ internal class PostHogTest {
         postHog.close()
         mockServer.shutdown()
     }
+
+    @Test
+    fun `isFeatureEnabled returns true when server returns the legacy featureFlags response shape`() {
+        // Repro: production saw isFeatureEnabled return the caller-supplied
+        // defaultValue (false) for a flag that is enabled at 100% of all users,
+        // and `$feature_flag_called` events carried `$feature_flag_error: "unknown_error"`.
+        //
+        // PostHogFlagsResponse has both a legacy `featureFlags: Map<String, Any>?`
+        // field (just key → enabled) and a new `flags: Map<String, FeatureFlag>?` field.
+        // `getFeatureFlagsFromRemote` only reads `response.flags`. If the server
+        // returns a payload with the old `featureFlags` shape but no `flags` field,
+        // the SDK caches `flags = null` and every legacy-method lookup falls back
+        // to the caller's defaultValue.
+        val legacyShapeResponse =
+            """
+            {
+                "featureFlags": {
+                    "greenwheels-reducing-balance": true
+                },
+                "requestId": "req-1",
+                "evaluatedAt": 1747487809
+            }
+            """.trimIndent()
+        val mockServer = createMockHttp(jsonResponse(legacyShapeResponse))
+        val url = mockServer.url("/").toString()
+
+        val postHog =
+            PostHog.with(
+                PostHogConfig.builder(TEST_API_KEY)
+                    .host(url)
+                    .build(),
+            )
+
+        val options = PostHogFeatureFlagOptions.builder().defaultValue(false).build()
+        val result = postHog.isFeatureEnabled("brian", "greenwheels-reducing-balance", options)
+
+        assertTrue(result, "Expected the flag to resolve to true (100% rollout); got the default value instead")
+
+        postHog.close()
+        mockServer.shutdown()
+    }
 }


### PR DESCRIPTION
## Symptom

On `posthog-server` 2.5.x, `isFeatureEnabled` / `getFeatureFlag` return the caller-supplied default value for flags that the server actually reports as enabled, and the corresponding `\$feature_flag_called` events carry `\$feature_flag_error: \"unknown_error\"`.

## Reproduction

`PostHogTest.isFeatureEnabled returns true when server returns the legacy featureFlags response shape` (added in this PR) mocks a `/flags` response in the V1 shape — only `featureFlags` populated, `flags` absent — and calls the public `isFeatureEnabled(distinctId, key, options)` entry point. The test fails on `main` (returns the default `false`) and passes with this change.

## Root cause

`PostHogFlagsResponse` carries both shapes:

```kotlin
public data class PostHogFlagsResponse(
    val errorsWhileComputingFlags: Boolean = false,
    val featureFlags: Map<String, Any>?,        // V1 — just key → enabled-or-variant
    val featureFlagPayloads: Map<String, Any?>?, // V1 — keyed payloads
    val flags: Map<String, FeatureFlag>? = null, // V4 — rich object per flag
    ...
)
```

`getFeatureFlagsFromRemote` only reads `response.flags`. When the server returns a V1-shaped response (some self-hosted deployments and older endpoint versions still do), `response.flags` is null, so the SDK caches `flags = null`. Then:

- `isFeatureEnabled` / `getFeatureFlag` resolve through `flags?.get(key)` → null → caller's default value.
- `getFeatureFlagError` hits its `entry.flags == null && entry.error == null → UNKNOWN_ERROR` branch and emits a spurious error tag on `\$feature_flag_called`.

The client SDK (`posthog`) already has an equivalent V4 → V1 normalisation in `PostHogRemoteConfig.normalizeFlagsResponse` for backward compat, and its `loadFeatureFlags` explicitly handles the V1 branch. The server SDK was missing the inverse direction.

## Fix

Add an `adaptLegacyFlags` helper in `PostHogFeatureFlags` that converts `featureFlags` + `featureFlagPayloads` into `Map<String, FeatureFlag>`:

- `featureFlags[\"k\"] = true | false` → `FeatureFlag(enabled = …, variant = null, …)`.
- `featureFlags[\"k\"] = \"variant-name\"` → `FeatureFlag(enabled = true, variant = \"variant-name\", …)`.
- Any payload lives on `metadata.payload`.

Applied as a fallback in `getFeatureFlagsFromRemote`:

```kotlin
val flags = response?.flags ?: adaptLegacyFlags(response)
```

V4 responses are untouched — the helper only runs when `response.flags` is null.

## Tests

- New regression test in `PostHogTest` reproduces the bug against a V1-shaped mock response and asserts `isFeatureEnabled` returns true.
- Confirmed the test fails on `main` (returns the default) and passes with this change.
- `./gradlew :posthog-server:test` — 378 tests, 0 failures.

## Changeset

`patch` bump on `posthog-server`.