### PR TITLE
chore(logs): internal plumbing for upcoming logs feature

### DIFF
--- a/.changeset/logs-pr2.md
+++ b/.changeset/logs-pr2.md
@@ -1,0 +1,8 @@
+---
+"posthog": minor
+"posthog-android": minor
+---
+
+Internal plumbing for the logs feature: log record + severity types, OTLP/JSON
+builder, `/i/v1/logs` endpoint on `PostHogApi`, and a `PostHogQueue` wired
+through `PostHog.setup`. No public capture API.

--- a/.changeset/logs-pr2.md
+++ b/.changeset/logs-pr2.md
@@ -1,8 +1,0 @@
----
-"posthog": minor
-"posthog-android": minor
----
-
-Internal plumbing for the logs feature: log record + severity types, OTLP/JSON
-builder, `/i/v1/logs` endpoint on `PostHogApi`, and a `PostHogQueue` wired
-through `PostHog.setup`. No public capture API.

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -97,9 +97,11 @@ public class PostHogAndroid private constructor() {
             val legacyPath = context.getDir("app_posthog-disk-queue", Context.MODE_PRIVATE)
             val path = File(context.cacheDir, "posthog-disk-queue")
             val replayPath = File(context.cacheDir, "posthog-disk-replay-queue")
+            val logsPath = File(context.cacheDir, "posthog-disk-logs-queue")
             config.legacyStoragePrefix = config.legacyStoragePrefix ?: legacyPath.absolutePath
             config.storagePrefix = config.storagePrefix ?: path.absolutePath
             config.replayStoragePrefix = config.replayStoragePrefix ?: replayPath.absolutePath
+            config.logsStoragePrefix = config.logsStoragePrefix ?: logsPath.absolutePath
             val preferences = config.cachePreferences ?: PostHogSharedPreferences(context, config)
             config.cachePreferences = preferences
             // Defaults to PostHogDeviceDateProvider when api < 33

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -22,7 +22,7 @@ public final class com/posthog/PersonProfiles : java/lang/Enum {
 
 public final class com/posthog/PostHog : com/posthog/PostHogStateless, com/posthog/PostHogInterface {
 	public static final field Companion Lcom/posthog/PostHog$Companion;
-	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;Ljava/util/concurrent/ExecutorService;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun alias (Ljava/lang/String;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)V
@@ -143,6 +143,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getIntegrations ()Ljava/util/List;
 	public final fun getLegacyStoragePrefix ()Ljava/lang/String;
 	public final fun getLogger ()Lcom/posthog/internal/PostHogLogger;
+	public final fun getLogsStoragePrefix ()Ljava/lang/String;
 	public final fun getMaxBatchSize ()I
 	public final fun getMaxQueueSize ()I
 	public final fun getMaxRetries ()I
@@ -188,6 +189,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setHttpClient (Lokhttp3/OkHttpClient;)V
 	public final fun setLegacyStoragePrefix (Ljava/lang/String;)V
 	public final fun setLogger (Lcom/posthog/internal/PostHogLogger;)V
+	public final fun setLogsStoragePrefix (Ljava/lang/String;)V
 	public final fun setMaxBatchSize (I)V
 	public final fun setMaxQueueSize (I)V
 	public final fun setMaxRetries (I)V

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1,6 +1,7 @@
 package com.posthog
 
 import com.posthog.errortracking.PostHogErrorTrackingAutoCaptureIntegration
+import com.posthog.internal.EndpointSpec
 import com.posthog.internal.PostHogApi
 import com.posthog.internal.PostHogApiEndpoint
 import com.posthog.internal.PostHogDefaultPersonPropertiesProvider
@@ -18,6 +19,7 @@ import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
 import com.posthog.internal.PostHogPreferences.Companion.VERSION
 import com.posthog.internal.PostHogPrintLogger
+import com.posthog.internal.PostHogQueue
 import com.posthog.internal.PostHogQueueInterface
 import com.posthog.internal.PostHogRemoteConfig
 import com.posthog.internal.PostHogSendCachedEventsIntegration
@@ -28,6 +30,7 @@ import com.posthog.internal.personPropertiesContext
 import com.posthog.internal.replay.PostHogSessionReplayHandler
 import com.posthog.internal.sortMapRecursively
 import com.posthog.internal.surveys.PostHogSurveysHandler
+import com.posthog.logs.PostHogLogRecord
 import com.posthog.vendor.uuid.TimeBasedEpochGenerator
 import java.util.Date
 import java.util.UUID
@@ -42,6 +45,10 @@ public class PostHog private constructor(
     private val replayExecutor: ExecutorService =
         Executors.newSingleThreadScheduledExecutor(
             PostHogThreadFactory("PostHogReplayQueueThread"),
+        ),
+    private val logsExecutor: ExecutorService =
+        Executors.newSingleThreadScheduledExecutor(
+            PostHogThreadFactory("PostHogLogsQueueThread"),
         ),
     private val remoteConfigExecutor: ExecutorService =
         Executors.newSingleThreadScheduledExecutor(
@@ -63,6 +70,8 @@ public class PostHog private constructor(
     private val cachedPersonPropertiesLock = Any()
 
     private var replayQueue: PostHogQueueInterface<PostHogEvent>? = null
+
+    private var logsQueue: PostHogQueueInterface<PostHogLogRecord>? = null
 
     private val remoteConfig: PostHogRemoteConfig?
         get() = config?.remoteConfigHolder
@@ -127,6 +136,17 @@ public class PostHog private constructor(
                         config.replayStoragePrefix,
                         replayExecutor,
                     )
+                // The events/snapshot queueProvider is intentionally kept
+                // PostHogEvent-typed; logs have a different record type and
+                // no `wrap me` extension point analogous to replay, so the
+                // queue is constructed directly here rather than threading a
+                // second generic through PostHogConfig.
+                val logsQueue =
+                    PostHogQueue(
+                        config,
+                        EndpointSpec.logs(config, api, config.logsStoragePrefix),
+                        logsExecutor,
+                    )
                 val onRemoteConfigLoaded =
                     PostHogOnRemoteConfigLoaded {
                         try {
@@ -172,6 +192,7 @@ public class PostHog private constructor(
                 this.config = config
                 this.queue = queue
                 this.replayQueue = replayQueue
+                this.logsQueue = logsQueue
 
                 if (featureFlags is PostHogRemoteConfig) {
                     config.remoteConfigHolder = featureFlags
@@ -190,6 +211,7 @@ public class PostHog private constructor(
                 getDeviceId()
 
                 queue.start()
+                // logsQueue.start() — uncomment when the public log() API ships
 
                 PostHogSessionManager.setOnSessionIdChangedListener {
                     try {
@@ -314,6 +336,7 @@ public class PostHog private constructor(
 
                 queue?.stop()
                 replayQueue?.stop()
+                logsQueue?.stop()
 
                 featureFlagsCalled.clear()
 
@@ -1205,6 +1228,7 @@ public class PostHog private constructor(
         }
         super.flush()
         replayQueue?.flush()
+        logsQueue?.flush()
     }
 
     public override fun setPersonPropertiesForFlags(
@@ -1500,13 +1524,18 @@ public class PostHog private constructor(
             featureFlagsExecutor: ExecutorService,
             cachedEventsExecutor: ExecutorService,
             reloadFeatureFlags: Boolean,
+            logsExecutor: ExecutorService =
+                Executors.newSingleThreadScheduledExecutor(
+                    PostHogThreadFactory("PostHogLogsQueueThread"),
+                ),
         ): PostHogInterface {
             val instance =
                 PostHog(
-                    queueExecutor,
-                    replayExecutor,
-                    featureFlagsExecutor,
-                    cachedEventsExecutor,
+                    queueExecutor = queueExecutor,
+                    replayExecutor = replayExecutor,
+                    logsExecutor = logsExecutor,
+                    remoteConfigExecutor = featureFlagsExecutor,
+                    cachedEventsExecutor = cachedEventsExecutor,
                     reloadFeatureFlags = reloadFeatureFlags,
                 )
             instance.setup(config)

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -384,6 +384,9 @@ public open class PostHogConfig(
     public var replayStoragePrefix: String? = null
 
     @PostHogInternal
+    public var logsStoragePrefix: String? = null
+
+    @PostHogInternal
     public var cachePreferences: PostHogPreferences? = null
 
     @PostHogInternal

--- a/posthog/src/main/java/com/posthog/internal/EndpointSpec.kt
+++ b/posthog/src/main/java/com/posthog/internal/EndpointSpec.kt
@@ -103,8 +103,12 @@ public class EndpointSpec<Record> internal constructor(
             api: PostHogApi,
             storagePrefix: String?,
             resourceAttributes: Map<String, Any> = emptyMap(),
-        ): EndpointSpec<PostHogLogRecord> =
-            EndpointSpec(
+        ): EndpointSpec<PostHogLogRecord> {
+            // Capture `os.*` from PostHogContext once at factory time. SDK-managed
+            // keys (telemetry.sdk.*) are layered on inside PostHogLogsOTLP; this
+            // overlay carries Android-side context.
+            val mergedResourceAttributes = mergeOsResourceAttributes(resourceAttributes, config.context)
+            return EndpointSpec(
                 recordsLabel = "logs",
                 storagePrefix = storagePrefix,
                 initialCap = { it.maxBatchSize },
@@ -119,9 +123,10 @@ public class EndpointSpec<Record> internal constructor(
                     map?.let { PostHogLogRecord.fromStorageMap(it) }
                 },
                 describe = { _ -> "log" },
-                send = { records -> api.sendLogs(records, resourceAttributes) },
+                send = { records -> api.sendLogs(records, mergedResourceAttributes) },
                 isRetriableStatusCode = ::isLogsRetriableStatusCode,
             )
+        }
     }
 }
 
@@ -130,3 +135,26 @@ internal val DEFAULT_EVENTS_RETRYABLE_STATUS_CODES: Set<Int> = setOf(429, 500, 5
 internal fun isEventsRetriableStatusCode(code: Int): Boolean = code in DEFAULT_EVENTS_RETRYABLE_STATUS_CODES
 
 internal fun isLogsRetriableStatusCode(code: Int): Boolean = code == 408 || code == 429 || code in 500..599
+
+/**
+ * Layers OpenTelemetry `os.name` / `os.version` resource attributes from
+ * [PostHogContext]'s static context onto the user-supplied resource attributes.
+ * SDK-managed keys win over user-supplied so the wire output reflects the
+ * actual device. Returns the user map unchanged when no context is present
+ * (e.g. pure-JVM `posthog` module without the Android overlay).
+ */
+private fun mergeOsResourceAttributes(
+    userResourceAttributes: Map<String, Any>,
+    context: PostHogContext?,
+): Map<String, Any> {
+    if (context == null) return userResourceAttributes
+    val staticContext = context.getStaticContext()
+    val osName = staticContext["\$os_name"] as? String
+    val osVersion = staticContext["\$os_version"] as? String
+    if (osName == null && osVersion == null) return userResourceAttributes
+    val merged = LinkedHashMap<String, Any>(userResourceAttributes.size + 2)
+    merged.putAll(userResourceAttributes)
+    osName?.let { merged["os.name"] = it }
+    osVersion?.let { merged["os.version"] = it }
+    return merged
+}

--- a/posthog/src/main/java/com/posthog/internal/EndpointSpec.kt
+++ b/posthog/src/main/java/com/posthog/internal/EndpointSpec.kt
@@ -3,6 +3,7 @@ package com.posthog.internal
 import com.posthog.PostHogConfig
 import com.posthog.PostHogEvent
 import com.posthog.PostHogInternal
+import com.posthog.logs.PostHogLogRecord
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.UUID
@@ -84,9 +85,48 @@ public class EndpointSpec<Record> internal constructor(
                 isFatalRecord = { it.isFatalExceptionEvent() },
                 recordUuid = { it.uuid },
             )
+
+        /**
+         * Returns the [EndpointSpec] for PostHog's logs ingestion endpoint
+         * (`/i/v1/logs`, OTLP/JSON). Pass the result to a
+         * [com.posthog.internal.PostHogQueue] to enqueue and flush log
+         * records.
+         *
+         * `resourceAttributes` is captured by value; supply the
+         * once-per-setup snapshot of any user-configurable resource keys
+         * (e.g. `service.name`, `service.version`, `deployment.environment`)
+         * here. SDK-managed `telemetry.sdk.*` keys are appended automatically
+         * and override any user-supplied values for those keys.
+         */
+        internal fun logs(
+            config: PostHogConfig,
+            api: PostHogApi,
+            storagePrefix: String?,
+            resourceAttributes: Map<String, Any> = emptyMap(),
+        ): EndpointSpec<PostHogLogRecord> =
+            EndpointSpec(
+                recordsLabel = "logs",
+                storagePrefix = storagePrefix,
+                initialCap = { it.maxBatchSize },
+                initialFlushAt = { it.flushAt },
+                maxQueueSize = { it.maxQueueSize },
+                flushIntervalSeconds = { it.flushIntervalSeconds },
+                encode = { record, stream ->
+                    config.serializer.serialize(record.toStorageMap(), stream.writer().buffered())
+                },
+                decode = { stream ->
+                    val map: Map<String, Any>? = config.serializer.deserialize(stream.reader().buffered())
+                    map?.let { PostHogLogRecord.fromStorageMap(it) }
+                },
+                describe = { _ -> "log" },
+                send = { records -> api.sendLogs(records, resourceAttributes) },
+                isRetriableStatusCode = ::isLogsRetriableStatusCode,
+            )
     }
 }
 
 internal val DEFAULT_EVENTS_RETRYABLE_STATUS_CODES: Set<Int> = setOf(429, 500, 502, 503, 504)
 
 internal fun isEventsRetriableStatusCode(code: Int): Boolean = code in DEFAULT_EVENTS_RETRYABLE_STATUS_CODES
+
+internal fun isLogsRetriableStatusCode(code: Int): Boolean = code == 408 || code == 429 || code in 500..599

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -7,6 +7,8 @@ import com.posthog.PostHogConfig.Companion.DEFAULT_US_ASSETS_HOST
 import com.posthog.PostHogConfig.Companion.DEFAULT_US_HOST
 import com.posthog.PostHogEvent
 import com.posthog.PostHogInternal
+import com.posthog.internal.logs.PostHogLogsOTLP
+import com.posthog.logs.PostHogLogRecord
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -87,6 +89,46 @@ public class PostHogApi(
         val request =
             makeRequest(url) {
                 config.serializer.serialize(events, it.bufferedWriter())
+            }
+
+        logRequestHeaders(request)
+
+        client.newCall(request).execute().use {
+            val response = logResponse(it)
+
+            if (!response.isSuccessful) {
+                throw PostHogApiError(response.code, response.message, response.body, parseRetryAfter(response))
+            }
+        }
+    }
+
+    /**
+     * Builds an OTLP/JSON payload for the supplied [records] and posts it to
+     * `/i/v1/logs?token=<apiKey>`. Throws [PostHogApiError] on a non-success
+     * status and [IOException] on a transport failure.
+     *
+     * `resourceAttributes` (e.g. `service.name`, `service.version`) is merged
+     * with SDK-managed `telemetry.sdk.*` keys before serialization.
+     */
+    @Throws(PostHogApiError::class, IOException::class)
+    internal fun sendLogs(
+        records: List<PostHogLogRecord>,
+        resourceAttributes: Map<String, Any>,
+    ) {
+        val payload =
+            PostHogLogsOTLP.buildPayload(
+                records = records,
+                resourceAttributes = resourceAttributes,
+                sdkName = config.sdkName,
+                sdkVersion = config.sdkVersion,
+            )
+
+        val url = "$theHost/i/v1/logs?token=${config.apiKey}"
+        val request =
+            makeRequest(url) {
+                logRequest(payload, url)
+
+                config.serializer.serialize(payload, it.bufferedWriter())
             }
 
         logRequestHeaders(request)

--- a/posthog/src/main/java/com/posthog/internal/logs/PostHogLogsOTLP.kt
+++ b/posthog/src/main/java/com/posthog/internal/logs/PostHogLogsOTLP.kt
@@ -1,6 +1,8 @@
 package com.posthog.internal.logs
 
+import com.posthog.internal.formatISO8601Date
 import com.posthog.logs.PostHogLogRecord
+import java.util.Date
 
 /**
  * OpenTelemetry / OTLP-JSON serialization for log records.
@@ -42,6 +44,7 @@ internal object PostHogLogsOTLP {
                 }
                 mapOf("kvlistValue" to mapOf("values" to toKeyValueList(safe)))
             }
+            is Date -> mapOf("stringValue" to formatISO8601Date(value))
             // Last resort: stringify so the user gets something rather than a
             // silently dropped attribute.
             else -> mapOf("stringValue" to value.toString())
@@ -103,10 +106,6 @@ internal object PostHogLogsOTLP {
      * Layers SDK-managed resource attributes (`telemetry.sdk.name`,
      * `telemetry.sdk.version`) on top of the user-supplied
      * `resourceAttributes` so the SDK identification can't be shadowed.
-     *
-     * Other resource attributes (`service.name`, `os.*`,
-     * `deployment.environment`) are populated by the caller through
-     * `resourceAttributes` once a logs config / context bridge exists.
      */
     fun buildResourceAttributes(
         userResourceAttributes: Map<String, Any>,

--- a/posthog/src/main/java/com/posthog/internal/logs/PostHogLogsOTLP.kt
+++ b/posthog/src/main/java/com/posthog/internal/logs/PostHogLogsOTLP.kt
@@ -1,0 +1,157 @@
+package com.posthog.internal.logs
+
+import com.posthog.logs.PostHogLogRecord
+
+/**
+ * OpenTelemetry / OTLP-JSON serialization for log records.
+ *
+ * Emits the OTLP `LogsService` request shape
+ * (`resourceLogs[].scopeLogs[].logRecords[]`) — distinct from PostHog's
+ * internal events batch shape because the logs ingestion endpoint expects OTLP.
+ */
+internal object PostHogLogsOTLP {
+    /**
+     * Wraps a value as an OTLP `AnyValue`. Returns `null` for values that
+     * have no representable OTLP form (which the caller should drop).
+     *
+     * `Int` / `Long` / `Short` / `Byte` map to `intValue` (encoded as a
+     * string per proto3 JSON int64 rules). `Double` / `Float` map to
+     * `doubleValue` for finite numbers and `stringValue` ("NaN" | "Infinity"
+     * | "-Infinity") otherwise — JSON cannot represent those floats directly.
+     */
+    fun toAnyValue(value: Any?): Map<String, Any>? {
+        if (value == null) return null
+        return when (value) {
+            is String -> mapOf("stringValue" to value)
+            is Boolean -> mapOf("boolValue" to value)
+            // Double / Float must precede Number so the NaN / Infinity sentinel path
+            // keeps firing for non-finite floats that JSON can't express directly.
+            is Double -> doubleAnyValue(value)
+            is Float -> doubleAnyValue(value.toDouble())
+            // Long / Int / Short / Byte / BigInteger / AtomicInteger all encode as
+            // int64-as-string per proto3 JSON.
+            is Number -> mapOf("intValue" to value.toLong().toString())
+            is List<*> -> {
+                val mapped = value.mapNotNull { toAnyValue(it) }
+                mapOf("arrayValue" to mapOf("values" to mapped))
+            }
+            is Map<*, *> -> {
+                val safe = LinkedHashMap<String, Any>()
+                for ((k, v) in value) {
+                    if (k is String && v != null) safe[k] = v
+                }
+                mapOf("kvlistValue" to mapOf("values" to toKeyValueList(safe)))
+            }
+            // Last resort: stringify so the user gets something rather than a
+            // silently dropped attribute.
+            else -> mapOf("stringValue" to value.toString())
+        }
+    }
+
+    private fun doubleAnyValue(value: Double): Map<String, Any> {
+        if (value.isNaN()) return mapOf("stringValue" to "NaN")
+        if (value.isInfinite()) {
+            return mapOf("stringValue" to if (value > 0) "Infinity" else "-Infinity")
+        }
+        return mapOf("doubleValue" to value)
+    }
+
+    /**
+     * Converts a `Map<String, Any>` to an OTLP `KeyValue[]` list, dropping
+     * entries whose values cannot be represented. Keys are sorted so the
+     * wire output is deterministic — easier on tests and diff-based debugging.
+     */
+    fun toKeyValueList(dict: Map<String, Any>): List<Map<String, Any>> {
+        val result = ArrayList<Map<String, Any>>(dict.size)
+        for (key in dict.keys.sorted()) {
+            val raw = dict[key] ?: continue
+            val value = toAnyValue(raw) ?: continue
+            result.add(mapOf("key" to key, "value" to value))
+        }
+        return result
+    }
+
+    /**
+     * Builds a single OTLP `LogRecord` element from a stored record.
+     * Auto-attached context (distinctId, sessionId, screen.name, app.state,
+     * feature_flags) is merged in *underneath* the user's `attributes` so
+     * user-supplied keys win on collision.
+     */
+    fun buildLogRecord(record: PostHogLogRecord): Map<String, Any> {
+        val attrs = LinkedHashMap<String, Any>()
+        record.distinctId?.let { attrs["posthogDistinctId"] = it }
+        record.sessionId?.let { attrs["sessionId"] = it }
+        record.screenName?.let { attrs["screen.name"] = it }
+        record.appState?.let { attrs["app.state"] = it }
+        if (record.featureFlagKeys.isNotEmpty()) attrs["feature_flags"] = record.featureFlagKeys
+        attrs.putAll(record.attributes)
+
+        val json = LinkedHashMap<String, Any>()
+        json["timeUnixNano"] = record.timeUnixNano
+        json["observedTimeUnixNano"] = record.observedTimeUnixNano
+        json["severityNumber"] = record.level.severityNumber
+        json["severityText"] = record.level.severityText
+        json["body"] = mapOf("stringValue" to record.body)
+        if (attrs.isNotEmpty()) json["attributes"] = toKeyValueList(attrs)
+        record.traceId?.let { json["traceId"] = it }
+        record.spanId?.let { json["spanId"] = it }
+        record.traceFlags?.let { json["flags"] = it }
+        return json
+    }
+
+    /**
+     * Layers SDK-managed resource attributes (`telemetry.sdk.name`,
+     * `telemetry.sdk.version`) on top of the user-supplied
+     * `resourceAttributes` so the SDK identification can't be shadowed.
+     *
+     * Other resource attributes (`service.name`, `os.*`,
+     * `deployment.environment`) are populated by the caller through
+     * `resourceAttributes` once a logs config / context bridge exists.
+     */
+    fun buildResourceAttributes(
+        userResourceAttributes: Map<String, Any>,
+        sdkName: String,
+        sdkVersion: String,
+    ): Map<String, Any> {
+        val attrs = LinkedHashMap<String, Any>()
+        attrs.putAll(userResourceAttributes)
+        attrs["telemetry.sdk.name"] = sdkName
+        attrs["telemetry.sdk.version"] = sdkVersion
+        return attrs
+    }
+
+    /**
+     * Builds the full OTLP request payload.
+     */
+    fun buildPayload(
+        records: List<PostHogLogRecord>,
+        resourceAttributes: Map<String, Any>,
+        sdkName: String,
+        sdkVersion: String,
+    ): Map<String, Any> {
+        val mergedResourceAttrs = buildResourceAttributes(resourceAttributes, sdkName, sdkVersion)
+        val logRecords = records.map { buildLogRecord(it) }
+        return mapOf(
+            "resourceLogs" to
+                listOf(
+                    mapOf(
+                        "resource" to
+                            mapOf(
+                                "attributes" to toKeyValueList(mergedResourceAttrs),
+                            ),
+                        "scopeLogs" to
+                            listOf(
+                                mapOf(
+                                    "scope" to
+                                        mapOf(
+                                            "name" to sdkName,
+                                            "version" to sdkVersion,
+                                        ),
+                                    "logRecords" to logRecords,
+                                ),
+                            ),
+                    ),
+                ),
+        )
+    }
+}

--- a/posthog/src/main/java/com/posthog/logs/PostHogLogRecord.kt
+++ b/posthog/src/main/java/com/posthog/logs/PostHogLogRecord.kt
@@ -1,5 +1,8 @@
 package com.posthog.logs
 
+import com.posthog.internal.PostHogDateProvider
+import com.posthog.internal.PostHogDeviceDateProvider
+
 /** A captured log entry queued for delivery to PostHog's logs ingestion. */
 internal data class PostHogLogRecord(
     val body: String,
@@ -74,6 +77,13 @@ internal data class PostHogLogRecord(
             )
         }
 
-        internal fun nanosNow(): String = (System.currentTimeMillis() * 1_000_000L).toString()
+        /**
+         * Default timestamp source. Production capture should call this with
+         * `config.dateProvider` so tests using `FakePostHogDateProvider` can
+         * drive log timestamps deterministically; the no-arg default falls
+         * back to the device clock for callers without an SDK instance.
+         */
+        internal fun nanosNow(dateProvider: PostHogDateProvider = PostHogDeviceDateProvider()): String =
+            (dateProvider.currentDate().time * 1_000_000L).toString()
     }
 }

--- a/posthog/src/main/java/com/posthog/logs/PostHogLogRecord.kt
+++ b/posthog/src/main/java/com/posthog/logs/PostHogLogRecord.kt
@@ -1,0 +1,79 @@
+package com.posthog.logs
+
+/** A captured log entry queued for delivery to PostHog's logs ingestion. */
+internal data class PostHogLogRecord(
+    val body: String,
+    val level: PostHogLogSeverity = PostHogLogSeverity.INFO,
+    val attributes: Map<String, Any> = emptyMap(),
+    val traceId: String? = null,
+    val spanId: String? = null,
+    val traceFlags: Int? = null,
+    val distinctId: String? = null,
+    val sessionId: String? = null,
+    val screenName: String? = null,
+    val featureFlagKeys: List<String> = emptyList(),
+    val appState: String? = null,
+    val timeUnixNano: String = nanosNow(),
+    val observedTimeUnixNano: String = timeUnixNano,
+) {
+    /**
+     * The on-disk shape consumed by [fromStorageMap]. Decoupled from the OTLP
+     * wire format so the wire format can change without rewriting persisted
+     * records.
+     */
+    fun toStorageMap(): Map<String, Any> {
+        val map = LinkedHashMap<String, Any>()
+        map["body"] = body
+        map["level"] = level.severityText
+        map["timeUnixNano"] = timeUnixNano
+        map["observedTimeUnixNano"] = observedTimeUnixNano
+        map["featureFlagKeys"] = featureFlagKeys
+        if (attributes.isNotEmpty()) map["attributes"] = attributes
+        traceId?.let { map["traceId"] = it }
+        spanId?.let { map["spanId"] = it }
+        traceFlags?.let { map["traceFlags"] = it }
+        distinctId?.let { map["distinctId"] = it }
+        sessionId?.let { map["sessionId"] = it }
+        screenName?.let { map["screenName"] = it }
+        appState?.let { map["appState"] = it }
+        return map
+    }
+
+    companion object {
+        fun fromStorageMap(map: Map<String, Any>): PostHogLogRecord? {
+            val body = map["body"] as? String ?: return null
+            val levelName = map["level"] as? String ?: "info"
+            val level = PostHogLogSeverity.from(levelName) ?: PostHogLogSeverity.INFO
+
+            @Suppress("UNCHECKED_CAST")
+            val attributes = (map["attributes"] as? Map<String, Any>) ?: emptyMap()
+            val timeUnixNano = map["timeUnixNano"] as? String ?: nanosNow()
+            val observedTimeUnixNano = map["observedTimeUnixNano"] as? String ?: timeUnixNano
+
+            @Suppress("UNCHECKED_CAST")
+            val featureFlagKeys = (map["featureFlagKeys"] as? List<String>) ?: emptyList()
+            val traceFlags =
+                when (val raw = map["traceFlags"]) {
+                    is Number -> raw.toInt()
+                    else -> null
+                }
+            return PostHogLogRecord(
+                body = body,
+                level = level,
+                attributes = attributes,
+                traceId = map["traceId"] as? String,
+                spanId = map["spanId"] as? String,
+                traceFlags = traceFlags,
+                distinctId = map["distinctId"] as? String,
+                sessionId = map["sessionId"] as? String,
+                screenName = map["screenName"] as? String,
+                featureFlagKeys = featureFlagKeys,
+                appState = map["appState"] as? String,
+                timeUnixNano = timeUnixNano,
+                observedTimeUnixNano = observedTimeUnixNano,
+            )
+        }
+
+        internal fun nanosNow(): String = (System.currentTimeMillis() * 1_000_000L).toString()
+    }
+}

--- a/posthog/src/main/java/com/posthog/logs/PostHogLogRecord.kt
+++ b/posthog/src/main/java/com/posthog/logs/PostHogLogRecord.kt
@@ -1,7 +1,6 @@
 package com.posthog.logs
 
 import com.posthog.internal.PostHogDateProvider
-import com.posthog.internal.PostHogDeviceDateProvider
 
 /** A captured log entry queued for delivery to PostHog's logs ingestion. */
 internal data class PostHogLogRecord(
@@ -78,12 +77,12 @@ internal data class PostHogLogRecord(
         }
 
         /**
-         * Default timestamp source. Production capture should call this with
-         * `config.dateProvider` so tests using `FakePostHogDateProvider` can
-         * drive log timestamps deterministically; the no-arg default falls
-         * back to the device clock for callers without an SDK instance.
+         * Nanoseconds since epoch. Pass a [PostHogDateProvider] for
+         * deterministic timestamps in tests; defaults to the system clock.
          */
-        internal fun nanosNow(dateProvider: PostHogDateProvider = PostHogDeviceDateProvider()): String =
-            (dateProvider.currentDate().time * 1_000_000L).toString()
+        internal fun nanosNow(dateProvider: PostHogDateProvider? = null): String {
+            val millis = dateProvider?.currentTimeMillis() ?: System.currentTimeMillis()
+            return (millis * 1_000_000L).toString()
+        }
     }
 }

--- a/posthog/src/main/java/com/posthog/logs/PostHogLogSeverity.kt
+++ b/posthog/src/main/java/com/posthog/logs/PostHogLogSeverity.kt
@@ -1,0 +1,31 @@
+package com.posthog.logs
+
+/**
+ * Severity level for a captured log record.
+ *
+ * Constants are declared in severity order so `>=` comparisons on
+ * [severityNumber] give the expected result.
+ *
+ * Maps to OpenTelemetry severity numbers (`TRACE=1`, `DEBUG=5`, `INFO=9`,
+ * `WARN=13`, `ERROR=17`, `FATAL=21`) for the OTLP wire format.
+ */
+internal enum class PostHogLogSeverity(
+    val severityNumber: Int,
+    val severityText: String,
+) {
+    TRACE(1, "trace"),
+    DEBUG(5, "debug"),
+    INFO(9, "info"),
+    WARN(13, "warn"),
+    ERROR(17, "error"),
+    FATAL(21, "fatal"),
+    ;
+
+    companion object {
+        /** Tolerates surrounding whitespace and casing. Returns `null` for unknown values. */
+        fun from(name: String): PostHogLogSeverity? {
+            val normalized = name.trim().lowercase()
+            return entries.firstOrNull { it.severityText == normalized }
+        }
+    }
+}

--- a/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
@@ -6,6 +6,7 @@ import com.posthog.awaitExecution
 import com.posthog.generateEvent
 import com.posthog.mockHttp
 import com.posthog.shutdownAndAwaitTermination
+import com.posthog.unGzip
 import okhttp3.mockwebserver.MockResponse
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -205,6 +206,67 @@ internal class EndpointSpecTest {
         // All 5 records retained — proves the spec re-reads config.maxQueueSize
         // each time removeRecordSync runs. A snapshot would still cap at 2.
         assertEquals(5, queue.dequeList.size)
+    }
+
+    @Test
+    fun `EndpointSpec logs factory writes to slash i v1 logs`() {
+        val executor = Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("Test"))
+        val storagePrefix = tmpDir.newFolder().absolutePath
+        val http = mockHttp(response = MockResponse().setBody(""))
+        val config =
+            PostHogConfig(API_KEY, http.url("/").toString()).apply {
+                this.storagePrefix = storagePrefix
+                this.flushAt = 1
+            }
+        val api = PostHogApi(config)
+        val spec = EndpointSpec.logs(config, api, storagePrefix)
+        val queue = PostHogQueue(config, spec, executor)
+
+        queue.add(com.posthog.logs.PostHogLogRecord(body = "via-spec"))
+
+        executor.shutdownAndAwaitTermination()
+
+        assertEquals(1, http.requestCount)
+        val request = http.takeRequest()
+        assertTrue(request.path!!.startsWith("/i/v1/logs?token="))
+        // Without the body assertion the test would pass if the queue posted an
+        // empty body or a non-OTLP body — prove the encoded record actually
+        // reaches the wire.
+        val unzipped = request.body.unGzip()
+        assertTrue(unzipped.contains("\"resourceLogs\""))
+        assertTrue(unzipped.contains("\"stringValue\":\"via-spec\""))
+
+        http.shutdown()
+    }
+
+    @Test
+    fun `logs spec retry policy retries 408 429 and 5xx`() {
+        assertTrue(isLogsRetriableStatusCode(408))
+        assertTrue(isLogsRetriableStatusCode(429))
+        assertTrue(isLogsRetriableStatusCode(500))
+        assertTrue(isLogsRetriableStatusCode(599))
+        // 3xx redirects are not retriable — a redirect from /i/v1/logs means
+        // misconfigured host, retrying would loop.
+        assertEquals(false, isLogsRetriableStatusCode(301))
+        assertEquals(false, isLogsRetriableStatusCode(400))
+        assertEquals(false, isLogsRetriableStatusCode(404))
+        assertEquals(false, isLogsRetriableStatusCode(600))
+    }
+
+    @Test
+    fun `events spec retry policy stays narrower than logs`() {
+        // Locks in the asymmetry. If someone copy-pastes the logs predicate
+        // (408 + all 5xx) into the events code path, 408 and 501/505/etc.
+        // would silently start retrying for events.
+        assertTrue(isEventsRetriableStatusCode(429))
+        assertTrue(isEventsRetriableStatusCode(500))
+        assertTrue(isEventsRetriableStatusCode(502))
+        assertTrue(isEventsRetriableStatusCode(503))
+        assertTrue(isEventsRetriableStatusCode(504))
+        assertEquals(false, isEventsRetriableStatusCode(408))
+        assertEquals(false, isEventsRetriableStatusCode(501))
+        assertEquals(false, isEventsRetriableStatusCode(505))
+        assertEquals(false, isEventsRetriableStatusCode(599))
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
@@ -2,6 +2,7 @@ package com.posthog.internal
 
 import com.posthog.API_KEY
 import com.posthog.PostHogConfig
+import com.posthog.TestPostHogContext
 import com.posthog.awaitExecution
 import com.posthog.generateEvent
 import com.posthog.mockHttp
@@ -251,6 +252,66 @@ internal class EndpointSpecTest {
         assertEquals(false, isLogsRetriableStatusCode(400))
         assertEquals(false, isLogsRetriableStatusCode(404))
         assertEquals(false, isLogsRetriableStatusCode(600))
+    }
+
+    @Test
+    fun `logs factory wires os name and version from PostHogContext into resource attributes`() {
+        // TestPostHogContext supplies $os_name = "Android" and $os_version = "13".
+        // The logs factory should translate those into OTLP os.name / os.version
+        // on the wire so log payloads carry device context without needing
+        // PostHogLogsConfig (lands in the public-capture PR).
+        val executor = Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("Test"))
+        val storagePrefix = tmpDir.newFolder().absolutePath
+        val http = mockHttp(response = MockResponse().setBody(""))
+        val config =
+            PostHogConfig(API_KEY, http.url("/").toString()).apply {
+                this.storagePrefix = storagePrefix
+                this.flushAt = 1
+                this.context = TestPostHogContext()
+            }
+        val api = PostHogApi(config)
+        val spec = EndpointSpec.logs(config, api, storagePrefix)
+        val queue = PostHogQueue(config, spec, executor)
+
+        queue.add(com.posthog.logs.PostHogLogRecord(body = "ctx"))
+
+        executor.shutdownAndAwaitTermination()
+
+        val unzipped = http.takeRequest().body.unGzip()
+        assertTrue(unzipped.contains("\"key\":\"os.name\""), "os.name missing: $unzipped")
+        assertTrue(unzipped.contains("\"stringValue\":\"Android\""), "os.name=Android missing: $unzipped")
+        assertTrue(unzipped.contains("\"key\":\"os.version\""), "os.version missing: $unzipped")
+        assertTrue(unzipped.contains("\"stringValue\":\"13\""), "os.version=13 missing: $unzipped")
+
+        http.shutdown()
+    }
+
+    @Test
+    fun `logs factory omits os attributes when PostHogContext is null`() {
+        // Pure-JVM consumers without the Android overlay have config.context == null.
+        // The factory must not crash and must not emit os.* keys.
+        val executor = Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("Test"))
+        val storagePrefix = tmpDir.newFolder().absolutePath
+        val http = mockHttp(response = MockResponse().setBody(""))
+        val config =
+            PostHogConfig(API_KEY, http.url("/").toString()).apply {
+                this.storagePrefix = storagePrefix
+                this.flushAt = 1
+                // context intentionally not set (null)
+            }
+        val api = PostHogApi(config)
+        val spec = EndpointSpec.logs(config, api, storagePrefix)
+        val queue = PostHogQueue(config, spec, executor)
+
+        queue.add(com.posthog.logs.PostHogLogRecord(body = "no-ctx"))
+
+        executor.shutdownAndAwaitTermination()
+
+        val unzipped = http.takeRequest().body.unGzip()
+        assertEquals(false, unzipped.contains("\"os.name\""), "os.name should be absent: $unzipped")
+        assertEquals(false, unzipped.contains("\"os.version\""), "os.version should be absent: $unzipped")
+
+        http.shutdown()
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -4,7 +4,10 @@ import com.posthog.API_KEY
 import com.posthog.BuildConfig
 import com.posthog.PostHogConfig
 import com.posthog.generateEvent
+import com.posthog.logs.PostHogLogRecord
+import com.posthog.logs.PostHogLogSeverity
 import com.posthog.mockHttp
+import com.posthog.unGzip
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertThrows
@@ -439,5 +442,73 @@ internal class PostHogApiTest {
             logger.messages.any { it.contains("Request headers for") && it.contains("/array/") },
             "Should log request headers for /array/ (remoteConfig) endpoint",
         )
+    }
+
+    @Test
+    fun `sendLogs posts OTLP body to slash i v1 logs with token in query`() {
+        val http = mockHttp()
+        val url = http.url("/")
+        val sut = getSut(host = url.toString())
+
+        val record =
+            PostHogLogRecord(
+                body = "hello",
+                level = PostHogLogSeverity.INFO,
+                timeUnixNano = "1700000000000000000",
+                observedTimeUnixNano = "1700000000000000000",
+            )
+        sut.sendLogs(listOf(record), emptyMap())
+
+        val request = http.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/i/v1/logs?token=$API_KEY", request.path)
+        assertEquals("gzip", request.headers["Content-Encoding"])
+        assertEquals("application/json; charset=utf-8", request.headers["Content-Type"])
+
+        val unzipped = request.body.unGzip()
+        // Smoke-test the OTLP wire shape — exhaustive shape coverage is in PostHogLogsOTLPTest.
+        assertTrue(unzipped.contains("\"resourceLogs\""))
+        assertTrue(unzipped.contains("\"scopeLogs\""))
+        assertTrue(unzipped.contains("\"logRecords\""))
+        assertTrue(unzipped.contains("\"telemetry.sdk.name\""))
+        assertTrue(unzipped.contains("\"posthog-java\"") || unzipped.contains("\"posthog-android\""))
+        assertTrue(unzipped.contains("\"stringValue\":\"hello\""))
+    }
+
+    @Test
+    fun `sendLogs throws on non-success`() {
+        val http = mockHttp(response = MockResponse().setResponseCode(500).setBody("oops"))
+        val url = http.url("/")
+        val sut = getSut(host = url.toString())
+
+        val record = PostHogLogRecord(body = "x")
+        val exc =
+            assertThrows(PostHogApiError::class.java) {
+                sut.sendLogs(listOf(record), emptyMap())
+            }
+        assertEquals(500, exc.statusCode)
+    }
+
+    @Test
+    fun `sendLogs throws PostHogApiError on 408`() {
+        // The whole reason isLogsRetriableStatusCode exists separately from the
+        // events predicate is to cover 408. Lock in that the wire path surfaces
+        // a 408 as a retriable PostHogApiError so the queue can keep records.
+        val http =
+            mockHttp(
+                response =
+                    MockResponse()
+                        .setResponseCode(408)
+                        .setHeader("Retry-After", "3")
+                        .setBody("timeout"),
+            )
+        val sut = getSut(host = http.url("/").toString())
+
+        val record = PostHogLogRecord(body = "x")
+        val exc =
+            assertThrows(PostHogApiError::class.java) {
+                sut.sendLogs(listOf(record), emptyMap())
+            }
+        assertEquals(408, exc.statusCode)
     }
 }

--- a/posthog/src/test/java/com/posthog/internal/logs/PostHogLogsOTLPTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/logs/PostHogLogsOTLPTest.kt
@@ -3,6 +3,7 @@ package com.posthog.internal.logs
 import com.posthog.logs.PostHogLogRecord
 import com.posthog.logs.PostHogLogSeverity
 import java.math.BigInteger
+import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -214,6 +215,13 @@ internal class PostHogLogsOTLPTest {
         assertEquals("abc", out["traceId"])
         assertEquals("def", out["spanId"])
         assertEquals(1, out["flags"])
+    }
+
+    @Test
+    fun `toAnyValue encodes Date as ISO8601 stringValue`() {
+        val epoch = Date(0L)
+        val result = PostHogLogsOTLP.toAnyValue(epoch)
+        assertEquals(mapOf("stringValue" to "1970-01-01T00:00:00.000Z"), result)
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/logs/PostHogLogsOTLPTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/logs/PostHogLogsOTLPTest.kt
@@ -1,0 +1,330 @@
+package com.posthog.internal.logs
+
+import com.posthog.logs.PostHogLogRecord
+import com.posthog.logs.PostHogLogSeverity
+import java.math.BigInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class PostHogLogsOTLPTest {
+    @Test
+    fun `toAnyValue String maps to stringValue`() {
+        assertEquals(mapOf("stringValue" to "hello"), PostHogLogsOTLP.toAnyValue("hello"))
+    }
+
+    @Test
+    fun `toAnyValue Bool maps to boolValue`() {
+        assertEquals(mapOf("boolValue" to true), PostHogLogsOTLP.toAnyValue(true))
+        assertEquals(mapOf("boolValue" to false), PostHogLogsOTLP.toAnyValue(false))
+    }
+
+    @Test
+    fun `toAnyValue integer types encode as intValue string per proto3`() {
+        assertEquals(mapOf("intValue" to "42"), PostHogLogsOTLP.toAnyValue(42))
+        assertEquals(mapOf("intValue" to "42"), PostHogLogsOTLP.toAnyValue(42L))
+        assertEquals(mapOf("intValue" to "42"), PostHogLogsOTLP.toAnyValue(42.toShort()))
+        assertEquals(mapOf("intValue" to "42"), PostHogLogsOTLP.toAnyValue(42.toByte()))
+    }
+
+    @Test
+    fun `toAnyValue finite Double maps to doubleValue`() {
+        assertEquals(mapOf("doubleValue" to 3.14), PostHogLogsOTLP.toAnyValue(3.14))
+        assertEquals(mapOf("doubleValue" to 1.5), PostHogLogsOTLP.toAnyValue(1.5f))
+    }
+
+    @Test
+    fun `toAnyValue non-finite Double maps to stringValue special sentinels`() {
+        assertEquals(mapOf("stringValue" to "NaN"), PostHogLogsOTLP.toAnyValue(Double.NaN))
+        assertEquals(
+            mapOf("stringValue" to "Infinity"),
+            PostHogLogsOTLP.toAnyValue(Double.POSITIVE_INFINITY),
+        )
+        assertEquals(
+            mapOf("stringValue" to "-Infinity"),
+            PostHogLogsOTLP.toAnyValue(Double.NEGATIVE_INFINITY),
+        )
+    }
+
+    @Test
+    fun `toAnyValue null returns null so caller can drop`() {
+        assertNull(PostHogLogsOTLP.toAnyValue(null))
+    }
+
+    @Test
+    fun `toAnyValue List wraps mapped values under arrayValue`() {
+        val result = PostHogLogsOTLP.toAnyValue(listOf("a", 1, true))
+
+        @Suppress("UNCHECKED_CAST")
+        val values = ((result?.get("arrayValue") as Map<String, Any>)["values"] as List<Map<String, Any>>)
+        assertEquals(listOf("a"), values.map { it["stringValue"] }.filterNotNull())
+        assertEquals(listOf("1"), values.map { it["intValue"] }.filterNotNull())
+        assertEquals(listOf(true), values.map { it["boolValue"] }.filterNotNull())
+    }
+
+    @Test
+    fun `toAnyValue empty List still produces an empty arrayValue`() {
+        // Guard against a refactor that returned null for empty lists — the
+        // wire shape should always be arrayValue { values: [] }, not null.
+        assertEquals(
+            mapOf("arrayValue" to mapOf("values" to emptyList<Any>())),
+            PostHogLogsOTLP.toAnyValue(emptyList<Any>()),
+        )
+    }
+
+    @Test
+    fun `toAnyValue nested Map wraps as kvlistValue`() {
+        val result = PostHogLogsOTLP.toAnyValue(mapOf("nested" to "yes"))
+
+        @Suppress("UNCHECKED_CAST")
+        val kvlist = result?.get("kvlistValue") as Map<String, Any>
+
+        @Suppress("UNCHECKED_CAST")
+        val values = kvlist["values"] as List<Map<String, Any>>
+        assertEquals(1, values.size)
+        assertEquals("nested", values[0]["key"])
+        assertEquals(mapOf("stringValue" to "yes"), values[0]["value"])
+    }
+
+    @Test
+    fun `toKeyValueList sorts keys alphabetically and drops nulls`() {
+        val result =
+            PostHogLogsOTLP.toKeyValueList(
+                linkedMapOf("z" to "last", "a" to "first", "m" to "mid"),
+            )
+        assertEquals(listOf("a", "m", "z"), result.map { it["key"] as String })
+    }
+
+    @Test
+    fun `buildLogRecord produces OTLP shape with body stringValue and severity`() {
+        val record =
+            PostHogLogRecord(
+                body = "hello",
+                level = PostHogLogSeverity.WARN,
+                timeUnixNano = "100",
+                observedTimeUnixNano = "100",
+            )
+        val out = PostHogLogsOTLP.buildLogRecord(record)
+        assertEquals("100", out["timeUnixNano"])
+        assertEquals("100", out["observedTimeUnixNano"])
+        assertEquals(13, out["severityNumber"])
+        assertEquals("warn", out["severityText"])
+        assertEquals(mapOf("stringValue" to "hello"), out["body"])
+        // Assert key absence (not just value-null) so mutating
+        // `record.x?.let { ... }` to always-execute can't silently land
+        // null under the key.
+        assertFalse(out.containsKey("attributes"))
+        assertFalse(out.containsKey("traceId"))
+        assertFalse(out.containsKey("spanId"))
+        assertFalse(out.containsKey("flags"))
+    }
+
+    @Test
+    fun `buildLogRecord auto-attaches each context field independently`() {
+        // Per-field positive coverage: every record field that auto-attaches
+        // to attrs must show up exactly when set and be absent when null.
+        // The collision-rules test below covers user-attr-wins-on-conflict.
+        val record =
+            PostHogLogRecord(
+                body = "ctx",
+                distinctId = "did-1",
+                sessionId = "sess-1",
+                screenName = "Home",
+                appState = "foreground",
+                featureFlagKeys = listOf("flag-a"),
+                timeUnixNano = "1",
+                observedTimeUnixNano = "1",
+            )
+        val out = PostHogLogsOTLP.buildLogRecord(record)
+
+        @Suppress("UNCHECKED_CAST")
+        val attrs = (out["attributes"] as List<Map<String, Any>>).associateBy { it["key"] as String }
+
+        assertEquals(mapOf("stringValue" to "did-1"), attrs["posthogDistinctId"]?.get("value"))
+        assertEquals(mapOf("stringValue" to "sess-1"), attrs["sessionId"]?.get("value"))
+        assertEquals(mapOf("stringValue" to "Home"), attrs["screen.name"]?.get("value"))
+        assertEquals(mapOf("stringValue" to "foreground"), attrs["app.state"]?.get("value"))
+        assertTrue(attrs.containsKey("feature_flags"))
+    }
+
+    @Test
+    fun `buildLogRecord omits context attribute keys when source fields are null or empty`() {
+        // Negative coverage for each auto-attach: with no record context,
+        // the corresponding attrs entries must not be present (not just absent
+        // in value — actually absent from the KeyValue list).
+        val record =
+            PostHogLogRecord(
+                body = "bare",
+                featureFlagKeys = emptyList(),
+                timeUnixNano = "1",
+                observedTimeUnixNano = "1",
+            )
+        val out = PostHogLogsOTLP.buildLogRecord(record)
+
+        // With every auto-attach source null/empty and no user attributes,
+        // attrs should be omitted entirely.
+        assertFalse(out.containsKey("attributes"))
+    }
+
+    @Test
+    fun `user attributes win on collision for every auto-attached key`() {
+        // Every auto-attached key must lose to a user-supplied attribute of the
+        // same name. A previous version of this test only exercised the
+        // posthogDistinctId collision; a refactor that moved the user merge
+        // above only one of the per-field ?.let blocks would have slipped through.
+        listOf("posthogDistinctId", "sessionId", "screen.name", "app.state", "feature_flags").forEach { key ->
+            val record =
+                PostHogLogRecord(
+                    body = "x",
+                    attributes = mapOf(key to "user-wins"),
+                    distinctId = "auto",
+                    sessionId = "auto",
+                    screenName = "auto",
+                    appState = "auto",
+                    featureFlagKeys = listOf("auto"),
+                    timeUnixNano = "1",
+                    observedTimeUnixNano = "1",
+                )
+            val out = PostHogLogsOTLP.buildLogRecord(record)
+
+            @Suppress("UNCHECKED_CAST")
+            val attrs = (out["attributes"] as List<Map<String, Any>>).associateBy { it["key"] as String }
+            assertEquals(
+                mapOf("stringValue" to "user-wins"),
+                attrs[key]?.get("value"),
+                "user-supplied $key should win on collision",
+            )
+        }
+    }
+
+    @Test
+    fun `buildLogRecord emits traceId spanId and flags when present`() {
+        val record =
+            PostHogLogRecord(
+                body = "trace",
+                traceId = "abc",
+                spanId = "def",
+                traceFlags = 1,
+                timeUnixNano = "1",
+                observedTimeUnixNano = "1",
+            )
+        val out = PostHogLogsOTLP.buildLogRecord(record)
+        assertEquals("abc", out["traceId"])
+        assertEquals("def", out["spanId"])
+        assertEquals(1, out["flags"])
+    }
+
+    @Test
+    fun `toAnyValue catches non-Long Number subclasses via intValue`() {
+        // The `is Number` catch-all is reached by Number subtypes that aren't
+        // Long/Int/Short/Byte (e.g. BigInteger, AtomicInteger).
+        assertEquals(
+            mapOf("intValue" to "98765"),
+            PostHogLogsOTLP.toAnyValue(BigInteger("98765")),
+        )
+    }
+
+    @Test
+    fun `toAnyValue Map drops non-String keys and null values`() {
+        val mixed: Map<Any?, Any?> =
+            mapOf(
+                "good" to "yes",
+                42 to "non-string-key-dropped",
+                "nullValue" to null,
+            )
+        val result = PostHogLogsOTLP.toAnyValue(mixed)
+
+        @Suppress("UNCHECKED_CAST")
+        val values = ((result?.get("kvlistValue") as Map<String, Any>)["values"] as List<Map<String, Any>>)
+        val keys = values.map { it["key"] as String }
+        assertEquals(listOf("good"), keys)
+    }
+
+    @Test
+    fun `buildResourceAttributes adds telemetry sdk keys overriding user values`() {
+        val merged =
+            PostHogLogsOTLP.buildResourceAttributes(
+                userResourceAttributes =
+                    mapOf(
+                        "service.name" to "my-app",
+                        "telemetry.sdk.name" to "user-tried-to-shadow",
+                    ),
+                sdkName = "posthog-android",
+                sdkVersion = "1.2.3",
+            )
+        assertEquals("my-app", merged["service.name"])
+        assertEquals("posthog-android", merged["telemetry.sdk.name"])
+        assertEquals("1.2.3", merged["telemetry.sdk.version"])
+    }
+
+    @Test
+    fun `buildPayload nests resourceLogs scopeLogs logRecords`() {
+        val record = PostHogLogRecord(body = "p", timeUnixNano = "1", observedTimeUnixNano = "1")
+        val payload =
+            PostHogLogsOTLP.buildPayload(
+                records = listOf(record),
+                resourceAttributes = mapOf("service.name" to "app"),
+                sdkName = "posthog-android",
+                sdkVersion = "1.0",
+            )
+
+        @Suppress("UNCHECKED_CAST")
+        val resourceLogs = payload["resourceLogs"] as List<Map<String, Any>>
+        assertEquals(1, resourceLogs.size)
+
+        @Suppress("UNCHECKED_CAST")
+        val resourceAttrs = (resourceLogs[0]["resource"] as Map<String, Any>)["attributes"] as List<Map<String, Any>>
+        val attrKeys = resourceAttrs.map { it["key"] as String }
+        // Sorted, including telemetry.sdk.* layered on top.
+        assertTrue(attrKeys.contains("service.name"))
+        assertTrue(attrKeys.contains("telemetry.sdk.name"))
+        assertTrue(attrKeys.contains("telemetry.sdk.version"))
+        // alphabetical
+        assertEquals(attrKeys.sorted(), attrKeys)
+
+        @Suppress("UNCHECKED_CAST")
+        val scopeLogs = resourceLogs[0]["scopeLogs"] as List<Map<String, Any>>
+        val scope = scopeLogs[0]["scope"] as Map<*, *>
+        assertEquals("posthog-android", scope["name"])
+        assertEquals("1.0", scope["version"])
+
+        @Suppress("UNCHECKED_CAST")
+        val logRecords = scopeLogs[0]["logRecords"] as List<Map<String, Any>>
+        assertEquals(1, logRecords.size)
+        assertEquals(mapOf("stringValue" to "p"), logRecords[0]["body"])
+    }
+
+    @Test
+    fun `buildPayload groups multiple records under one resource and scope envelope`() {
+        // Architectural invariant: all records in a batch share a single
+        // resourceLogs[] entry and a single scopeLogs[] entry. A regression
+        // that emitted one resourceLogs per record (or duplicated the resource
+        // block per record) would still pass every single-record test.
+        val records =
+            listOf(
+                PostHogLogRecord(body = "one", timeUnixNano = "1", observedTimeUnixNano = "1"),
+                PostHogLogRecord(body = "two", timeUnixNano = "2", observedTimeUnixNano = "2"),
+                PostHogLogRecord(body = "three", timeUnixNano = "3", observedTimeUnixNano = "3"),
+            )
+        val payload =
+            PostHogLogsOTLP.buildPayload(records, emptyMap(), "posthog-android", "1.0")
+
+        @Suppress("UNCHECKED_CAST")
+        val resourceLogs = payload["resourceLogs"] as List<Map<String, Any>>
+        assertEquals(1, resourceLogs.size)
+
+        @Suppress("UNCHECKED_CAST")
+        val scopeLogs = resourceLogs[0]["scopeLogs"] as List<Map<String, Any>>
+        assertEquals(1, scopeLogs.size)
+
+        @Suppress("UNCHECKED_CAST")
+        val logRecords = scopeLogs[0]["logRecords"] as List<Map<String, Any>>
+        assertEquals(3, logRecords.size)
+        assertEquals(
+            listOf("one", "two", "three"),
+            logRecords.map { (it["body"] as Map<*, *>)["stringValue"] as String },
+        )
+    }
+}

--- a/posthog/src/test/java/com/posthog/logs/PostHogLogRecordTest.kt
+++ b/posthog/src/test/java/com/posthog/logs/PostHogLogRecordTest.kt
@@ -1,0 +1,180 @@
+package com.posthog.logs
+
+import com.posthog.API_KEY
+import com.posthog.PostHogConfig
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class PostHogLogRecordTest {
+    @Test
+    fun `timeUnixNano defaults to current time and observedTimeUnixNano mirrors it`() {
+        val before = System.currentTimeMillis() * 1_000_000L
+        val record = PostHogLogRecord(body = "hello")
+        val after = System.currentTimeMillis() * 1_000_000L
+
+        val time = record.timeUnixNano.toLong()
+        assertTrue(time in before..after, "timeUnixNano ($time) not in [$before, $after]")
+        assertEquals(record.timeUnixNano, record.observedTimeUnixNano)
+    }
+
+    @Test
+    fun `storage round-trip preserves all fields`() {
+        val original =
+            PostHogLogRecord(
+                body = "round-trip me",
+                level = PostHogLogSeverity.WARN,
+                attributes = mapOf("k" to "v", "n" to 42),
+                traceId = "0102030405060708090a0b0c0d0e0f10",
+                spanId = "0102030405060708",
+                traceFlags = 1,
+                distinctId = "user-1",
+                sessionId = "sess-1",
+                screenName = "Home",
+                featureFlagKeys = listOf("flag-a", "flag-b"),
+                appState = "foreground",
+                timeUnixNano = "1700000000000000000",
+                observedTimeUnixNano = "1700000000000000001",
+            )
+
+        val map = original.toStorageMap()
+        val restored = PostHogLogRecord.fromStorageMap(map)
+
+        assertNotNull(restored)
+        assertEquals(original.body, restored.body)
+        assertEquals(original.level, restored.level)
+        assertEquals(original.attributes, restored.attributes)
+        assertEquals(original.traceId, restored.traceId)
+        assertEquals(original.spanId, restored.spanId)
+        assertEquals(original.traceFlags, restored.traceFlags)
+        assertEquals(original.distinctId, restored.distinctId)
+        assertEquals(original.sessionId, restored.sessionId)
+        assertEquals(original.screenName, restored.screenName)
+        assertEquals(original.featureFlagKeys, restored.featureFlagKeys)
+        assertEquals(original.appState, restored.appState)
+        assertEquals(original.timeUnixNano, restored.timeUnixNano)
+        assertEquals(original.observedTimeUnixNano, restored.observedTimeUnixNano)
+    }
+
+    @Test
+    fun `storage round-trip through serializer preserves wire-relevant fields`() {
+        // Goes through the actual production codec: toStorageMap -> Gson serialize ->
+        // file bytes -> Gson deserialize -> fromStorageMap. Catches type-erasure
+        // surprises (e.g. Gson's Int->Double widening on Map<String, Any> values).
+        val config = PostHogConfig(API_KEY)
+        val original =
+            PostHogLogRecord(
+                body = "round-trip",
+                level = PostHogLogSeverity.WARN,
+                attributes = mapOf("k" to "v", "n" to 42),
+                traceFlags = 1,
+                featureFlagKeys = listOf("a"),
+            )
+        val buf = ByteArrayOutputStream()
+        config.serializer.serialize(original.toStorageMap(), buf.writer().buffered())
+        val map: Map<String, Any> =
+            config.serializer.deserialize(
+                ByteArrayInputStream(buf.toByteArray()).reader().buffered(),
+            )!!
+        val restored = PostHogLogRecord.fromStorageMap(map)!!
+        assertEquals("round-trip", restored.body)
+        assertEquals(PostHogLogSeverity.WARN, restored.level)
+        assertEquals(1, restored.traceFlags) // proves Number -> Int coercion holds
+        assertEquals(listOf("a"), restored.featureFlagKeys)
+    }
+
+    @Test
+    fun `storage map omits null optionals`() {
+        val record = PostHogLogRecord(body = "minimal")
+        val map = record.toStorageMap()
+        // Assert key absence, not just null value — a mutated `?.let { map[k] = it }`
+        // could put null under the key and `assertNull(map[k])` would still pass.
+        assertFalse(map.containsKey("traceId"))
+        assertFalse(map.containsKey("spanId"))
+        assertFalse(map.containsKey("traceFlags"))
+        assertFalse(map.containsKey("distinctId"))
+        assertFalse(map.containsKey("sessionId"))
+        assertFalse(map.containsKey("screenName"))
+        assertFalse(map.containsKey("appState"))
+        assertFalse(map.containsKey("attributes")) // empty attributes are omitted
+    }
+
+    @Test
+    fun `storage map includes every optional when set`() {
+        val record =
+            PostHogLogRecord(
+                body = "set everything",
+                attributes = mapOf("k" to "v"),
+                traceId = "tid",
+                spanId = "sid",
+                traceFlags = 1,
+                distinctId = "did",
+                sessionId = "sess",
+                screenName = "Home",
+                appState = "foreground",
+            )
+        val map = record.toStorageMap()
+        assertEquals("tid", map["traceId"])
+        assertEquals("sid", map["spanId"])
+        assertEquals(1, map["traceFlags"])
+        assertEquals("did", map["distinctId"])
+        assertEquals("sess", map["sessionId"])
+        assertEquals("Home", map["screenName"])
+        assertEquals("foreground", map["appState"])
+        assertEquals(mapOf("k" to "v"), map["attributes"])
+    }
+
+    @Test
+    fun `fromStorageMap ignores wrong-typed optional fields`() {
+        // Wrong type at an optional key is treated as absent, not a crash.
+        // Locks in the `as?` fallback path on each optional.
+        val map =
+            mapOf<String, Any>(
+                "body" to "x",
+                "attributes" to "not-a-map",
+                "featureFlagKeys" to "not-a-list",
+                "traceId" to 123,
+                "spanId" to 456,
+                "distinctId" to true,
+                "sessionId" to listOf("nope"),
+                "screenName" to mapOf("a" to "b"),
+                "appState" to 99,
+            )
+        val record = PostHogLogRecord.fromStorageMap(map)
+        assertNotNull(record)
+        assertEquals(emptyMap<String, Any>(), record.attributes)
+        assertEquals(emptyList<String>(), record.featureFlagKeys)
+        assertNull(record.traceId)
+        assertNull(record.spanId)
+        assertNull(record.distinctId)
+        assertNull(record.sessionId)
+        assertNull(record.screenName)
+        assertNull(record.appState)
+    }
+
+    @Test
+    fun `fromStorageMap defaults level to INFO when unknown`() {
+        val map = mapOf<String, Any>("body" to "x", "level" to "verbose")
+        val record = PostHogLogRecord.fromStorageMap(map)
+        assertNotNull(record)
+        assertEquals(PostHogLogSeverity.INFO, record.level)
+    }
+
+    @Test
+    fun `fromStorageMap returns null without body`() {
+        assertNull(PostHogLogRecord.fromStorageMap(mapOf("level" to "info")))
+    }
+
+    @Test
+    fun `fromStorageMap accepts numeric traceFlags`() {
+        val map = mapOf<String, Any>("body" to "x", "traceFlags" to 1.0)
+        val record = PostHogLogRecord.fromStorageMap(map)
+        assertNotNull(record)
+        assertEquals(1, record.traceFlags)
+    }
+}

--- a/posthog/src/test/java/com/posthog/logs/PostHogLogSeverityTest.kt
+++ b/posthog/src/test/java/com/posthog/logs/PostHogLogSeverityTest.kt
@@ -1,0 +1,46 @@
+package com.posthog.logs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class PostHogLogSeverityTest {
+    @Test
+    fun `severity numbers match OTLP spec`() {
+        assertEquals(1, PostHogLogSeverity.TRACE.severityNumber)
+        assertEquals(5, PostHogLogSeverity.DEBUG.severityNumber)
+        assertEquals(9, PostHogLogSeverity.INFO.severityNumber)
+        assertEquals(13, PostHogLogSeverity.WARN.severityNumber)
+        assertEquals(17, PostHogLogSeverity.ERROR.severityNumber)
+        assertEquals(21, PostHogLogSeverity.FATAL.severityNumber)
+    }
+
+    @Test
+    fun `severity text is the lowercased OTLP name`() {
+        assertEquals("trace", PostHogLogSeverity.TRACE.severityText)
+        assertEquals("debug", PostHogLogSeverity.DEBUG.severityText)
+        assertEquals("info", PostHogLogSeverity.INFO.severityText)
+        assertEquals("warn", PostHogLogSeverity.WARN.severityText)
+        assertEquals("error", PostHogLogSeverity.ERROR.severityText)
+        assertEquals("fatal", PostHogLogSeverity.FATAL.severityText)
+    }
+
+    @Test
+    fun `from tolerates whitespace and casing for every severity`() {
+        // Iterate so a future severity addition picks up coverage automatically.
+        // A regression that swapped `firstOrNull { it.severityText == normalized }`
+        // for a case-sensitive valueOf-style lookup would only fail one or two
+        // entries here unless every case is checked.
+        PostHogLogSeverity.entries.forEach { severity ->
+            assertEquals(severity, PostHogLogSeverity.from(severity.severityText))
+            assertEquals(severity, PostHogLogSeverity.from(severity.severityText.uppercase()))
+            assertEquals(severity, PostHogLogSeverity.from("  ${severity.severityText}\n"))
+        }
+    }
+
+    @Test
+    fun `from returns null for unknown name`() {
+        assertNull(PostHogLogSeverity.from("verbose"))
+        assertNull(PostHogLogSeverity.from(""))
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

Sets up the internal plumbing for the upcoming logs feature so that the
public-facing PR (next) is purely additive on top of a proven wire path.

Adds:

- `PostHogLogRecord` and `PostHogLogSeverity` (both `internal`)
- OTLP/JSON payload builder (`PostHogLogsOTLP`)
- `PostHogApi.sendLogs(...)` — POSTs to `/i/v1/logs?token=<apiKey>`
- `EndpointSpec.logs(...)` factory — wires a third `PostHogQueue` into
  `PostHog.setup` alongside events and replay

**No public `log()` API in this PR** — that lands in the follow-up,
along with `PostHogLogsConfig` (service.name / environment / beforeSend
hook), capture-time context snapshot (distinctId / sessionId / screen
name), and screen-name tracking via `Application.ActivityLifecycleCallbacks`.
That follow-up will carry the changeset and the version bump; this PR
ships zero runtime behavior change.

The logs queue is constructed but **not started** in `setup()` — nothing
can enqueue records yet, so spinning up the periodic flush timer would
waste a daemon thread. A one-line `// logsQueue.start()` marker sits in
`PostHog.setup` where it'll be uncommented when the public capture API
ships.

Worth noting for review:

- Retry policy for `/i/v1/logs` is narrower than `/batch` /
  `/snapshot`: 408, 429, and 5xx only. 3xx redirects aren't retried
  (would loop on a misconfigured host). Regression-guarded so events
  don't accidentally inherit the broader set.
- Wire format follows OTLP `LogsService` JSON
  (`resourceLogs[].scopeLogs[].logRecords[]`). Multi-record batches
  share a single resource + scope envelope, locked in by test.
- ABI delta: one synthetic constructor parameter on `private PostHog(...)`
  (unreachable from outside the class) plus two `@PostHogInternal`
  accessors for `logsStoragePrefix`. No public surface change.

## :green_heart: How did you test it?

- `./gradlew :posthog:test` — OTLP shape, storage round-trip (both
  direct and through `config.serializer`), retry policy, multi-record
  batching, `sendLogs` 408 / 500, per-key collision rules,
  parameterized severity coverage
- `./gradlew :posthog-android:testDebugUnitTest`
- `./gradlew :posthog:apiCheck` — confirms ABI is additive
- `./gradlew spotlessCheck detekt`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
