### PR TITLE
fix(server): include group context in $feature_flag_called dedupe key

### DIFF
--- a/.changeset/include-group-context-in-flag-called-dedupe.md
+++ b/.changeset/include-group-context-in-flag-called-dedupe.md
@@ -1,0 +1,6 @@
+---
+"posthog": patch
+"posthog-server": patch
+---
+
+Include group context in the `$feature_flag_called` LRU dedupe key so group-scoped flags fire a separate event for each group a user is evaluated under, instead of being dedup-ed against the first group context the same `(distinctId, flagKey, value)` was seen under. The groups are canonicalized order-independently so two equal maps built in different insertion orders still dedupe to one event.

--- a/posthog-server/src/main/java/com/posthog/server/PostHog.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHog.kt
@@ -15,9 +15,10 @@ public class PostHog : PostHogStateless(), PostHogInterface {
                 key: String,
                 value: Any?,
                 properties: Map<String, Any>,
+                groups: Map<String, String>?,
             ) {
                 if (getConfig<com.posthog.PostHogConfig>()?.sendFeatureFlagEvent == false) return
-                this@PostHog.captureFeatureFlagCalledEvent(distinctId, key, value, properties)
+                this@PostHog.captureFeatureFlagCalledEvent(distinctId, key, value, properties, groups)
             }
 
             override fun logWarning(message: String) {
@@ -321,6 +322,7 @@ public class PostHog : PostHogStateless(), PostHogInterface {
             definitionsLoadedAt = result.definitionsLoadedAt,
             responseError = result.responseError,
             host = evaluationsHost,
+            groups = groups,
         )
     }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
@@ -32,6 +32,7 @@ public class PostHogFeatureFlagEvaluations internal constructor(
     private val responseError: String?,
     private val host: EvaluationsHost,
     initialAccessed: Set<String> = emptySet(),
+    private val groups: Map<String, String>? = null,
 ) {
     private val flagMap: Map<String, FeatureFlag> = Collections.unmodifiableMap(LinkedHashMap(flagMap))
     private val locallyEvaluated: Map<String, Boolean> = Collections.unmodifiableMap(HashMap(locallyEvaluated))
@@ -158,6 +159,7 @@ public class PostHogFeatureFlagEvaluations internal constructor(
             responseError = responseError,
             host = host,
             initialAccessed = emptySet(),
+            groups = groups,
         )
     }
 
@@ -191,7 +193,7 @@ public class PostHogFeatureFlagEvaluations internal constructor(
             props["\$feature_flag_error"] = error.joinToString(",")
         }
 
