### PR TITLE
chore: bump PostHog/.github reusable workflow SHA to fix action pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         name: Notify Slack - Approval Needed
         needs: check-changesets
         if: needs.check-changesets.outputs.has-changesets == 'true'
-        uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+        uses: PostHog/.github/.github/workflows/notify-approval-needed.yml@b6cef416551ce8e557d57e1bb4f6766da7389b4e
         with:
             slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
             slack_user_group_id: ${{ vars.GROUP_CLIENT_LIBRARIES_SLACK_GROUP_ID }}
@@ -66,7 +66,7 @@ jobs:
         steps:
             - name: Notify Slack - Approved
               continue-on-error: true
-              uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+              uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -135,7 +135,7 @@ jobs:
             - name: Notify Slack - Failed
               continue-on-error: true
               if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
-              uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+              uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -175,7 +175,7 @@ jobs:
             - name: Notify Slack - Rejected
               if: steps.check-rejection.outputs.was_rejected == 'true'
               continue-on-error: true
-              uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+              uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -338,7 +338,7 @@ jobs:
             - name: Notify Slack - Failed
               continue-on-error: true
               if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
-              uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+              uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
@@ -357,7 +357,7 @@ jobs:
 
             - name: Notify Slack - Released
               continue-on-error: true
-              uses: PostHog/.github/.github/actions/slack-thread-reply@d2e7c952fef6a22b2210bcffc70bec71abeeba03
+              uses: PostHog/.github/.github/actions/slack-thread-reply@b6cef416551ce8e557d57e1bb4f6766da7389b4e
               with:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}


### PR DESCRIPTION
## Summary

- Bumps all `PostHog/.github` reusable workflow and action references from `d2e7c952fef6a22b2210bcffc70bec71abeeba03` to `b6cef416551ce8e557d57e1bb4f6766da7389b4e`
- The old SHA pointed to a version of `notify-approval-needed.yml` that used tag-pinned action refs (`actions/checkout@v6`, `posthog/posthog-github-action@v1.1.1`), violating the repo's requirement that all actions be pinned to a full commit SHA
- The new SHA contains the fixed version with proper SHA-pinned refs throughout

## Test plan

- [ ] Confirm the `Notify Slack - Approval Needed` job no longer fails at `Set up job` with the action pinning error
- [ ] Verify the release workflow completes successfully on next triggered run