### PR TITLE
feat(server): Add request context support

### DIFF
--- a/.changeset/request-context-server.md
+++ b/.changeset/request-context-server.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": minor
+---
+
+Add request-scoped context support for server-side captures, including PostHog tracing headers, session metadata, personless fallback events, and context-aware exception capture.

--- a/posthog-server/USAGE.md
+++ b/posthog-server/USAGE.md
@@ -208,6 +208,69 @@ postHog.capture(
 
 When `appendFeatureFlags` is `true`, the SDK will fetch feature flags for the user (or use locally evaluated flags if local evaluation is enabled) and include them in the event properties.
 
+### Frontend-to-backend request context
+
+If your server handles requests from a frontend that sends PostHog tracing headers, wrap request handling in a request context. Captures inside the scope can omit `distinctId`; the SDK uses the context distinct ID, falls back to a generated personless UUID when missing, and adds `$session_id` plus any request metadata unless explicitly overridden.
+
+#### Kotlin
+
+```kotlin
+val context = PostHogRequestContext.fromHeaders(
+    headers = mapOf(
+        "X-PostHog-Distinct-Id" to requestDistinctIdHeader,
+        "X-PostHog-Session-Id" to requestSessionIdHeader,
+    ),
+    properties = mapOf(
+        "\$current_url" to currentUrlWithoutSecrets,
+        "\$request_method" to method,
+        "\$request_path" to path,
+        "\$user_agent" to userAgent,
+        "\$ip" to clientIp,
+    ),
+)
+
+PostHogRequestContext.beginScope(context, fresh = true).use {
+    postHog.capture("backend_event")
+    postHog.captureException(error)
+
+    // Uses context distinctId when omitted
+    val flags = postHog.evaluateFlags()
+
+    // Same, with request-scoped options
+    val scopedFlags = postHog.evaluateFlags(
+        PostHogEvaluateFlagsOptions.builder()
+            .flagKeys(listOf("new-checkout"))
+            .build()
+    )
+}
+```
+
+#### Java
+
+```java
+Map<String, Object> properties = new HashMap<>();
+properties.put("$request_path", path);
+properties.put("$request_method", method);
+
+PostHogRequestContextData context = PostHogRequestContext.fromHeaders(headers, true, properties);
+try (PostHogRequestContext.Scope ignored = PostHogRequestContext.beginScope(context, true)) {
+    postHog.capture("backend_event");
+    postHog.captureException(error);
+
+    // Uses context distinctId when omitted
+    PostHogFeatureFlagEvaluations flags = postHog.evaluateFlags();
+
+    // Same, with request-scoped options
+    PostHogFeatureFlagEvaluations scopedFlags = postHog.evaluateFlags(
+        PostHogEvaluateFlagsOptions.builder()
+            .flagKeys(Arrays.asList("new-checkout"))
+            .build()
+    );
+}
+```
+
+Use `PostHogRequestContext.fromHeaders(headers, false, properties)` to ignore client-supplied tracing headers while still attaching request metadata. Explicit `distinctId` and explicit `$session_id` values passed to `capture` always override request context. Header values are trimmed, control characters are removed, empty values are ignored, and long values are capped.
+
 ### Single-Call Flag Evaluation: `evaluateFlags()`
 
 When you need to read several flags for the same user, call `evaluateFlags()` once and pass the resulting snapshot around. The snapshot answers `isEnabled` / `getFlag` / `getFlagPayload` from memory, dedups `$feature_flag_called` events per flag, and can be attached to a `capture()` call so the event is enriched without making another `/flags` request.

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -2,15 +2,20 @@ public final class com/posthog/server/PostHog : com/posthog/PostHogStateless, co
 	public static final field Companion Lcom/posthog/server/PostHog$Companion;
 	public fun <init> ()V
 	public fun alias (Ljava/lang/String;Ljava/lang/String;)V
+	public fun capture (Ljava/lang/String;)V
+	public fun capture (Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
 	public fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;)V
+	public synthetic fun capture (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;)V
 	public fun captureException (Ljava/lang/Throwable;)V
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/String;)V
 	public fun captureException (Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;)V
 	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)V
 	public fun close ()V
 	public fun debug (Z)V
