### PR TITLE
fix(server): reject leading-zero semver values in local evaluation

### DIFF
--- a/.changeset/strict-semver-leading-zeros.md
+++ b/.changeset/strict-semver-leading-zeros.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Reject semver values with leading zeros in local flag evaluation. Per semver 2.0.0 §2, numeric identifiers must not include leading zeros — values like `1.07.3` are not valid semver and should not match targeting conditions. Both override values and flag values are now validated; invalid inputs raise `InconclusiveMatchException` so the condition does not match.

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -506,11 +506,28 @@ internal class FlagEvaluator(
             REGEX_SEMVER.matchEntire(cleaned)
                 ?: throw InconclusiveMatchException("Invalid semver version: '$version'")
 
-        val major = match.groupValues[1].toInt()
-        val minor = match.groupValues[2].takeIf { it.isNotEmpty() }?.toInt() ?: 0
-        val patch = match.groupValues[3].takeIf { it.isNotEmpty() }?.toInt() ?: 0
+        val major =
+            parseSemverNumericIdentifier(match.groupValues[1])
+                ?: throw InconclusiveMatchException("Invalid semver version: '$version'")
+        val minor =
+            match.groupValues[2].takeIf { it.isNotEmpty() }?.let {
+                parseSemverNumericIdentifier(it)
+                    ?: throw InconclusiveMatchException("Invalid semver version: '$version'")
+            } ?: 0
+        val patch =
+            match.groupValues[3].takeIf { it.isNotEmpty() }?.let {
+                parseSemverNumericIdentifier(it)
+                    ?: throw InconclusiveMatchException("Invalid semver version: '$version'")
+            } ?: 0
 
         return SemverVersion(major, minor, patch)
+    }
+
+    // Semver 2.0.0 §2: numeric identifiers MUST NOT include leading zeros.
+    private fun parseSemverNumericIdentifier(part: String): Int? {
+        if (part.isEmpty() || !part.all { it.isDigit() }) return null
+        if (part.length > 1 && part[0] == '0') return null
+        return part.toIntOrNull()
     }
 
     /**
@@ -559,7 +576,12 @@ internal class FlagEvaluator(
             }
 
             PropertyOperator.SEMVER_WILDCARD -> {
-                val (lower, upper) = computeWildcardBounds(propertyString)
+                val (lower, upper) =
+                    try {
+                        computeWildcardBounds(propertyString)
+                    } catch (e: InconclusiveMatchException) {
+                        throw InconclusiveMatchException("The flag condition value is not a valid semver: ${e.message}")
+                    }
                 overrideVersion >= lower && overrideVersion < upper
             }
 
@@ -655,7 +677,7 @@ internal class FlagEvaluator(
         for (part in parts) {
             if (part.isEmpty()) continue
             val num =
-                part.toIntOrNull()
+                parseSemverNumericIdentifier(part)
                     ?: throw InconclusiveMatchException("Invalid wildcard version: '$propertyValue'")
             components.add(num)
         }

--- a/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
@@ -2309,8 +2309,8 @@ internal class FlagEvaluatorTest {
     }
 
     @Test
-    internal fun testSemverLeadingZeros() {
-        // "01.02.03" should parse as (1, 2, 3)
+    internal fun testSemverLeadingZerosRejected() {
+        // Semver 2.0.0 §2: numeric identifiers MUST NOT include leading zeros.
         val property =
             FlagProperty(
                 key = "version",
@@ -2321,8 +2321,111 @@ internal class FlagEvaluatorTest {
                 dependencyChain = null,
             )
 
-        assertTrue(evaluator.matchProperty(property, mapOf("version" to "01.02.03")))
-        assertTrue(evaluator.matchProperty(property, mapOf("version" to "001.002.003")))
+        val invalidOverrides =
+            listOf("01.2.3", "1.02.3", "1.2.03", "1.07.3", "001.2.3", "01.02.03", "001.002.003")
+        for (override in invalidOverrides) {
+            try {
+                evaluator.matchProperty(property, mapOf("version" to override))
+                assertTrue("Expected InconclusiveMatchException for '$override'", false)
+            } catch (e: InconclusiveMatchException) {
+                assertTrue(e.message?.contains("not a valid semver") ?: false)
+            }
+        }
+    }
+
+    @Test
+    internal fun testSemverLiteralZeroComponentsAllowed() {
+        // A single "0" is a valid numeric identifier; only multi-digit leading zeros are rejected.
+        val property =
+            FlagProperty(
+                key = "version",
+                propertyValue = "0.1.0",
+                propertyOperator = PropertyOperator.SEMVER_EQ,
+                type = PropertyType.PERSON,
+                negation = false,
+                dependencyChain = null,
+            )
+        assertTrue(evaluator.matchProperty(property, mapOf("version" to "0.1.0")))
+
+        val zeroZeroZero =
+            FlagProperty(
+                key = "version",
+                propertyValue = "0.0.0",
+                propertyOperator = PropertyOperator.SEMVER_EQ,
+                type = PropertyType.PERSON,
+                negation = false,
+                dependencyChain = null,
+            )
+        assertTrue(evaluator.matchProperty(zeroZeroZero, mapOf("version" to "0.0.0")))
+
+        val oneZeroZero =
+            FlagProperty(
+                key = "version",
+                propertyValue = "1.0.0",
+                propertyOperator = PropertyOperator.SEMVER_EQ,
+                type = PropertyType.PERSON,
+                negation = false,
+                dependencyChain = null,
+            )
+        assertTrue(evaluator.matchProperty(oneZeroZero, mapOf("version" to "1.0.0")))
+    }
+
+    @Test
+    internal fun testSemverLeadingZerosRejectedAcrossOperators() {
+        // Leading zeros must be rejected in flag condition values as well as override values,
+        // and for every semver operator (gt, caret, tilde, wildcard).
+        val operatorsWithFlagValue =
+            listOf(
+                PropertyOperator.SEMVER_GT to "1.07.0",
+                PropertyOperator.SEMVER_CARET to "01.2.3",
+                PropertyOperator.SEMVER_TILDE to "1.02.3",
+                PropertyOperator.SEMVER_WILDCARD to "01.*",
+            )
+
+        for ((op, badConditionValue) in operatorsWithFlagValue) {
+            val property =
+                FlagProperty(
+                    key = "version",
+                    propertyValue = badConditionValue,
+                    propertyOperator = op,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            try {
+                evaluator.matchProperty(property, mapOf("version" to "1.2.3"))
+                assertTrue("Expected InconclusiveMatchException for operator $op with '$badConditionValue'", false)
+            } catch (e: InconclusiveMatchException) {
+                assertTrue(e.message?.contains("not a valid semver") ?: false)
+            }
+        }
+
+        // Override values with leading zeros must also be rejected across operators.
+        val operatorsWithGoodConditionValue =
+            listOf(
+                PropertyOperator.SEMVER_GT to "1.0.0",
+                PropertyOperator.SEMVER_CARET to "1.2.3",
+                PropertyOperator.SEMVER_TILDE to "1.2.3",
+                PropertyOperator.SEMVER_WILDCARD to "1.*",
+            )
+
+        for ((op, conditionValue) in operatorsWithGoodConditionValue) {
+            val property =
+                FlagProperty(
+                    key = "version",
+                    propertyValue = conditionValue,
+                    propertyOperator = op,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            try {
+                evaluator.matchProperty(property, mapOf("version" to "1.07.3"))
+                assertTrue("Expected InconclusiveMatchException for operator $op with override '1.07.3'", false)
+            } catch (e: InconclusiveMatchException) {
+                assertTrue(e.message?.contains("not a valid semver") ?: false)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Per [semver 2.0.0 §2](https://semver.org/#spec-item-2), numeric identifiers MUST NOT include leading zeros. Values like `1.07.3` or `01.2.3` are not valid semver — `FlagEvaluator.parseSemver` in `posthog-server` currently parses them silently (the regex matches `\d+` and `String.toInt()` strips leading zeros), which means a person property of `1.07.3` would incorrectly match a `semver_eq` condition against `1.7.3`.

This PR makes the parser reject leading zeros in numeric identifiers. Both override values and flag values are validated; invalid inputs raise `InconclusiveMatchException` so the condition simply does not match.

## Changes

- `parseSemver` now uses a `parseSemverNumericIdentifier` helper that rejects strings with leading zeros (except literal `"0"`).
- `computeWildcardBounds` uses the same helper, so `01.*` and `1.07.*` are rejected.
- The `SEMVER_WILDCARD` branch in `compareSemver` wraps `computeWildcardBounds` so its error is reported with the same `"not a valid semver"` phrasing as the other operators.
- Updated the existing edge-case test that previously asserted `01.02.03` matched `1.2.3` — it now correctly rejects.
- Added a comprehensive test covering rejection across `eq`/`gt`/`caret`/`tilde`/`wildcard` for both override values and flag values, plus a positive test ensuring literal `0` components (e.g. `0.1.0`, `0.0.0`, `1.0.0`) continue to work.

Sibling fixes: posthog-python PR #601, posthog-go PR #200.

## Test plan

- [x] `./gradlew :posthog-server:test` — all tests pass
- [x] `./gradlew spotlessCheck` clean
- [x] `./gradlew detekt` clean
- [x] `./gradlew :posthog-server:apiCheck` clean