### PR TITLE
fix: stop screenshot frames being dropped during animations

### DIFF
--- a/.changeset/tough-parrots-watch.md
+++ b/.changeset/tough-parrots-watch.md
@@ -1,0 +1,7 @@
+---
+"posthog-android": patch
+---
+
+Fix session replay screenshots being dropped on screens with continuous animations (e.g. Lottie). 
+Previously, any `onDraw` callback received while PixelCopy was in flight caused the screenshot to be discarded. Introduces `isOnlyAnimationRedraw` to distinguish animation-driven redraws from structural layout changes. 
+Uses `View.hasTransientState()` on the decor view, which Android propagates up from any animating descendant, as the signal.

--- a/.github/workflows/changeset-hygiene.yml
+++ b/.github/workflows/changeset-hygiene.yml
@@ -15,4 +15,4 @@ concurrency:
 
 jobs:
     check:
-        uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+        uses: PostHog/.github/.github/workflows/changeset-hygiene.yml@b6cef416551ce8e557d57e1bb4f6766da7389b4e

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -201,9 +201,10 @@ public class PostHogReplayIntegration(
 
     private fun onDrawCallback(decorView: View) {
         isOnDrawnCalled = true
-        // hasTransientState() propagates up from any descendant that is actively animating,
-        // so checking the decor view tells us whether the invalidation came from an animation.
-        isOnlyAnimationRedraw = decorView.hasTransientState()
+        // hasTransientState() propagates up from any descendant using a ValueAnimator (e.g. Lottie),
+        // indicating pixel-only changes with stable view geometry. We additionally exclude legacy
+        // view.animation which mutates the transformation matrix and can shift mask positions.
+        isOnlyAnimationRedraw = decorView.hasTransientState() && !decorView.isAnimationRunning()
     }
 
     private fun addView(

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -193,8 +193,17 @@ public class PostHogReplayIntegration(
     @Volatile
     private var isOnDrawnCalled: Boolean = false
 
-    private fun onDrawCallback() {
+    // True when the draw was triggered purely by an in-progress animation (e.g. Lottie) rather
+    // than a structural layout change. When set, the isOnDrawnCalled guard is relaxed so that
+    // continuously-animating screens can still be captured (mask geometry remains valid).
+    @Volatile
+    private var isOnlyAnimationRedraw: Boolean = false
+
+    private fun onDrawCallback(decorView: View) {
         isOnDrawnCalled = true
+        // hasTransientState() propagates up from any descendant that is actively animating,
+        // so checking the decor view tells us whether the invalidation came from an animation.
+        isOnlyAnimationRedraw = decorView.hasTransientState()
     }
 
     private fun addView(
@@ -219,7 +228,7 @@ public class PostHogReplayIntegration(
                                         mainHandler,
                                         config.dateProvider,
                                         config.sessionReplayConfig.throttleDelayMs,
-                                        ::onDrawCallback,
+                                        { onDrawCallback(decorView) },
                                     ) {
                                         if (!isActive() || !isNativeSdk) {
                                             return@onNextDraw
@@ -449,6 +458,7 @@ public class PostHogReplayIntegration(
 
             isSessionReplayActive = false
             isOnDrawnCalled = false
+            isOnlyAnimationRedraw = false
 
             pixelCopyThread?.quitSafely()
             pixelCopyThread = null
@@ -836,7 +846,7 @@ public class PostHogReplayIntegration(
 
         if (walkChildren && view is ViewGroup && view.childCount > 0) {
             for (i in 0 until view.childCount) {
-                if (isOnDrawnCalled) {
+                if (isOnDrawnCalled && !isOnlyAnimationRedraw) {
                     config.logger.log("Session Replay screenshot discarded due to screen changes.")
                     return false
                 }
@@ -995,8 +1005,9 @@ public class PostHogReplayIntegration(
         var callbackCompleted = false
 
         try {
-            // reset the isOnDrawnCalled since we are about to take a screenshot
+            // reset the draw-dirty flags since we are about to take a screenshot
             isOnDrawnCalled = false
+            isOnlyAnimationRedraw = false
 
             PixelCopy.request(window, bitmap, { copyResult ->
                 try {
@@ -1004,7 +1015,10 @@ public class PostHogReplayIntegration(
                         config.logger.log("Session Replay PixelCopy failed: $copyResult.")
                         success = false
                     } else {
-                        if (!isOnDrawnCalled) {
+                        // Allow capture if the screen hasn't redrawn, or if the only redraws
+                        // since PixelCopy started were animation frames (e.g. Lottie). In the
+                        // animation case, view geometry is stable so mask positions are still valid.
+                        if (!isOnDrawnCalled || isOnlyAnimationRedraw) {
                             val maskableWidgets = mutableListOf<Rect>()
 
                             if (findMaskableWidgets(view, maskableWidgets)) {
@@ -1024,7 +1038,7 @@ public class PostHogReplayIntegration(
                                     }
 
                                 maskableWidgets.forEach {
-                                    if (isOnDrawnCalled) {
+                                    if (isOnDrawnCalled && !isOnlyAnimationRedraw) {
                                         config.logger.log("Session Replay screenshot discarded due to screen changes.")
                                         success = false
                                         return@forEach
@@ -1037,9 +1051,8 @@ public class PostHogReplayIntegration(
                             }
                         } else {
                             config.logger.log("Session Replay screenshot discarded due to screen changes.")
-                            // if isOnDrawnCalled is true, it means that the view has already been drawn
-                            // again, so we don't need to draw the maskable widgets otherwise
-                            // they might be out of sync (leaking possible PII)
+                            // isOnDrawnCalled is true and it was a structural change (not just an
+                            // animation frame), so masks may be out of sync — discard to avoid PII leak.
                             success = false
                         }
                     }
@@ -1047,8 +1060,9 @@ public class PostHogReplayIntegration(
                     config.logger.log("Session Replay PixelCopy failed: $e.")
                     success = false
                 } finally {
-                    // reset the isOnDrawnCalled since we've taken the screenshot
+                    // reset the draw-dirty flags since we've taken the screenshot
                     isOnDrawnCalled = false
+                    isOnlyAnimationRedraw = false
                     callbackCompleted = true
                     latch.countDown()
                 }
@@ -1071,6 +1085,7 @@ public class PostHogReplayIntegration(
             config.logger.log("Session Replay PixelCopy timed out: $e.")
         } finally {
             isOnDrawnCalled = false
+            isOnlyAnimationRedraw = false
             // Only recycle the bitmap if the callback has completed.
             // If the latch timed out, the PixelCopy callback may still be writing to the bitmap
             // on another thread; recycling it now would cause a native SIGSEGV.
@@ -1660,6 +1675,7 @@ public class PostHogReplayIntegration(
     override fun stop() {
         isSessionReplayActive = false
         isOnDrawnCalled = false
+        isOnlyAnimationRedraw = false
     }
 
     override fun isActive(): Boolean {


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up to #524

- Adds isOnlyAnimationRedraw to distinguish animation-driven redraws from structural layout changes
- Uses View.hasTransientState() on the decor view as the signal — Android propagates transient state up from any animating descendant, so a single check at the root covers deeply nested LottieAnimationView instances without walking the tree
- The PII concern is preserved: if a structural change occurs (mask positions could shift), isOnlyAnimationRedraw is false and the screenshot is still discarded. Only pure animation redraws (where view geometry is stable) are allowed through

## :green_heart: How did you test it?

Tested on a sample project with lottie animations ([here](https://us.posthog.com/shared/wSoFrC48qKqAuaq-CkJD2HyZRcrMjw?t=5))
 - snapshots don't get dropped because of animated view
 - fast scrolling does not cause masking drift

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