+	public fun evaluateFlags ()Lcom/posthog/server/PostHogFeatureFlagEvaluations;
+	public fun evaluateFlags (Lcom/posthog/server/PostHogEvaluateFlagsOptions;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public fun evaluateFlags (Ljava/lang/String;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public fun evaluateFlags (Ljava/lang/String;Lcom/posthog/server/PostHogEvaluateFlagsOptions;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public fun evaluateFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;ZZ)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
@@ -313,15 +318,20 @@ public final class com/posthog/server/PostHogFeatureFlagResultOptions$Companion 
 
 public abstract interface class com/posthog/server/PostHogInterface {
 	public abstract fun alias (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun capture (Ljava/lang/String;)V
+	public abstract fun capture (Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
 	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun capture (Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
 	public abstract synthetic fun capture (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;)V
+	public abstract synthetic fun capture (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;)V
 	public abstract fun captureException (Ljava/lang/Throwable;)V
 	public abstract fun captureException (Ljava/lang/Throwable;Ljava/lang/String;)V
 	public abstract fun captureException (Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun close ()V
 	public abstract fun debug (Z)V
+	public abstract fun evaluateFlags ()Lcom/posthog/server/PostHogFeatureFlagEvaluations;
+	public abstract fun evaluateFlags (Lcom/posthog/server/PostHogEvaluateFlagsOptions;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public abstract fun evaluateFlags (Ljava/lang/String;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public abstract fun evaluateFlags (Ljava/lang/String;Lcom/posthog/server/PostHogEvaluateFlagsOptions;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public abstract synthetic fun evaluateFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;ZZ)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
@@ -351,13 +361,19 @@ public abstract interface class com/posthog/server/PostHogInterface {
 }
 
 public final class com/posthog/server/PostHogInterface$DefaultImpls {
+	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;)V
+	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
 	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogCaptureOptions;)V
+	public static synthetic fun capture (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;)V
 	public static synthetic fun capture$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;ILjava/lang/Object;)V
+	public static synthetic fun capture$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;ILjava/lang/Object;)V
 	public static fun captureException (Lcom/posthog/server/PostHogInterface;Ljava/lang/Throwable;)V
 	public static fun captureException (Lcom/posthog/server/PostHogInterface;Ljava/lang/Throwable;Ljava/lang/String;)V
 	public static fun captureException (Lcom/posthog/server/PostHogInterface;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public static synthetic fun captureException$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static fun evaluateFlags (Lcom/posthog/server/PostHogInterface;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
+	public static fun evaluateFlags (Lcom/posthog/server/PostHogInterface;Lcom/posthog/server/PostHogEvaluateFlagsOptions;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public static fun evaluateFlags (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public static fun evaluateFlags (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Lcom/posthog/server/PostHogEvaluateFlagsOptions;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
 	public static synthetic fun evaluateFlags$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/List;ZZILjava/lang/Object;)Lcom/posthog/server/PostHogFeatureFlagEvaluations;
@@ -380,5 +396,42 @@ public final class com/posthog/server/PostHogInterface$DefaultImpls {
 	public static fun isFeatureEnabled (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Lcom/posthog/server/PostHogFeatureFlagOptions;)Z
 	public static fun isFeatureEnabled (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;Z)Z
 	public static synthetic fun isFeatureEnabled$default (Lcom/posthog/server/PostHogInterface;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Z
+}
+
+public final class com/posthog/server/PostHogRequestContext {
+	public static final field Companion Lcom/posthog/server/PostHogRequestContext$Companion;
+	public static final field DISTINCT_ID_HEADER Ljava/lang/String;
+	public static final field SESSION_ID_HEADER Ljava/lang/String;
+	public static final fun beginScope (Lcom/posthog/server/PostHogRequestContextData;)Lcom/posthog/server/PostHogRequestContext$Scope;
+	public static final fun beginScope (Lcom/posthog/server/PostHogRequestContextData;Z)Lcom/posthog/server/PostHogRequestContext$Scope;
+	public static final fun current ()Lcom/posthog/server/PostHogRequestContextData;
+	public static final fun fromHeaders (Ljava/util/Map;)Lcom/posthog/server/PostHogRequestContextData;
+	public static final fun fromHeaders (Ljava/util/Map;Z)Lcom/posthog/server/PostHogRequestContextData;
+	public static final fun fromHeaders (Ljava/util/Map;ZLjava/util/Map;)Lcom/posthog/server/PostHogRequestContextData;
+}
+
+public final class com/posthog/server/PostHogRequestContext$Companion {
+	public final fun beginScope (Lcom/posthog/server/PostHogRequestContextData;)Lcom/posthog/server/PostHogRequestContext$Scope;
+	public final fun beginScope (Lcom/posthog/server/PostHogRequestContextData;Z)Lcom/posthog/server/PostHogRequestContext$Scope;
+	public final fun current ()Lcom/posthog/server/PostHogRequestContextData;
+	public final fun fromHeaders (Ljava/util/Map;)Lcom/posthog/server/PostHogRequestContextData;
+	public final fun fromHeaders (Ljava/util/Map;Z)Lcom/posthog/server/PostHogRequestContextData;
+	public final fun fromHeaders (Ljava/util/Map;ZLjava/util/Map;)Lcom/posthog/server/PostHogRequestContextData;
+	public static synthetic fun fromHeaders$default (Lcom/posthog/server/PostHogRequestContext$Companion;Ljava/util/Map;ZLjava/util/Map;ILjava/lang/Object;)Lcom/posthog/server/PostHogRequestContextData;
+	public final fun withContext (Lcom/posthog/server/PostHogRequestContextData;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun withContext (Lcom/posthog/server/PostHogRequestContextData;ZLkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class com/posthog/server/PostHogRequestContext$Scope : java/lang/AutoCloseable {
+	public fun close ()V
+}
+
+public final class com/posthog/server/PostHogRequestContextData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDistinctId ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getSessionId ()Ljava/lang/String;
 }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHog.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHog.kt
@@ -64,6 +64,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         appendFeatureFlags: Boolean,
         flags: PostHogFeatureFlagEvaluations?,
     ) {
+        val captureContext = PostHogRequestContext.resolveCaptureContext(distinctId, properties)
         val mergedProperties =
             when {
                 flags != null -> {
@@ -73,7 +74,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
                                 "using the supplied snapshot and skipping the redundant /flags fetch.",
                         )
                     }
-                    mergeFeatureFlagPropertiesFromSnapshot(properties, flags)
+                    mergeFeatureFlagPropertiesFromSnapshot(captureContext.properties, flags)
                 }
                 appendFeatureFlags -> {
                     getConfig<com.posthog.PostHogConfig>()?.logger?.log(
@@ -84,19 +85,19 @@ public class PostHog : PostHogStateless(), PostHogInterface {
                             "scope which flags to attach via flags.onlyAccessed() or flags.only(...).",
                     )
                     mergeFeatureFlagProperties(
-                        distinctId = distinctId,
+                        distinctId = captureContext.distinctId,
                         groups = groups,
                         userProperties = userProperties,
                         groupProperties = null,
-                        properties = properties,
+                        properties = captureContext.properties,
                     )
                 }
-                else -> properties
+                else -> captureContext.properties
             }
 
         super.captureStateless(
             event,
-            distinctId,
+            captureContext.distinctId,
             mergedProperties,
             userProperties,
             userPropertiesSetOnce,
@@ -116,8 +117,9 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         personProperties: Map<String, Any?>?,
         groupProperties: Map<String, Map<String, Any?>>?,
     ): Boolean {
+        val resolvedDistinctId = PostHogRequestContext.resolveDistinctId(distinctId) ?: distinctId
         return super.isFeatureEnabledStateless(
-            distinctId,
+            resolvedDistinctId,
             key,
             defaultValue,
             groups,
@@ -137,8 +139,9 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         personProperties: Map<String, Any?>?,
         groupProperties: Map<String, Map<String, Any?>>?,
     ): Any? {
+        val resolvedDistinctId = PostHogRequestContext.resolveDistinctId(distinctId) ?: distinctId
         return super.getFeatureFlagStateless(
-            distinctId,
+            resolvedDistinctId,
             key,
             defaultValue,
             groups,
@@ -158,8 +161,9 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         personProperties: Map<String, Any?>?,
         groupProperties: Map<String, Map<String, Any?>>?,
     ): Any? {
+        val resolvedDistinctId = PostHogRequestContext.resolveDistinctId(distinctId) ?: distinctId
         return super.getFeatureFlagPayloadStateless(
-            distinctId,
+            resolvedDistinctId,
             key,
             defaultValue,
             groups,
@@ -181,8 +185,9 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         groupProperties: Map<String, Map<String, Any?>>?,
         sendFeatureFlagEvent: Boolean?,
     ): FeatureFlagResult? {
+        val resolvedDistinctId = PostHogRequestContext.resolveDistinctId(distinctId) ?: distinctId
         return super.getFeatureFlagResultStateless(
-            distinctId,
+            resolvedDistinctId,
             key,
             groups,
             personProperties,
@@ -224,10 +229,20 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         distinctId: String?,
         properties: Map<String, Any>?,
     ) {
+        if (!enabled) {
+            super.captureExceptionStateless(
+                exception,
+                distinctId = distinctId,
+                properties = properties,
+            )
+            return
+        }
+
+        val captureContext = PostHogRequestContext.resolveCaptureContext(distinctId, properties)
         super.captureExceptionStateless(
             exception,
-            distinctId = distinctId,
-            properties = properties,
+            distinctId = captureContext.distinctId,
+            properties = captureContext.properties,
         )
     }
 
@@ -293,7 +308,8 @@ public class PostHog : PostHogStateless(), PostHogInterface {
         onlyEvaluateLocally: Boolean,
         disableGeoip: Boolean,
     ): PostHogFeatureFlagEvaluations {
-        if (distinctId.isBlank()) {
+        val resolvedDistinctId = PostHogRequestContext.resolveDistinctId(distinctId)
+        if (resolvedDistinctId.isNullOrBlank()) {
             return PostHogFeatureFlagEvaluations.empty(evaluationsHost)
         }
 
@@ -303,7 +319,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
 
         val result =
             featureFlagsImpl.evaluateFlags(
-                distinctId = distinctId,
+                distinctId = resolvedDistinctId,
                 groups = groups,
                 personProperties = personProperties,
                 groupProperties = groupProperties,
@@ -313,7 +329,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
             )
 
         return PostHogFeatureFlagEvaluations(
-            distinctId = distinctId,
+            distinctId = resolvedDistinctId,
             flagMap = result.flags,
             locallyEvaluated = result.locallyEvaluated,
             requestId = result.requestId,

--- a/posthog-server/src/main/java/com/posthog/server/PostHog.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHog.kt
@@ -54,7 +54,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
     }
 
     override fun capture(
-        distinctId: String,
+        distinctId: String?,
         event: String,
         properties: Map<String, Any>?,
         userProperties: Map<String, Any>?,
@@ -300,7 +300,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
     }
 
     override fun evaluateFlags(
-        distinctId: String,
+        distinctId: String?,
         groups: Map<String, String>?,
         personProperties: Map<String, Any?>?,
         groupProperties: Map<String, Map<String, Any?>>?,

--- a/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
@@ -70,7 +70,8 @@ public sealed interface PostHogInterface {
 
     /**
      * Captures events
-     * @param distinctId the distinctId of the user performing the event
+     * @param distinctId the distinctId of the user performing the event. When blank, the current
+     *   [PostHogRequestContext] distinct ID is used; if none exists, a personless UUID is generated.
      * @param event the event name
      * @param properties the custom properties
      * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
@@ -96,8 +97,37 @@ public sealed interface PostHogInterface {
     )
 
     /**
+     * Captures an event using the current [PostHogRequestContext] distinct ID, or as a personless
+     * event when no request context identity is active.
+     */
+    @JvmSynthetic
+    public fun capture(
+        event: String,
+        properties: Map<String, Any>? = null,
+        userProperties: Map<String, Any>? = null,
+        userPropertiesSetOnce: Map<String, Any>? = null,
+        groups: Map<String, String>? = null,
+        timestamp: Date? = null,
+        appendFeatureFlags: Boolean = false,
+        flags: PostHogFeatureFlagEvaluations? = null,
+    ) {
+        capture(
+            distinctId = "",
+            event = event,
+            properties = properties,
+            userProperties = userProperties,
+            userPropertiesSetOnce = userPropertiesSetOnce,
+            groups = groups,
+            timestamp = timestamp,
+            appendFeatureFlags = appendFeatureFlags,
+            flags = flags,
+        )
+    }
+
+    /**
      * Captures events
-     * @param distinctId the distinctId
+     * @param distinctId the distinctId. When blank, the current [PostHogRequestContext] distinct ID
+     *   is used; if none exists, a personless UUID is generated.
      * @param event the event name
      * @param options the capture options containing properties, userProperties, userPropertiesSetOnce, groups, and appendFeatureFlags
      */
@@ -120,9 +150,25 @@ public sealed interface PostHogInterface {
     }
 
     /**
+     * Captures an event using the current [PostHogRequestContext] distinct ID, or as a personless
+     * event when no request context identity is active.
+     */
+    public fun capture(
+        event: String,
+        options: PostHogCaptureOptions,
+    ) {
+        capture(
+            "",
+            event,
+            options,
+        )
+    }
+
+    /**
      * Captures events
      * @param event the event name
-     * @param distinctId the distinctId
+     * @param distinctId the distinctId. When blank, the current [PostHogRequestContext] distinct ID
+     *   is used; if none exists, a personless UUID is generated.
      */
     public fun capture(
         distinctId: String,
@@ -138,6 +184,17 @@ public sealed interface PostHogInterface {
             null,
             false,
             null,
+        )
+    }
+
+    /**
+     * Captures an event using the current [PostHogRequestContext] distinct ID, or as a personless
+     * event when no request context identity is active.
+     */
+    public fun capture(event: String) {
+        capture(
+            "",
+            event,
         )
     }
 
@@ -598,6 +655,17 @@ public sealed interface PostHogInterface {
     }
 
     /**
+     * Evaluate every feature flag using the current [PostHogRequestContext] distinct ID and the
+     * supplied options object. Returns an empty snapshot when no request context identity is active.
+     */
+    public fun evaluateFlags(options: PostHogEvaluateFlagsOptions): PostHogFeatureFlagEvaluations {
+        return evaluateFlags(
+            "",
+            options,
+        )
+    }
+
+    /**
      * Evaluate every feature flag for [distinctId] using default options.
      */
     public fun evaluateFlags(distinctId: String): PostHogFeatureFlagEvaluations {
@@ -610,6 +678,14 @@ public sealed interface PostHogInterface {
             onlyEvaluateLocally = false,
             disableGeoip = false,
         )
+    }
+
+    /**
+     * Evaluate every feature flag using the current [PostHogRequestContext] distinct ID. Returns an
+     * empty snapshot when no request context identity is active.
+     */
+    public fun evaluateFlags(): PostHogFeatureFlagEvaluations {
+        return evaluateFlags("")
     }
 
     /**

--- a/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
@@ -70,8 +70,8 @@ public sealed interface PostHogInterface {
 
     /**
      * Captures events
-     * @param distinctId the distinctId of the user performing the event. When blank, the current
-     *   [PostHogRequestContext] distinct ID is used; if none exists, a personless UUID is generated.
+     * @param distinctId the distinctId of the user performing the event. When null or blank, the
+     *   current [PostHogRequestContext] distinct ID is used; if none exists, a personless UUID is generated.
      * @param event the event name
      * @param properties the custom properties
      * @param userProperties the user properties, set as a "$set" property, Docs https://posthog.com/docs/product-analytics/user-properties
@@ -85,7 +85,7 @@ public sealed interface PostHogInterface {
      */
     @JvmSynthetic
     public fun capture(
-        distinctId: String,
+        distinctId: String?,
         event: String,
         properties: Map<String, Any>? = null,
         userProperties: Map<String, Any>? = null,
@@ -112,7 +112,7 @@ public sealed interface PostHogInterface {
         flags: PostHogFeatureFlagEvaluations? = null,
     ) {
         capture(
-            distinctId = "",
+            distinctId = null,
             event = event,
             properties = properties,
             userProperties = userProperties,
@@ -126,26 +126,26 @@ public sealed interface PostHogInterface {
 
     /**
      * Captures events
-     * @param distinctId the distinctId. When blank, the current [PostHogRequestContext] distinct ID
-     *   is used; if none exists, a personless UUID is generated.
+     * @param distinctId the distinctId. When null or blank, the current [PostHogRequestContext]
+     *   distinct ID is used; if none exists, a personless UUID is generated.
      * @param event the event name
      * @param options the capture options containing properties, userProperties, userPropertiesSetOnce, groups, and appendFeatureFlags
      */
     public fun capture(
-        distinctId: String,
+        distinctId: String?,
         event: String,
         options: PostHogCaptureOptions,
     ) {
         capture(
-            distinctId,
-            event,
-            options.properties,
-            options.userProperties,
-            options.userPropertiesSetOnce,
-            options.groups,
-            options.timestamp,
-            options.appendFeatureFlags,
-            options.flags,
+            distinctId = distinctId,
+            event = event,
+            properties = options.properties,
+            userProperties = options.userProperties,
+            userPropertiesSetOnce = options.userPropertiesSetOnce,
+            groups = options.groups,
+            timestamp = options.timestamp,
+            appendFeatureFlags = options.appendFeatureFlags,
+            flags = options.flags,
         )
     }
 
@@ -158,32 +158,32 @@ public sealed interface PostHogInterface {
         options: PostHogCaptureOptions,
     ) {
         capture(
-            "",
-            event,
-            options,
+            distinctId = null,
+            event = event,
+            options = options,
         )
     }
 
     /**
      * Captures events
      * @param event the event name
-     * @param distinctId the distinctId. When blank, the current [PostHogRequestContext] distinct ID
-     *   is used; if none exists, a personless UUID is generated.
+     * @param distinctId the distinctId. When null or blank, the current [PostHogRequestContext]
+     *   distinct ID is used; if none exists, a personless UUID is generated.
      */
     public fun capture(
-        distinctId: String,
+        distinctId: String?,
         event: String,
     ) {
         capture(
-            distinctId,
-            event,
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
+            distinctId = distinctId,
+            event = event,
+            properties = null,
+            userProperties = null,
+            userPropertiesSetOnce = null,
+            groups = null,
+            timestamp = null,
+            appendFeatureFlags = false,
+            flags = null,
         )
     }
 
@@ -193,8 +193,8 @@ public sealed interface PostHogInterface {
      */
     public fun capture(event: String) {
         capture(
-            "",
-            event,
+            distinctId = null,
+            event = event,
         )
     }
 
@@ -614,7 +614,8 @@ public sealed interface PostHogInterface {
      * snapshot. Repeat lookups against the snapshot do not make additional network requests, and
      * `is_enabled` / `getFlag` accesses still emit deduped `$feature_flag_called` events.
      *
-     * @param distinctId the distinctId
+     * @param distinctId the distinctId. When null or blank, the current [PostHogRequestContext]
+     *   distinct ID is used; if none exists, an empty snapshot is returned.
      * @param groups groups for group-based flags
      * @param personProperties person properties for flag evaluation
      * @param groupProperties group properties for flag evaluation
@@ -626,7 +627,7 @@ public sealed interface PostHogInterface {
      */
     @JvmSynthetic
     public fun evaluateFlags(
-        distinctId: String,
+        distinctId: String?,
         groups: Map<String, String>? = null,
         personProperties: Map<String, Any?>? = null,
         groupProperties: Map<String, Map<String, Any?>>? = null,
@@ -640,11 +641,11 @@ public sealed interface PostHogInterface {
      * Java-friendly overload that mirrors the canonical [evaluateFlags] entry point.
      */
     public fun evaluateFlags(
-        distinctId: String,
+        distinctId: String?,
         options: PostHogEvaluateFlagsOptions,
     ): PostHogFeatureFlagEvaluations {
         return evaluateFlags(
-            distinctId,
+            distinctId = distinctId,
             groups = options.groups,
             personProperties = options.personProperties,
             groupProperties = options.groupProperties,
@@ -660,17 +661,17 @@ public sealed interface PostHogInterface {
      */
     public fun evaluateFlags(options: PostHogEvaluateFlagsOptions): PostHogFeatureFlagEvaluations {
         return evaluateFlags(
-            "",
-            options,
+            distinctId = null,
+            options = options,
         )
     }
 
     /**
      * Evaluate every feature flag for [distinctId] using default options.
      */
-    public fun evaluateFlags(distinctId: String): PostHogFeatureFlagEvaluations {
+    public fun evaluateFlags(distinctId: String?): PostHogFeatureFlagEvaluations {
         return evaluateFlags(
-            distinctId,
+            distinctId = distinctId,
             groups = null,
             personProperties = null,
             groupProperties = null,
@@ -685,7 +686,7 @@ public sealed interface PostHogInterface {
      * empty snapshot when no request context identity is active.
      */
     public fun evaluateFlags(): PostHogFeatureFlagEvaluations {
-        return evaluateFlags("")
+        return evaluateFlags(distinctId = null)
     }
 
     /**

--- a/posthog-server/src/main/java/com/posthog/server/PostHogRequestContext.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogRequestContext.kt
@@ -1,0 +1,254 @@
+package com.posthog.server
+
+import java.util.UUID
+
+/**
+ * Request-scoped PostHog analytics context.
+ *
+ * Use [beginScope] at the start of a server request and close the returned scope when the
+ * request completes. Captures made on the same thread while the scope is active inherit the
+ * context distinct ID, session ID, and properties unless the capture provides explicit values.
+ *
+ * Context is stored in a [ThreadLocal]. Framework integrations should create and close a fresh
+ * scope per request and use their runtime's async propagation support when work moves across
+ * threads.
+ */
+public class PostHogRequestContext private constructor() {
+    public companion object {
+        public const val DISTINCT_ID_HEADER: String = "X-PostHog-Distinct-Id"
+        public const val SESSION_ID_HEADER: String = "X-PostHog-Session-Id"
+
+        private const val SESSION_ID_PROPERTY = "\$session_id"
+        private const val PROCESS_PERSON_PROFILE_PROPERTY = "\$process_person_profile"
+        private const val MAX_HEADER_VALUE_LENGTH = 1000
+
+        private val currentContext = ThreadLocal<PostHogRequestContextData?>()
+
+        /**
+         * Returns the context active on the current thread, or null when no scope is active.
+         */
+        @JvmStatic
+        public fun current(): PostHogRequestContextData? = currentContext.get()
+
+        /**
+         * Starts a request context scope and returns an [AutoCloseable] that restores the previous context.
+         *
+         * Nested scopes inherit the current context by default. Pass [fresh] to start from an empty context.
+         */
+        @JvmStatic
+        public fun beginScope(data: PostHogRequestContextData): Scope = beginScope(data, fresh = false)
+
+        /**
+         * Starts a request context scope and returns an [AutoCloseable] that restores the previous context.
+         */
+        @JvmStatic
+        public fun beginScope(
+            data: PostHogRequestContextData,
+            fresh: Boolean,
+        ): Scope {
+            val previous = currentContext.get()
+            val base = if (fresh) null else previous
+            currentContext.set(resolveContext(data, base))
+            return Scope(previous)
+        }
+
+        /**
+         * Runs [block] inside a request context scope and restores the previous context afterwards.
+         */
+        public fun <T> withContext(
+            data: PostHogRequestContextData,
+            block: () -> T,
+        ): T = withContext(data, fresh = false, block)
+
+        /**
+         * Runs [block] inside a request context scope and restores the previous context afterwards.
+         */
+        public fun <T> withContext(
+            data: PostHogRequestContextData,
+            fresh: Boolean,
+            block: () -> T,
+        ): T {
+            beginScope(data, fresh).use {
+                return block()
+            }
+        }
+
+        /**
+         * Extracts PostHog tracing headers into context data.
+         *
+         * Header names are matched case-insensitively. Values are trimmed, control characters are
+         * removed, empty values are ignored, and long values are capped. When [captureTracingHeaders]
+         * is false, tracing headers are ignored but [properties] are still preserved.
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun fromHeaders(
+            headers: Map<String, *>?,
+            captureTracingHeaders: Boolean = true,
+            properties: Map<String, Any>? = null,
+        ): PostHogRequestContextData {
+            return try {
+                val distinctId =
+                    if (captureTracingHeaders) {
+                        sanitizeHeaderValue(firstHeaderValue(headers, DISTINCT_ID_HEADER))
+                    } else {
+                        null
+                    }
+                val sessionId =
+                    if (captureTracingHeaders) {
+                        sanitizeHeaderValue(firstHeaderValue(headers, SESSION_ID_HEADER))
+                    } else {
+                        null
+                    }
+
+                val mergedProperties = properties?.toMutableMap() ?: mutableMapOf()
+                if (!sessionId.isNullOrEmpty()) {
+                    mergedProperties.putIfAbsent(SESSION_ID_PROPERTY, sessionId)
+                }
+
+                PostHogRequestContextData(
+                    distinctId = distinctId,
+                    sessionId = sessionId,
+                    properties = mergedProperties.ifEmpty { null },
+                )
+            } catch (_: Exception) {
+                PostHogRequestContextData(properties = properties?.ifEmpty { null })
+            }
+        }
+
+        /**
+         * Sanitizes an untrusted tracing header value.
+         */
+        internal fun sanitizeHeaderValue(value: String?): String? {
+            if (value.isNullOrBlank()) {
+                return null
+            }
+
+            val sanitized =
+                buildString(value.length) {
+                    value.forEach { character ->
+                        if (!character.isISOControl()) {
+                            append(character)
+                        }
+                    }
+                }.trim()
+
+            if (sanitized.isEmpty()) {
+                return null
+            }
+
+            return if (sanitized.length <= MAX_HEADER_VALUE_LENGTH) {
+                sanitized
+            } else {
+                sanitized.substring(0, MAX_HEADER_VALUE_LENGTH)
+            }
+        }
+
+        internal fun resolveDistinctId(preferredDistinctId: String? = null): String? {
+            if (!preferredDistinctId.isNullOrBlank()) {
+                return preferredDistinctId
+            }
+            return current()?.distinctId?.takeUnless { it.isBlank() }
+        }
+
+        internal fun resolveCaptureContext(
+            distinctId: String?,
+            properties: Map<String, Any>?,
+        ): PostHogResolvedCaptureContext {
+            val resolvedDistinctId = resolveDistinctId(distinctId)
+            val isPersonless = resolvedDistinctId.isNullOrBlank()
+            val mergedProperties = properties?.toMutableMap() ?: mutableMapOf()
+            val captureDistinctId = resolvedDistinctId ?: UUID.randomUUID().toString()
+
+            if (isPersonless) {
+                mergedProperties.putIfAbsent(PROCESS_PERSON_PROFILE_PROPERTY, false)
+            }
+
+            return PostHogResolvedCaptureContext(
+                distinctId = captureDistinctId,
+                properties = mergedProperties.ifEmpty { null },
+            )
+        }
+
+        private fun resolveContext(
+            data: PostHogRequestContextData,
+            base: PostHogRequestContextData?,
+        ): PostHogRequestContextData {
+            val mergedProperties = base?.properties?.toMutableMap() ?: mutableMapOf()
+            data.properties?.let { mergedProperties.putAll(it) }
+
+            val distinctId = if (data.distinctId.isNullOrBlank()) base?.distinctId else data.distinctId
+            val sessionId = if (data.sessionId.isNullOrBlank()) base?.sessionId else data.sessionId
+            val childOverridesSessionId = !data.sessionId.isNullOrBlank()
+            val childProvidedSessionProperty = data.properties?.containsKey(SESSION_ID_PROPERTY) == true
+            if (childOverridesSessionId && !sessionId.isNullOrBlank() && !childProvidedSessionProperty) {
+                mergedProperties[SESSION_ID_PROPERTY] = sessionId
+            }
+
+            return PostHogRequestContextData(
+                distinctId = distinctId,
+                sessionId = sessionId,
+                properties = mergedProperties.ifEmpty { null },
+            )
+        }
+
+        private fun firstHeaderValue(
+            headers: Map<String, *>?,
+            headerName: String,
+        ): String? {
+            if (headers == null) {
+                return null
+            }
+
+            for ((key, value) in headers) {
+                if (key.equals(headerName, ignoreCase = true)) {
+                    return firstHeaderValue(value)
+                }
+            }
+
+            return null
+        }
+
+        private fun firstHeaderValue(value: Any?): String? =
+            when (value) {
+                is String -> value
+                is Iterable<*> -> value.firstOrNull() as? String
+                is Array<*> -> value.firstOrNull() as? String
+                else -> null
+            }
+    }
+
+    /**
+     * Active request context scope. Close it to restore the previous context.
+     */
+    public class Scope internal constructor(private val previous: PostHogRequestContextData?) : AutoCloseable {
+        private var closed: Boolean = false
+
+        override fun close() {
+            if (closed) {
+                return
+            }
+
+            if (previous == null) {
+                currentContext.remove()
+            } else {
+                currentContext.set(previous)
+            }
+            closed = true
+        }
+    }
+}
+
+/**
+ * Values applied to captures made inside a [PostHogRequestContext] scope.
+ */
+public class PostHogRequestContextData public constructor(
+    public val distinctId: String? = null,
+    public val sessionId: String? = null,
+    public val properties: Map<String, Any>? = null,
+)
+
+internal data class PostHogResolvedCaptureContext(
+    val distinctId: String,
+    val properties: Map<String, Any>?,
+)

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogServerContext.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogServerContext.kt
@@ -1,6 +1,7 @@
 package com.posthog.server.internal
 
 import com.posthog.internal.PostHogContext
+import com.posthog.server.PostHogRequestContext
 
 /**
  * PostHog context implementation for server-side SDK
@@ -9,7 +10,15 @@ import com.posthog.internal.PostHogContext
 internal class PostHogServerContext(private val config: com.posthog.PostHogConfig) : PostHogContext {
     override fun getStaticContext(): Map<String, Any> = emptyMap()
 
-    override fun getDynamicContext(): Map<String, Any> = emptyMap()
+    override fun getDynamicContext(): Map<String, Any> {
+        val requestContext = PostHogRequestContext.current() ?: return emptyMap()
+        val properties = requestContext.properties?.toMutableMap() ?: mutableMapOf()
+        val sessionId = requestContext.sessionId
+        if (!sessionId.isNullOrBlank()) {
+            properties.putIfAbsent("\$session_id", sessionId)
+        }
+        return properties
+    }
 
     override fun getSdkInfo(): Map<String, Any> =
         mapOf(

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
@@ -266,6 +266,39 @@ internal class PostHogEvaluateFlagsTest {
     }
 
     @Test
+    fun `evaluateFlags uses request context distinctId when null`() {
+        val mockServer = MockWebServer()
+        mockServer.enqueue(jsonResponse(createFlagsResponse("a", enabled = true)))
+        mockServer.start()
+
+        var postHog: PostHogInterface? = null
+        try {
+            postHog =
+                PostHog.with(
+                    PostHogConfig.builder(TEST_API_KEY)
+                        .host(mockServer.url("/").toString())
+                        .build(),
+                )
+
+            val snapshot =
+                PostHogRequestContext.withContext(PostHogRequestContextData(distinctId = "context-user")) {
+                    postHog.evaluateFlags(null)
+                }
+
+            assertEquals("context-user", snapshot.distinctId)
+            assertTrue(snapshot.isEnabled("a"))
+
+            val request = mockServer.takeRequest(2, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val body = request.body.unGzip()
+            assertTrue(body.contains("\"distinct_id\":\"context-user\""), "expected context distinctId in request body, got: $body")
+        } finally {
+            postHog?.close()
+            mockServer.shutdown()
+        }
+    }
+
+    @Test
     fun `evaluateFlags with blank distinctId returns an empty snapshot and fires no events on access`() {
         val mockServer = MockWebServer()
         mockServer.start()

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
@@ -233,68 +233,46 @@ internal class PostHogEvaluateFlagsTest {
     }
 
     @Test
-    fun `evaluateFlags uses request context distinctId when omitted`() {
-        val mockServer = MockWebServer()
-        mockServer.enqueue(jsonResponse(createFlagsResponse("a", enabled = true)))
-        mockServer.start()
+    fun `evaluateFlags uses request context distinctId when omitted or null`() {
+        val cases =
+            listOf<Pair<String, (PostHogInterface) -> PostHogFeatureFlagEvaluations>>(
+                "omitted distinctId" to { client -> client.evaluateFlags() },
+                "null distinctId" to { client -> client.evaluateFlags(null) },
+            )
 
-        var postHog: PostHogInterface? = null
-        try {
-            postHog =
-                PostHog.with(
-                    PostHogConfig.builder(TEST_API_KEY)
-                        .host(mockServer.url("/").toString())
-                        .build(),
+        for ((caseName, evaluateFlags) in cases) {
+            val mockServer = MockWebServer()
+            mockServer.enqueue(jsonResponse(createFlagsResponse("a", enabled = true)))
+            mockServer.start()
+
+            var postHog: PostHogInterface? = null
+            try {
+                postHog =
+                    PostHog.with(
+                        PostHogConfig.builder(TEST_API_KEY)
+                            .host(mockServer.url("/").toString())
+                            .build(),
+                    )
+
+                val snapshot =
+                    PostHogRequestContext.withContext(PostHogRequestContextData(distinctId = "context-user")) {
+                        evaluateFlags(postHog)
+                    }
+
+                assertEquals("context-user", snapshot.distinctId, "case: $caseName")
+                assertTrue(snapshot.isEnabled("a"), "case: $caseName")
+
+                val request = mockServer.takeRequest(2, TimeUnit.SECONDS)
+                assertNotNull(request, "case: $caseName")
+                val body = request.body.unGzip()
+                assertTrue(
+                    body.contains("\"distinct_id\":\"context-user\""),
+                    "expected context distinctId in request body for $caseName, got: $body",
                 )
-
-            val snapshot =
-                PostHogRequestContext.withContext(PostHogRequestContextData(distinctId = "context-user")) {
-                    postHog.evaluateFlags()
-                }
-
-            assertEquals("context-user", snapshot.distinctId)
-            assertTrue(snapshot.isEnabled("a"))
-
-            val request = mockServer.takeRequest(2, TimeUnit.SECONDS)
-            assertNotNull(request)
-            val body = request.body.unGzip()
-            assertTrue(body.contains("\"distinct_id\":\"context-user\""), "expected context distinctId in request body, got: $body")
-        } finally {
-            postHog?.close()
-            mockServer.shutdown()
-        }
-    }
-
-    @Test
-    fun `evaluateFlags uses request context distinctId when null`() {
-        val mockServer = MockWebServer()
-        mockServer.enqueue(jsonResponse(createFlagsResponse("a", enabled = true)))
-        mockServer.start()
-
-        var postHog: PostHogInterface? = null
-        try {
-            postHog =
-                PostHog.with(
-                    PostHogConfig.builder(TEST_API_KEY)
-                        .host(mockServer.url("/").toString())
-                        .build(),
-                )
-
-            val snapshot =
-                PostHogRequestContext.withContext(PostHogRequestContextData(distinctId = "context-user")) {
-                    postHog.evaluateFlags(null)
-                }
-
-            assertEquals("context-user", snapshot.distinctId)
-            assertTrue(snapshot.isEnabled("a"))
-
-            val request = mockServer.takeRequest(2, TimeUnit.SECONDS)
-            assertNotNull(request)
-            val body = request.body.unGzip()
-            assertTrue(body.contains("\"distinct_id\":\"context-user\""), "expected context distinctId in request body, got: $body")
-        } finally {
-            postHog?.close()
-            mockServer.shutdown()
+            } finally {
+                postHog?.close()
+                mockServer.shutdown()
+            }
         }
     }
 

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
@@ -233,6 +233,39 @@ internal class PostHogEvaluateFlagsTest {
     }
 
     @Test
+    fun `evaluateFlags uses request context distinctId when omitted`() {
+        val mockServer = MockWebServer()
+        mockServer.enqueue(jsonResponse(createFlagsResponse("a", enabled = true)))
+        mockServer.start()
+
+        var postHog: PostHogInterface? = null
+        try {
+            postHog =
+                PostHog.with(
+                    PostHogConfig.builder(TEST_API_KEY)
+                        .host(mockServer.url("/").toString())
+                        .build(),
+                )
+
+            val snapshot =
+                PostHogRequestContext.withContext(PostHogRequestContextData(distinctId = "context-user")) {
+                    postHog.evaluateFlags()
+                }
+
+            assertEquals("context-user", snapshot.distinctId)
+            assertTrue(snapshot.isEnabled("a"))
+
+            val request = mockServer.takeRequest(2, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val body = request.body.unGzip()
+            assertTrue(body.contains("\"distinct_id\":\"context-user\""), "expected context distinctId in request body, got: $body")
+        } finally {
+            postHog?.close()
+            mockServer.shutdown()
+        }
+    }
+
+    @Test
     fun `evaluateFlags with blank distinctId returns an empty snapshot and fires no events on access`() {
         val mockServer = MockWebServer()
         mockServer.start()

--- a/posthog-server/src/test/java/com/posthog/server/PostHogRequestContextTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogRequestContextTest.kt
@@ -1,0 +1,320 @@
+package com.posthog.server
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class PostHogRequestContextTest {
+    @Test
+    fun `captures use request context identity session and properties`() {
+        withPostHog { http, postHog ->
+            val context =
+                PostHogRequestContext.fromHeaders(
+                    headers =
+                        mapOf(
+                            PostHogRequestContext.DISTINCT_ID_HEADER to "frontend-user",
+                            PostHogRequestContext.SESSION_ID_HEADER to "frontend-session",
+                        ),
+                    properties =
+                        mapOf(
+                            "\$current_url" to "https://example.com/api/test",
+                            "\$request_method" to "POST",
+                            "\$request_path" to "/api/test",
+                            "\$user_agent" to "TestAgent/1.0",
+                            "\$ip" to "10.0.0.2",
+                        ),
+                )
+
+            PostHogRequestContext.beginScope(context, fresh = true).use {
+                postHog.capture("request-event")
+            }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            val event = batch.firstEvent
+            assertEquals("frontend-user", event?.get("distinct_id")?.asString)
+            val properties = batch.firstEventProperties()
+            assertEquals("frontend-session", properties["\$session_id"])
+            assertEquals("https://example.com/api/test", properties["\$current_url"])
+            assertEquals("POST", properties["\$request_method"])
+            assertEquals("/api/test", properties["\$request_path"])
+            assertEquals("TestAgent/1.0", properties["\$user_agent"])
+            assertEquals("10.0.0.2", properties["\$ip"])
+            assertFalse(properties.containsKey("\$process_person_profile"))
+        }
+    }
+
+    @Test
+    fun `explicit capture values override request context`() {
+        withPostHog { http, postHog ->
+            PostHogRequestContext.beginScope(
+                PostHogRequestContextData(
+                    distinctId = "context-user",
+                    sessionId = "context-session",
+                    properties = mapOf("shared" to "context-value", "context-only" to "context-only-value"),
+                ),
+                fresh = true,
+            ).use {
+                postHog.capture(
+                    distinctId = "explicit-user",
+                    event = "explicit-event",
+                    properties = mapOf("shared" to "explicit-value", "\$session_id" to "explicit-session"),
+                )
+            }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            assertEquals("explicit-user", batch.firstEvent?.get("distinct_id")?.asString)
+            val properties = batch.firstEventProperties()
+            assertEquals("explicit-session", properties["\$session_id"])
+            assertEquals("explicit-value", properties["shared"])
+            assertEquals("context-only-value", properties["context-only"])
+        }
+    }
+
+    @Test
+    fun `nested child context session override updates emitted session property`() {
+        withPostHog { http, postHog ->
+            PostHogRequestContext.beginScope(
+                PostHogRequestContextData(
+                    distinctId = "outer-user",
+                    sessionId = "outer-session",
+                    properties = mapOf("outer" to true),
+                ),
+                fresh = true,
+            ).use {
+                PostHogRequestContext.beginScope(
+                    PostHogRequestContextData(
+                        sessionId = "child-session",
+                        properties = mapOf("inner" to true),
+                    ),
+                ).use {
+                    postHog.capture("nested-session-event")
+                }
+            }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            assertEquals("outer-user", batch.firstEvent?.get("distinct_id")?.asString)
+            val properties = batch.firstEventProperties()
+            assertEquals("child-session", properties["\$session_id"])
+            assertEquals(true, properties["outer"])
+            assertEquals(true, properties["inner"])
+        }
+    }
+
+    @Test
+    fun `tracing headers can be disabled while preserving request metadata`() {
+        withPostHog { http, postHog ->
+            val context =
+                PostHogRequestContext.fromHeaders(
+                    headers =
+                        mapOf(
+                            PostHogRequestContext.DISTINCT_ID_HEADER to "header-user",
+                            PostHogRequestContext.SESSION_ID_HEADER to "header-session",
+                        ),
+                    captureTracingHeaders = false,
+                    properties = mapOf("\$request_path" to "/api/test"),
+                )
+
+            PostHogRequestContext.beginScope(context, fresh = true).use {
+                postHog.capture("metadata-event")
+            }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            val distinctId = batch.firstEvent?.get("distinct_id")?.asString
+            assertNotNull(distinctId)
+            assertNotEquals("header-user", distinctId)
+            assertTrue(runCatching { java.util.UUID.fromString(distinctId) }.isSuccess)
+            val properties = batch.firstEventProperties()
+            assertEquals(false, properties["\$process_person_profile"])
+            assertFalse(properties.containsKey("\$session_id"))
+            assertEquals("/api/test", properties["\$request_path"])
+        }
+    }
+
+    @Test
+    fun `missing identity creates personless event without session`() {
+        withPostHog { http, postHog ->
+            PostHogRequestContext.beginScope(PostHogRequestContextData(properties = mapOf("request" to "present")), fresh = true)
+                .use {
+                    postHog.capture("personless-event")
+                }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            val distinctId = batch.firstEvent?.get("distinct_id")?.asString
+            assertNotNull(distinctId)
+            assertTrue(runCatching { java.util.UUID.fromString(distinctId) }.isSuccess)
+            val properties = batch.firstEventProperties()
+            assertEquals(false, properties["\$process_person_profile"])
+            assertEquals("present", properties["request"])
+            assertFalse(properties.containsKey("\$session_id"))
+        }
+    }
+
+    @Test
+    fun `explicit process person profile property is preserved for personless events`() {
+        withPostHog { http, postHog ->
+            postHog.capture("", "personless-event", properties = mapOf("\$process_person_profile" to true))
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            val properties = batch.firstEventProperties()
+            assertEquals(true, properties["\$process_person_profile"])
+        }
+    }
+
+    @Test
+    fun `exception capture falls back to request context and explicit distinct id wins`() {
+        withPostHog(flushAt = 2) { http, postHog ->
+            PostHogRequestContext.beginScope(
+                PostHogRequestContextData(
+                    distinctId = "context-user",
+                    sessionId = "context-session",
+                    properties = mapOf("\$request_path" to "/api/test"),
+                ),
+                fresh = true,
+            ).use {
+                postHog.captureException(IllegalStateException("boom"))
+                postHog.captureException(IllegalArgumentException("boom 2"), "explicit-user")
+            }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            val exceptions = batch.batch.filter { it.get("event")?.asString == "\$exception" }
+            assertEquals(2, exceptions.size)
+            assertEquals("context-user", exceptions[0].get("distinct_id")?.asString)
+            assertEquals("context-session", exceptions[0].getAsJsonObject("properties").get("\$session_id")?.asString)
+            assertEquals("/api/test", exceptions[0].getAsJsonObject("properties").get("\$request_path")?.asString)
+            assertEquals("explicit-user", exceptions[1].get("distinct_id")?.asString)
+            assertEquals("context-session", exceptions[1].getAsJsonObject("properties").get("\$session_id")?.asString)
+        }
+    }
+
+    @Test
+    fun `concurrent request contexts do not leak between threads`() {
+        val executor = Executors.newFixedThreadPool(2)
+        val started = CountDownLatch(2)
+        val release = CountDownLatch(1)
+        val results = Collections.synchronizedMap(mutableMapOf<String, Pair<String?, String?>>())
+
+        fun submit(
+            key: String,
+            distinctId: String,
+            sessionId: String,
+        ) {
+            executor.submit {
+                PostHogRequestContext.beginScope(PostHogRequestContextData(distinctId, sessionId), fresh = true).use {
+                    started.countDown()
+                    release.await(5, TimeUnit.SECONDS)
+                    val current = PostHogRequestContext.current()
+                    results[key] = current?.distinctId to current?.sessionId
+                }
+            }
+        }
+
+        try {
+            submit("first", "user-a", "session-a")
+            submit("second", "user-b", "session-b")
+            assertTrue(started.await(5, TimeUnit.SECONDS))
+            release.countDown()
+            executor.shutdown()
+            assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS))
+
+            assertEquals("user-a" to "session-a", results["first"])
+            assertEquals("user-b" to "session-b", results["second"])
+            assertNull(PostHogRequestContext.current())
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `headers are case insensitive and sanitized safely`() {
+        val context =
+            PostHogRequestContext.fromHeaders(
+                mapOf(
+                    "x-posthog-distinct-id" to " \u0000\u0001 ",
+                    "x-posthog-session-id" to listOf("  ${"s".repeat(1200)}\u0000  "),
+                ),
+            )
+
+        assertNull(context.distinctId)
+        assertEquals("s".repeat(1000), context.sessionId)
+        assertEquals("s".repeat(1000), context.properties?.get("\$session_id"))
+    }
+
+    @Test
+    fun `nested contexts inherit unless fresh`() {
+        PostHogRequestContext.beginScope(
+            PostHogRequestContextData("outer-user", "outer-session", mapOf("outer" to true)),
+            fresh = true,
+        ).use {
+            PostHogRequestContext.beginScope(PostHogRequestContextData(properties = mapOf("inner" to true))).use {
+                val current = PostHogRequestContext.current()
+                assertEquals("outer-user", current?.distinctId)
+                assertEquals("outer-session", current?.sessionId)
+                assertEquals(true, current?.properties?.get("outer"))
+                assertEquals(true, current?.properties?.get("inner"))
+            }
+
+            PostHogRequestContext.beginScope(PostHogRequestContextData(properties = mapOf("fresh" to true)), fresh = true).use {
+                val current = PostHogRequestContext.current()
+                assertNull(current?.distinctId)
+                assertNull(current?.sessionId)
+                assertFalse(current?.properties?.containsKey("outer") ?: true)
+                assertEquals(true, current?.properties?.get("fresh"))
+            }
+        }
+
+        assertNull(PostHogRequestContext.current())
+    }
+
+    private inline fun withPostHog(
+        flushAt: Int = 1,
+        block: (MockWebServer, PostHogInterface) -> Unit,
+    ) {
+        val http = MockWebServer()
+        var postHog: PostHogInterface? = null
+        try {
+            http.enqueue(MockResponse().setResponseCode(200))
+            http.start()
+            postHog = createPostHog(http, flushAt)
+            block(http, postHog)
+        } finally {
+            postHog?.close()
+            runCatching { http.shutdown() }
+        }
+    }
+
+    private fun createPostHog(
+        http: MockWebServer,
+        flushAt: Int = 1,
+    ): PostHogInterface =
+        PostHog.with(
+            PostHogConfig.builder(TEST_API_KEY)
+                .host(http.url("/").toString())
+                .flushAt(flushAt)
+                .build(),
+        )
+}

--- a/posthog-server/src/test/java/com/posthog/server/PostHogRequestContextTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogRequestContextTest.kt
@@ -56,6 +56,21 @@ internal class PostHogRequestContextTest {
     }
 
     @Test
+    fun `null capture distinct id uses request context identity`() {
+        withPostHog { http, postHog ->
+            PostHogRequestContext.beginScope(PostHogRequestContextData(distinctId = "context-user"), fresh = true).use {
+                postHog.capture(null, "null-distinct-event")
+            }
+
+            val request = http.takeRequest(5, TimeUnit.SECONDS)
+            assertNotNull(request)
+            val batch = request.parseBatch()
+            assertEquals("context-user", batch.firstEvent?.get("distinct_id")?.asString)
+            assertFalse(batch.firstEventProperties().containsKey("\$process_person_profile"))
+        }
+    }
+
+    @Test
     fun `explicit capture values override request context`() {
         withPostHog { http, postHog ->
             PostHogRequestContext.beginScope(


### PR DESCRIPTION
## :bulb: Motivation and Context
Server-side SDK users handling frontend requests need a safe way to carry PostHog frontend tracing context into backend captures. This adds request-scoped context support for `posthog-server`, so captures and exception captures can inherit frontend distinct/session metadata while still preserving explicit SDK call overrides.

## :green_heart: How did you test it?
- `./gradlew :posthog-server:test --tests "com.posthog.server.PostHogRequestContextTest" --tests "com.posthog.server.PostHogEvaluateFlagsTest"`
- `make checkFormat`
- `./gradlew :posthog-server:test`
- `git diff --check`
- `make api`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a changeset file (`.changeset/request-context-server.md`)

<!-- For more details check RELEASING.md -->