-        host.captureFeatureFlagCalled(distinctId, key, value, props)
+        host.captureFeatureFlagCalled(distinctId, key, value, props, groups)
     }
 
     public companion object {

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
@@ -32,10 +32,11 @@ public class PostHogFeatureFlagEvaluations internal constructor(
     private val responseError: String?,
     private val host: EvaluationsHost,
     initialAccessed: Set<String> = emptySet(),
-    private val groups: Map<String, String>? = null,
+    groups: Map<String, String>? = null,
 ) {
     private val flagMap: Map<String, FeatureFlag> = Collections.unmodifiableMap(LinkedHashMap(flagMap))
     private val locallyEvaluated: Map<String, Boolean> = Collections.unmodifiableMap(HashMap(locallyEvaluated))
+    private val groups: Map<String, String>? = groups?.let { Collections.unmodifiableMap(HashMap(it)) }
 
     private val accessLock = Any()
     private val accessed: MutableSet<String> = HashSet(initialAccessed)

--- a/posthog-server/src/main/java/com/posthog/server/internal/EvaluationsHost.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/EvaluationsHost.kt
@@ -12,6 +12,7 @@ internal interface EvaluationsHost {
         key: String,
         value: Any?,
         properties: Map<String, Any>,
+        groups: Map<String, String>? = null,
     )
 
     fun logWarning(message: String)

--- a/posthog-server/src/test/java/com/posthog/server/PostHogFeatureFlagEvaluationsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogFeatureFlagEvaluationsTest.kt
@@ -16,6 +16,7 @@ internal class PostHogFeatureFlagEvaluationsTest {
         val key: String,
         val value: Any?,
         val properties: Map<String, Any>,
+        val groups: Map<String, String>?,
     )
 
     private class FakeHost : EvaluationsHost {
@@ -27,8 +28,9 @@ internal class PostHogFeatureFlagEvaluationsTest {
             key: String,
             value: Any?,
             properties: Map<String, Any>,
+            groups: Map<String, String>?,
         ) {
-            captures.add(RecordedCall(distinctId, key, value, properties))
+            captures.add(RecordedCall(distinctId, key, value, properties, groups))
         }
 
         override fun logWarning(message: String) {
@@ -62,6 +64,7 @@ internal class PostHogFeatureFlagEvaluationsTest {
         evaluatedAt: Long? = 1_700_000_000_000L,
         definitionsLoadedAt: Long? = null,
         responseError: String? = null,
+        groups: Map<String, String>? = null,
     ) = PostHogFeatureFlagEvaluations(
         distinctId = distinctId,
         flagMap = flags,
@@ -71,6 +74,7 @@ internal class PostHogFeatureFlagEvaluationsTest {
         definitionsLoadedAt = definitionsLoadedAt,
         responseError = responseError,
         host = host,
+        groups = groups,
     )
 
     @Test
@@ -114,6 +118,23 @@ internal class PostHogFeatureFlagEvaluationsTest {
             "errors_while_computing_flags,flag_missing",
             host.captures.single().properties["\$feature_flag_error"],
         )
+    }
+
+    @Test
+    fun `isEnabled propagates groups to the host so dedup can include group context`() {
+        val host = FakeHost()
+        val snapshot =
+            snapshot(
+                host = host,
+                flags = mapOf("group-flag" to flag("group-flag", enabled = true)),
+                groups = mapOf("organization" to "org-a"),
+            )
+
+        snapshot.isEnabled("group-flag")
+
+        assertEquals(1, host.captures.size)
+        val call = host.captures.single()
+        assertEquals(mapOf("organization" to "org-a"), call.groups)
     }
 
     @Test

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -395,6 +395,8 @@ public class com/posthog/PostHogStateless : com/posthog/PostHogStatelessInterfac
 	public static synthetic fun buildEvent$default (Lcom/posthog/PostHogStateless;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lcom/posthog/PostHogEvent;
 	public fun captureExceptionStateless (Ljava/lang/Throwable;Ljava/lang/String;Ljava/util/Map;)V
 	protected final fun captureFeatureFlagCalledEvent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;)V
+	protected final fun captureFeatureFlagCalledEvent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/util/Map;)V
+	public static synthetic fun captureFeatureFlagCalledEvent$default (Lcom/posthog/PostHogStateless;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)V
 	public fun captureStateless (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;)V
 	public fun close ()V
 	public fun debug (Z)V

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -458,7 +458,7 @@ public open class PostHogStateless protected constructor(
             details.reason?.description?.let { props["\$feature_flag_reason"] = it }
         }
 
-        captureFeatureFlagCalledEvent(distinctId, key, value, props)
+        captureFeatureFlagCalledEvent(distinctId, key, value, props, groups)
     }
 
     /**
@@ -467,15 +467,20 @@ public open class PostHogStateless protected constructor(
      * the per-distinct-id dedup and routes through the queue. Both the existing per-flag accessor
      * (after applying its `sendFeatureFlagEvent` override) and the new feature-flag-evaluations
      * snapshot (after checking its own config) funnel through here so dedup stays uniform.
+     *
+     * `groups` is mixed into the dedup key so group-scoped flags fire a separate event for each
+     * group a user is evaluated under, instead of dedup-ing across groups.
      */
     @PostHogInternal
+    @JvmOverloads
     protected fun captureFeatureFlagCalledEvent(
         distinctId: String,
         key: String,
         value: Any?,
         properties: Map<String, Any>,
+        groups: Map<String, String>? = null,
     ) {
-        val isNewlySeen = featureFlagsCalled?.add(distinctId, key, value) ?: false
+        val isNewlySeen = featureFlagsCalled?.add(distinctId, key, value, groups) ?: false
         if (!isNewlySeen) return
 
         val props = mutableMapOf<String, Any>()
@@ -483,7 +488,7 @@ public open class PostHogStateless protected constructor(
         props["\$feature_flag"] = key
         props["\$feature_flag_response"] = value ?: ""
 
-        captureStateless(PostHogEventName.FEATURE_FLAG_CALLED.event, distinctId, properties = props)
+        captureStateless(PostHogEventName.FEATURE_FLAG_CALLED.event, distinctId, properties = props, groups = groups)
     }
 
     public override fun getFeatureFlagStateless(

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
@@ -163,7 +163,10 @@ internal fun canonicalGroupsRepr(groups: Map<String, String>?): String {
     return sb.toString()
 }
 
-private fun appendEscaped(sb: StringBuilder, value: String) {
+private fun appendEscaped(
+    sb: StringBuilder,
+    value: String,
+) {
     for (c in value) {
         when (c) {
             '\\', '=', ';' -> sb.append('\\').append(c)

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
@@ -142,6 +142,12 @@ internal data class FeatureFlagCalledKey(
  * inserted in a different order produce the same dedup key. An empty / null
  * map returns the empty string so callers that never pass groups keep their
  * legacy "no groups" dedup behavior.
+ *
+ * Keys and values are escaped so that a literal `=`, `;`, or `\` embedded in
+ * either cannot collide with the separators used to join entries. Without
+ * this, e.g. `mapOf("a" to "b;c=d", "e" to "f")` and
+ * `mapOf("a" to "b", "c" to "d", "e" to "f")` would both serialize to
+ * `a=b;c=d;e=f;` and silently dedupe to the same cache entry.
  */
 internal fun canonicalGroupsRepr(groups: Map<String, String>?): String {
     if (groups.isNullOrEmpty()) {
@@ -149,7 +155,19 @@ internal fun canonicalGroupsRepr(groups: Map<String, String>?): String {
     }
     val sb = StringBuilder()
     for (key in groups.keys.sorted()) {
-        sb.append(key).append('=').append(groups[key]).append(';')
+        appendEscaped(sb, key)
+        sb.append('=')
+        appendEscaped(sb, groups[key] ?: "")
+        sb.append(';')
     }
     return sb.toString()
+}
+
+private fun appendEscaped(sb: StringBuilder, value: String) {
+    for (c in value) {
+        when (c) {
+            '\\', '=', ';' -> sb.append('\\').append(c)
+            else -> sb.append(c)
+        }
+    }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFeatureFlagCalledCache.kt
@@ -22,14 +22,20 @@ internal class PostHogFeatureFlagCalledCache(
     /**
      * Atomically check if this combination has been seen before, and if not, mark it as seen.
      * Returns true if this is the first time seeing this combination (was added), false if already seen.
+     *
+     * `groups` is canonicalized into a sorted-key representation so group-scoped flags
+     * fire a separate `$feature_flag_called` event for each distinct group context the
+     * same user is evaluated under. Same groups passed in a different insertion order
+     * still dedupe to the same cache entry.
      */
     @Synchronized
     fun add(
         distinctId: String,
         flagKey: String,
         value: Any?,
+        groups: Map<String, String>? = null,
     ): Boolean {
-        val key = FeatureFlagCalledKey(distinctId, flagKey, value)
+        val key = FeatureFlagCalledKey(distinctId, flagKey, value, canonicalGroupsRepr(groups))
 
         val existingNode = cache.get(key)
         if (existingNode != null) {
@@ -121,10 +127,29 @@ internal class PostHogFeatureFlagCalledCache(
 }
 
 /**
- * Cache key combining distinct ID, flag key, and value
+ * Cache key combining distinct ID, flag key, evaluated value, and a canonical
+ * representation of the group context.
  */
 internal data class FeatureFlagCalledKey(
     val distinctId: String,
     val flagKey: String,
     val value: Any?,
+    val groupsRepr: String,
 )
+
+/**
+ * Build a canonical string from the group map so two equal maps with keys
+ * inserted in a different order produce the same dedup key. An empty / null
+ * map returns the empty string so callers that never pass groups keep their
+ * legacy "no groups" dedup behavior.
+ */
+internal fun canonicalGroupsRepr(groups: Map<String, String>?): String {
+    if (groups.isNullOrEmpty()) {
+        return ""
+    }
+    val sb = StringBuilder()
+    for (key in groups.keys.sorted()) {
+        sb.append(key).append('=').append(groups[key]).append(';')
+    }
+    return sb.toString()
+}

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagCalledCacheTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagCalledCacheTest.kt
@@ -261,6 +261,61 @@ internal class PostHogFeatureFlagCalledCacheTest {
     }
 
     @Test
+    fun `same flag and value with different group contexts are tracked separately`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1", mapOf("organization" to "org-a")))
+        assertTrue(cache.add("user1", "flag1", "value1", mapOf("organization" to "org-b")))
+
+        assertEquals(2, cache.size())
+    }
+
+    @Test
+    fun `same flag and value with same group context dedupe`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1", mapOf("organization" to "org-a")))
+        assertFalse(cache.add("user1", "flag1", "value1", mapOf("organization" to "org-a")))
+
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `same flag and value with same groups in different key order dedupe`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(
+            cache.add(
+                "user1",
+                "flag1",
+                "value1",
+                linkedMapOf("organization" to "org-a", "team" to "red"),
+            ),
+        )
+        assertFalse(
+            cache.add(
+                "user1",
+                "flag1",
+                "value1",
+                linkedMapOf("team" to "red", "organization" to "org-a"),
+            ),
+        )
+
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `null vs empty vs unset groups all dedupe to no-group bucket`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertFalse(cache.add("user1", "flag1", "value1", null))
+        assertFalse(cache.add("user1", "flag1", "value1", emptyMap()))
+
+        assertEquals(1, cache.size())
+    }
+
+    @Test
     fun `batch eviction allows cache to grow beyond max before next eviction`() {
         val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagCalledCacheTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFeatureFlagCalledCacheTest.kt
@@ -305,14 +305,44 @@ internal class PostHogFeatureFlagCalledCacheTest {
     }
 
     @Test
-    fun `null vs empty vs unset groups all dedupe to no-group bucket`() {
+    fun `null and unset groups canonicalize to the same no-group bucket`() {
+        // Independent caches per pair so a returned `false` means the canonical
+        // repr matched, not merely that the prior call inserted the same key.
         val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
 
         assertTrue(cache.add("user1", "flag1", "value1"))
         assertFalse(cache.add("user1", "flag1", "value1", null))
-        assertFalse(cache.add("user1", "flag1", "value1", emptyMap()))
-
         assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `emptyMap and unset groups canonicalize to the same no-group bucket`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1"))
+        assertFalse(cache.add("user1", "flag1", "value1", emptyMap()))
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `null and emptyMap groups canonicalize to the same no-group bucket`() {
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1", null))
+        assertFalse(cache.add("user1", "flag1", "value1", emptyMap()))
+        assertEquals(1, cache.size())
+    }
+
+    @Test
+    fun `values containing the entry separators dedupe distinctly from synthetic decompositions`() {
+        // Without escaping, mapOf("a" to "b;c=d", "e" to "f") and
+        // mapOf("a" to "b", "c" to "d", "e" to "f") both serialize to the same
+        // `a=b;c=d;e=f;` string. Verify they hit two different cache entries.
+        val cache = PostHogFeatureFlagCalledCache(maxSize = 10)
+
+        assertTrue(cache.add("user1", "flag1", "value1", mapOf("a" to "b;c=d", "e" to "f")))
+        assertTrue(cache.add("user1", "flag1", "value1", mapOf("a" to "b", "c" to "d", "e" to "f")))
+        assertEquals(2, cache.size())
     }
 
     @Test


### PR DESCRIPTION
## :bulb: Motivation and Context

In `PostHogFeatureFlagCalledCache.add`, the per-`distinctId` LRU dedupe key only included `(distinctId, flagKey, value)`. For group-scoped flags this meant that when the same user was evaluated under a different group, no new `$feature_flag_called` event was fired — causing per-group exposure undercount for experiments scoped to a group key.

This affects two modules:
- **`posthog/`** (PostHogStateless / cache) — `captureFeatureFlagCalledEvent` now takes an optional `groups` parameter (added via `@JvmOverloads` so the existing Java-callable signature still exists). The cache key gets a canonical `groupsRepr` built from the sorted entries so two equal maps with keys in a different insertion order still dedupe.
- **`posthog-server/`** — `PostHogFeatureFlagEvaluations` now carries the `groups` it was evaluated under and passes them to the host's dedup-aware capture call.

Mirrors the posthog-node fix in PostHog/posthog-js#3658 (which closes PostHog/posthog-js#3651). Both SDKs share the same dedupe shape, so backend evaluation needs the same change.

## :green_heart: How did you test it?

Added 4 new tests in `PostHogFeatureFlagCalledCacheTest` and 1 in `PostHogFeatureFlagEvaluationsTest`:

Cache-level (`posthog/`):
- `same flag and value with different group contexts are tracked separately` — two cache entries.
- `same flag and value with same group context dedupe` — one cache entry.
- `same flag and value with same groups in different key order dedupe` — one cache entry (canonicalized).
- `null vs empty vs unset groups all dedupe to no-group bucket` — single entry covers all three.

Snapshot-level (`posthog-server/`):
- `isEnabled propagates groups to the host so dedup can include group context` — confirms the snapshot threads its evaluation groups through to the host's capture call.

`./gradlew :posthog:test :posthog-server:test` is green; `./gradlew :posthog:apiDump :posthog-server:apiDump` regenerated the public `.api` files.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*