### PR TITLE
chore: use shared semantic PR title workflow

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,12 +15,7 @@ concurrency:
 jobs:
   lint-pr:
     name: Validate PR title against Conventional Commits
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # pin v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+    uses: PostHog/.github/.github/workflows/semantic-pr-title.yml@926dd076f0c796f7531177ae5cfcf1cf7cf0aeb3


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHog/.github` now provides a shared reusable workflow for validating PR titles against Conventional Commits. This switches the local SDK workflow to call that shared workflow, pinned to the merged `.github` workflow SHA, so the semantic PR title policy is centralized while each SDK repo still owns its PR trigger.

This supports the changelog flow because merged PR titles are used to determine changelog entries.

## :green_heart: How did you test it?

- Parsed the updated workflow YAML locally with PyYAML.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] No changeset/Sampo entry needed for this CI-only change.
