### PR TITLE
chore(ci): migrate to gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # pin@v3.5.0
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
gradle/wrapper-validation-action is deprecated. Migrating to gradle/actions/wrapper-validation@v6.1.0, the supported replacement (JS action, node24).

The deprecate version has unpinned transitive dependencies and is incompatible with GitHub's "Require actions to be pinned to a full-length commit SHA" setting.