### PR TITLE
chore: opt into changeset-hygiene transitive re-exports

### DIFF
--- a/.changeset/hygiene.json
+++ b/.changeset/hygiene.json
@@ -1,0 +1,5 @@
+{
+    "transitiveReExports": {
+        "posthog": ["posthog-android", "posthog-server"]
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

The changeset-hygiene check flags `posthog-android` and `posthog-server` as "extra" when they're declared alongside `posthog` without source changes of their own — see false positive on https://github.com/PostHog/posthog-android/pull/525.

But this is the correct pattern for our setup: both modules declare `api(project(":posthog"))` in Gradle, so they must republish to deliver upstream core changes to their Maven consumers. The hygiene script can't see Gradle deps.

The shared workflow now supports an opt-in config for this case: https://github.com/PostHog/.github/pull/42.

## :green_heart: How did you test it?

Manually walked through the script logic against PR #525's diff:

- `affected` = `{posthog}` (only `posthog/` source changed)
- `declared` = `{posthog, posthog-android}`
- With this config, `posthog` is in both → `posthog-android` is excused from the "extra" check
- Result: no warning comment posted

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.
