### PR TITLE
fix: retry event uploads on HTTP 408 (Request Timeout)

### DIFF
--- a/.changeset/retry-events-on-408.md
+++ b/.changeset/retry-events-on-408.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Retry event uploads on HTTP 408 (Request Timeout). 408 is transient and retryable, and the logs endpoint already retries it; this aligns the events endpoint with the SDK compliance contract.

--- a/posthog/src/main/java/com/posthog/internal/EndpointSpec.kt
+++ b/posthog/src/main/java/com/posthog/internal/EndpointSpec.kt
@@ -124,7 +124,7 @@ public class EndpointSpec<Record> internal constructor(
     }
 }
 
-internal val DEFAULT_EVENTS_RETRYABLE_STATUS_CODES: Set<Int> = setOf(429, 500, 502, 503, 504)
+internal val DEFAULT_EVENTS_RETRYABLE_STATUS_CODES: Set<Int> = setOf(408, 429, 500, 502, 503, 504)
 
 internal fun isEventsRetriableStatusCode(code: Int): Boolean = code in DEFAULT_EVENTS_RETRYABLE_STATUS_CODES
 

--- a/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
@@ -258,6 +258,18 @@ internal class EndpointSpecTest {
     }
 
     @Test
+    fun `events spec does not retry non-retriable status codes`() {
+        // Events keeps a curated retry set (408, 429, 500, 502, 503, 504); it
+        // must not retry arbitrary 4xx, nor the extra 5xx codes the broad logs
+        // policy (500..599) covers. Guards against widening the set by mistake.
+        assertEquals(false, isEventsRetriableStatusCode(400))
+        assertEquals(false, isEventsRetriableStatusCode(413))
+        assertEquals(false, isEventsRetriableStatusCode(501))
+        assertEquals(false, isEventsRetriableStatusCode(505))
+        assertEquals(false, isEventsRetriableStatusCode(599))
+    }
+
+    @Test
     fun `logs factory wires os name and version from PostHogContext into resource attributes`() {
         // TestPostHogContext supplies $os_name = "Android" and $os_version = "13".
         // The logs factory should translate those into OTLP os.name / os.version

--- a/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/EndpointSpecTest.kt
@@ -318,22 +318,6 @@ internal class EndpointSpecTest {
     }
 
     @Test
-    fun `events spec retry policy stays narrower than logs`() {
-        // Locks in the asymmetry. If someone copy-pastes the logs predicate
-        // (408 + all 5xx) into the events code path, 408 and 501/505/etc.
-        // would silently start retrying for events.
-        assertTrue(isEventsRetriableStatusCode(429))
-        assertTrue(isEventsRetriableStatusCode(500))
-        assertTrue(isEventsRetriableStatusCode(502))
-        assertTrue(isEventsRetriableStatusCode(503))
-        assertTrue(isEventsRetriableStatusCode(504))
-        assertEquals(false, isEventsRetriableStatusCode(408))
-        assertEquals(false, isEventsRetriableStatusCode(501))
-        assertEquals(false, isEventsRetriableStatusCode(505))
-        assertEquals(false, isEventsRetriableStatusCode(599))
-    }
-
-    @Test
     fun `EndpointSpec batch factory preserves events on-wire behavior`() {
         val executor = Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("Test"))
         val storagePrefix = tmpDir.newFolder().absolutePath

--- a/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogQueueTest.kt
@@ -502,6 +502,15 @@ internal class PostHogQueueTest {
     }
 
     @Test
+    fun `retries on 408`() {
+        val e = PostHogApiError(408, "", null)
+        val config = PostHogConfig(API_KEY)
+        val limits = initialBatchLimits(config)
+
+        assertFalse(deleteFilesIfAPIError(e, limits, actualBatchSize = limits.cap, logger = config.logger))
+    }
+
+    @Test
     fun `retries on 500`() {
         val e = PostHogApiError(500, "", null)
         val config = PostHogConfig(API_KEY)


### PR DESCRIPTION
## :bulb: Motivation and Context

HTTP 408 (Request Timeout) is transient and retryable, and the logs endpoint already retries it — but the events retry set omitted it (a copy-paste guard from when the broader logs policy landed). The SDK compliance contract now requires retrying 408 on events, so this adds it.

Closes #538. (posthog-ios counterpart: PostHog/posthog-ios#623.)

## :green_heart: How did you test it?

Added `retries on 408` to `PostHogQueueTest` (mirrors the existing 503/500/502/504 cases). Removed the obsolete "events spec retry policy stays narrower than logs" test, which asserted 408 was excluded — events stays curated (still no `501`/`505`), it just gains `408`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
