### PR TITLE
feat(server): Add async flag definition cache provider

### DIFF
--- a/.changeset/mean-years-applaud.md
+++ b/.changeset/mean-years-applaud.md
@@ -2,4 +2,6 @@
 "posthog-server": minor
 ---
 
-Add a new `PostHogFlagDefinitionCacheProvider` public API to customize feature flag definition cache behavior in the server SDK.
+Add the ability to integrate custom caching for feature flag definitions in the server SDK.
+
+This introduces an async-capable `PostHogFlagDefinitionCacheProvider` public API and a `PostHogBlockingFlagDefinitionCacheProvider` base class for synchronous cache backends.

--- a/.changeset/mean-years-applaud.md
+++ b/.changeset/mean-years-applaud.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": minor
+---
+
+Add a new `PostHogFlagDefinitionCacheProvider` public API to customize feature flag definition cache behavior in the server SDK.

--- a/.changeset/tidy-flags-smile.md
+++ b/.changeset/tidy-flags-smile.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Update core local-evaluation serialization so cached flag definitions round-trip using endpoint-compatible JSON for nested property values, property operators, and property types.

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -49,6 +49,18 @@ public final class com/posthog/server/PostHog$Companion {
 	public final fun with (Lcom/posthog/server/PostHogConfig;)Lcom/posthog/server/PostHogInterface;
 }
 
+public abstract class com/posthog/server/PostHogBlockingFlagDefinitionCacheProvider : com/posthog/server/PostHogFlagDefinitionCacheProvider {
+	public fun <init> ()V
+	public final fun getFlagDefinitions ()Ljava/util/concurrent/CompletionStage;
+	public abstract fun getFlagDefinitionsBlocking ()Ljava/util/Map;
+	public final fun onFlagDefinitionsReceived (Ljava/util/Map;)Ljava/util/concurrent/CompletionStage;
+	public abstract fun onFlagDefinitionsReceivedBlocking (Ljava/util/Map;)V
+	public final fun shouldFetchFlagDefinitions ()Ljava/util/concurrent/CompletionStage;
+	public abstract fun shouldFetchFlagDefinitionsBlocking ()Z
+	public final fun shutdown ()Ljava/util/concurrent/CompletionStage;
+	public fun shutdownBlocking ()V
+}
+
 public final class com/posthog/server/PostHogCaptureOptions {
 	public static final field Companion Lcom/posthog/server/PostHogCaptureOptions$Companion;
 	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Date;ZLcom/posthog/server/PostHogFeatureFlagEvaluations;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -320,10 +332,10 @@ public final class com/posthog/server/PostHogFeatureFlagResultOptions$Companion 
 }
 
 public abstract interface class com/posthog/server/PostHogFlagDefinitionCacheProvider {
-	public abstract fun getFlagDefinitions ()Ljava/util/Map;
-	public abstract fun onFlagDefinitionsReceived (Ljava/util/Map;)V
-	public abstract fun shouldFetchFlagDefinitions ()Z
-	public abstract fun shutdown ()V
+	public abstract fun getFlagDefinitions ()Ljava/util/concurrent/CompletionStage;
+	public abstract fun onFlagDefinitionsReceived (Ljava/util/Map;)Ljava/util/concurrent/CompletionStage;
+	public abstract fun shouldFetchFlagDefinitions ()Ljava/util/concurrent/CompletionStage;
+	public abstract fun shutdown ()Ljava/util/concurrent/CompletionStage;
 }
 
 public abstract interface class com/posthog/server/PostHogInterface {

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -319,24 +319,9 @@ public final class com/posthog/server/PostHogFeatureFlagResultOptions$Companion 
 	public final fun builder ()Lcom/posthog/server/PostHogFeatureFlagResultOptions$Builder;
 }
 
-public final class com/posthog/server/PostHogFlagDefinitionCacheData {
-	public fun <init> (Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ljava/util/Map;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/server/PostHogFlagDefinitionCacheData;
-	public static synthetic fun copy$default (Lcom/posthog/server/PostHogFlagDefinitionCacheData;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/server/PostHogFlagDefinitionCacheData;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCohorts ()Ljava/util/Map;
-	public final fun getFlags ()Ljava/util/List;
-	public final fun getGroupTypeMapping ()Ljava/util/Map;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract interface class com/posthog/server/PostHogFlagDefinitionCacheProvider {
-	public abstract fun getFlagDefinitions ()Lcom/posthog/server/PostHogFlagDefinitionCacheData;
-	public abstract fun onFlagDefinitionsReceived (Lcom/posthog/server/PostHogFlagDefinitionCacheData;)V
+	public abstract fun getFlagDefinitions ()Ljava/lang/String;
+	public abstract fun onFlagDefinitionsReceived (Ljava/lang/String;)V
 	public abstract fun shouldFetchFlagDefinitions ()Z
 	public abstract fun shutdown ()V
 }

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -125,6 +125,7 @@ public class com/posthog/server/PostHogConfig {
 	public final fun getFeatureFlagCacheMaxAgeMs ()I
 	public final fun getFeatureFlagCacheSize ()I
 	public final fun getFeatureFlagCalledCacheSize ()I
+	public final fun getFlagDefinitionCacheProvider ()Lcom/posthog/server/PostHogFlagDefinitionCacheProvider;
 	public final fun getFlushAt ()I
 	public final fun getFlushIntervalSeconds ()I
 	public final fun getHost ()Ljava/lang/String;
@@ -145,6 +146,7 @@ public class com/posthog/server/PostHogConfig {
 	public final fun setFeatureFlagCacheMaxAgeMs (I)V
 	public final fun setFeatureFlagCacheSize (I)V
 	public final fun setFeatureFlagCalledCacheSize (I)V
+	public final fun setFlagDefinitionCacheProvider (Lcom/posthog/server/PostHogFlagDefinitionCacheProvider;)V
 	public final fun setFlushAt (I)V
 	public final fun setFlushIntervalSeconds (I)V
 	public final fun setLocalEvaluation (Z)V
@@ -168,6 +170,7 @@ public final class com/posthog/server/PostHogConfig$Builder {
 	public final fun featureFlagCacheMaxAgeMs (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun featureFlagCacheSize (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun featureFlagCalledCacheSize (I)Lcom/posthog/server/PostHogConfig$Builder;
+	public final fun flagDefinitionCacheProvider (Lcom/posthog/server/PostHogFlagDefinitionCacheProvider;)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun flushAt (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun flushIntervalSeconds (I)Lcom/posthog/server/PostHogConfig$Builder;
 	public final fun host (Ljava/lang/String;)Lcom/posthog/server/PostHogConfig$Builder;
@@ -314,6 +317,28 @@ public final class com/posthog/server/PostHogFeatureFlagResultOptions$Builder {
 
 public final class com/posthog/server/PostHogFeatureFlagResultOptions$Companion {
 	public final fun builder ()Lcom/posthog/server/PostHogFeatureFlagResultOptions$Builder;
+}
+
+public final class com/posthog/server/PostHogFlagDefinitionCacheData {
+	public fun <init> (Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)Lcom/posthog/server/PostHogFlagDefinitionCacheData;
+	public static synthetic fun copy$default (Lcom/posthog/server/PostHogFlagDefinitionCacheData;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/posthog/server/PostHogFlagDefinitionCacheData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCohorts ()Ljava/util/Map;
+	public final fun getFlags ()Ljava/util/List;
+	public final fun getGroupTypeMapping ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/posthog/server/PostHogFlagDefinitionCacheProvider {
+	public abstract fun getFlagDefinitions ()Lcom/posthog/server/PostHogFlagDefinitionCacheData;
+	public abstract fun onFlagDefinitionsReceived (Lcom/posthog/server/PostHogFlagDefinitionCacheData;)V
+	public abstract fun shouldFetchFlagDefinitions ()Z
+	public abstract fun shutdown ()V
 }
 
 public abstract interface class com/posthog/server/PostHogInterface {

--- a/posthog-server/api/posthog-server.api
+++ b/posthog-server/api/posthog-server.api
@@ -320,8 +320,8 @@ public final class com/posthog/server/PostHogFeatureFlagResultOptions$Companion 
 }
 
 public abstract interface class com/posthog/server/PostHogFlagDefinitionCacheProvider {
-	public abstract fun getFlagDefinitions ()Ljava/lang/String;
-	public abstract fun onFlagDefinitionsReceived (Ljava/lang/String;)V
+	public abstract fun getFlagDefinitions ()Ljava/util/Map;
+	public abstract fun onFlagDefinitionsReceived (Ljava/util/Map;)V
 	public abstract fun shouldFetchFlagDefinitions ()Z
 	public abstract fun shutdown ()V
 }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -159,6 +159,14 @@ public open class PostHogConfig constructor(
      */
     public var personalApiKey: String? = personalApiKey?.trim()?.ifBlank { null }
 
+    /**
+     * Shared cache provider for local-evaluation feature flag definitions.
+     *
+     * This can reduce duplicate definition fetches when multiple SDK instances run in
+     * the same service. Defaults to null.
+     */
+    public var flagDefinitionCacheProvider: PostHogFlagDefinitionCacheProvider? = null
+
     private val beforeSendCallbacks = mutableListOf<PostHogBeforeSend>()
     private val integrations = mutableListOf<PostHogIntegration>()
 
@@ -217,6 +225,7 @@ public open class PostHogConfig constructor(
                         personalApiKey = personalApiKey,
                         pollIntervalSeconds = pollIntervalSeconds,
                         onFeatureFlags = onFeatureFlags,
+                        flagDefinitionCacheProvider = flagDefinitionCacheProvider,
                     )
                 },
                 queueProvider = { config, api, endpoint, _, executor ->
@@ -295,6 +304,7 @@ public open class PostHogConfig constructor(
         private var personalApiKey: String? = null
         private var pollIntervalSeconds: Int = DEFAULT_POLL_INTERVAL_SECONDS
         private var evaluationContexts: List<String>? = null
+        private var flagDefinitionCacheProvider: PostHogFlagDefinitionCacheProvider? = null
 
         /**
          * Sets the PostHog ingestion host.
@@ -467,33 +477,46 @@ public open class PostHogConfig constructor(
         public fun evaluationContexts(evaluationContexts: List<String>?): Builder = apply { this.evaluationContexts = evaluationContexts }
 
         /**
+         * Sets the provider for caching feature flag definitions.
+         *
+         * @param flagDefinitionCacheProvider The cache provider, or null to use the default.
+         * @return This builder.
+         */
+        public fun flagDefinitionCacheProvider(flagDefinitionCacheProvider: PostHogFlagDefinitionCacheProvider?): Builder =
+            apply { this.flagDefinitionCacheProvider = flagDefinitionCacheProvider }
+
+        /**
          * Builds a [PostHogConfig] from the accumulated values.
          *
          * @return The configured server SDK config.
          */
         @Suppress("DEPRECATION")
-        public fun build(): PostHogConfig =
-            PostHogConfig(
-                apiKey = apiKey,
-                host = host,
-                debug = debug,
-                sendFeatureFlagEvent = sendFeatureFlagEvent,
-                preloadFeatureFlags = preloadFeatureFlags,
-                remoteConfig = remoteConfig,
-                flushAt = flushAt,
-                maxQueueSize = maxQueueSize,
-                maxBatchSize = maxBatchSize,
-                flushIntervalSeconds = flushIntervalSeconds,
-                encryption = encryption,
-                onFeatureFlags = onFeatureFlags,
-                proxy = proxy,
-                featureFlagCacheSize = featureFlagCacheSize,
-                featureFlagCacheMaxAgeMs = featureFlagCacheMaxAgeMs,
-                featureFlagCalledCacheSize = featureFlagCalledCacheSize,
-                localEvaluation = localEvaluation ?: false,
-                personalApiKey = personalApiKey,
-                pollIntervalSeconds = pollIntervalSeconds,
-                evaluationContexts = evaluationContexts,
-            )
+        public fun build(): PostHogConfig {
+            val config =
+                PostHogConfig(
+                    apiKey = apiKey,
+                    host = host,
+                    debug = debug,
+                    sendFeatureFlagEvent = sendFeatureFlagEvent,
+                    preloadFeatureFlags = preloadFeatureFlags,
+                    remoteConfig = remoteConfig,
+                    flushAt = flushAt,
+                    maxQueueSize = maxQueueSize,
+                    maxBatchSize = maxBatchSize,
+                    flushIntervalSeconds = flushIntervalSeconds,
+                    encryption = encryption,
+                    onFeatureFlags = onFeatureFlags,
+                    proxy = proxy,
+                    featureFlagCacheSize = featureFlagCacheSize,
+                    featureFlagCacheMaxAgeMs = featureFlagCacheMaxAgeMs,
+                    featureFlagCalledCacheSize = featureFlagCalledCacheSize,
+                    localEvaluation = localEvaluation ?: false,
+                    personalApiKey = personalApiKey,
+                    pollIntervalSeconds = pollIntervalSeconds,
+                    evaluationContexts = evaluationContexts,
+                )
+            config.flagDefinitionCacheProvider = flagDefinitionCacheProvider
+            return config
+        }
     }
 }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
@@ -14,12 +14,12 @@ package com.posthog.server
  */
 public interface PostHogFlagDefinitionCacheProvider {
     /**
-     * Return cached flag definitions as a JSON string, or null when the cache is empty or unavailable.
+     * Return cached flag definitions, or null when the cache is empty or unavailable.
      *
-     * The JSON string should use the shared local-evaluation definitions shape returned by PostHog's
+     * The data should use the shared local-evaluation definitions shape returned by PostHog's
      * `/flags/definitions` endpoint: `flags`, `group_type_mapping`, and `cohorts`.
      */
-    public fun getFlagDefinitions(): String?
+    public fun getFlagDefinitions(): Map<String, Any?>?
 
     /**
      * Return true when this SDK instance should fetch definitions from PostHog.
@@ -27,12 +27,11 @@ public interface PostHogFlagDefinitionCacheProvider {
     public fun shouldFetchFlagDefinitions(): Boolean
 
     /**
-     * Called with cached flag definitions JSON after this SDK instance successfully fetches fresh definitions from PostHog.
+     * Called with flag definitions after this SDK instance successfully fetches fresh definitions from PostHog.
      *
-     * Implementations should store this string as an opaque blob to keep cache contents shareable
-     * across PostHog server SDKs.
+     * Implementations are responsible for serializing and storing this data in their cache backend.
      */
-    public fun onFlagDefinitionsReceived(data: String): Unit
+    public fun onFlagDefinitionsReceived(data: Map<String, Any?>): Unit
 
     /**
      * Clean up any resources held by the provider, such as distributed locks.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
@@ -1,0 +1,62 @@
+package com.posthog.server
+
+import com.google.gson.annotations.SerializedName
+import com.posthog.internal.FlagDefinition
+import com.posthog.internal.PropertyGroup
+
+/**
+ * Feature flag definitions that can be shared between PostHog server SDK instances.
+ *
+ * Cache providers can store this data in a shared cache so only one process needs to
+ * fetch local-evaluation flag definitions from PostHog while other processes read the
+ * latest definitions from the cache.
+ */
+public data class PostHogFlagDefinitionCacheData(
+    /**
+     * Feature flag definitions returned by the local-evaluation definitions endpoint.
+     */
+    public val flags: List<FlagDefinition>,
+    /**
+     * Mapping of group type indexes to group names used by group-based flags.
+     */
+    @SerializedName("group_type_mapping")
+    public val groupTypeMapping: Map<String, String>,
+    /**
+     * Cohort definitions used while evaluating flags locally.
+     */
+    public val cohorts: Map<String, PropertyGroup>,
+)
+
+/**
+ * Shared cache provider for local-evaluation feature flag definitions.
+ *
+ * Implementations usually coordinate leadership across SDK instances. When
+ * [shouldFetchFlagDefinitions] returns true this instance fetches definitions from
+ * PostHog and receives them through [onFlagDefinitionsReceived]. When it returns
+ * false this instance reads definitions from [getFlagDefinitions] instead.
+ *
+ * Provider errors are handled defensively by the SDK: failed reads fall back to the
+ * API only when no definitions are already loaded, and failed writes/shutdowns are
+ * logged without failing flag evaluation.
+ */
+public interface PostHogFlagDefinitionCacheProvider {
+    /**
+     * Return cached flag definitions, or null when the cache is empty or unavailable.
+     */
+    public fun getFlagDefinitions(): PostHogFlagDefinitionCacheData?
+
+    /**
+     * Return true when this SDK instance should fetch definitions from PostHog.
+     */
+    public fun shouldFetchFlagDefinitions(): Boolean
+
+    /**
+     * Called after this SDK instance successfully fetches fresh definitions from PostHog.
+     */
+    public fun onFlagDefinitionsReceived(data: PostHogFlagDefinitionCacheData): Unit
+
+    /**
+     * Clean up any resources held by the provider, such as distributed locks.
+     */
+    public fun shutdown(): Unit
+}

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
@@ -1,32 +1,5 @@
 package com.posthog.server
 
-import com.google.gson.annotations.SerializedName
-import com.posthog.internal.FlagDefinition
-import com.posthog.internal.PropertyGroup
-
-/**
- * Feature flag definitions that can be shared between PostHog server SDK instances.
- *
- * Cache providers can store this data in a shared cache so only one process needs to
- * fetch local-evaluation flag definitions from PostHog while other processes read the
- * latest definitions from the cache.
- */
-public data class PostHogFlagDefinitionCacheData(
-    /**
-     * Feature flag definitions returned by the local-evaluation definitions endpoint.
-     */
-    public val flags: List<FlagDefinition>,
-    /**
-     * Mapping of group type indexes to group names used by group-based flags.
-     */
-    @SerializedName("group_type_mapping")
-    public val groupTypeMapping: Map<String, String>,
-    /**
-     * Cohort definitions used while evaluating flags locally.
-     */
-    public val cohorts: Map<String, PropertyGroup>,
-)
-
 /**
  * Shared cache provider for local-evaluation feature flag definitions.
  *
@@ -41,9 +14,12 @@ public data class PostHogFlagDefinitionCacheData(
  */
 public interface PostHogFlagDefinitionCacheProvider {
     /**
-     * Return cached flag definitions, or null when the cache is empty or unavailable.
+     * Return cached flag definitions as a JSON string, or null when the cache is empty or unavailable.
+     *
+     * The JSON string should use the shared local-evaluation definitions shape returned by PostHog's
+     * `/flags/definitions` endpoint: `flags`, `group_type_mapping`, and `cohorts`.
      */
-    public fun getFlagDefinitions(): PostHogFlagDefinitionCacheData?
+    public fun getFlagDefinitions(): String?
 
     /**
      * Return true when this SDK instance should fetch definitions from PostHog.
@@ -51,9 +27,12 @@ public interface PostHogFlagDefinitionCacheProvider {
     public fun shouldFetchFlagDefinitions(): Boolean
 
     /**
-     * Called after this SDK instance successfully fetches fresh definitions from PostHog.
+     * Called with cached flag definitions JSON after this SDK instance successfully fetches fresh definitions from PostHog.
+     *
+     * Implementations should store this string as an opaque blob to keep cache contents shareable
+     * across PostHog server SDKs.
      */
-    public fun onFlagDefinitionsReceived(data: PostHogFlagDefinitionCacheData): Unit
+    public fun onFlagDefinitionsReceived(data: String): Unit
 
     /**
      * Clean up any resources held by the provider, such as distributed locks.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFlagDefinitionCacheProvider.kt
@@ -1,5 +1,8 @@
 package com.posthog.server
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
 /**
  * Shared cache provider for local-evaluation feature flag definitions.
  *
@@ -7,6 +10,11 @@ package com.posthog.server
  * [shouldFetchFlagDefinitions] returns true this instance fetches definitions from
  * PostHog and receives them through [onFlagDefinitionsReceived]. When it returns
  * false this instance reads definitions from [getFlagDefinitions] instead.
+ *
+ * Provider methods return [CompletionStage] so implementations can use either blocking
+ * backends or async clients such as Reactor `Mono.toFuture()`; `Flux` should be reduced
+ * to one result first, for example with `next()` or `collectList()`. The SDK waits for
+ * these stages in its current synchronous flag-loading flow.
  *
  * Provider errors are handled defensively by the SDK: failed reads fall back to the
  * API only when no definitions are already loaded, and failed writes/shutdowns are
@@ -19,22 +27,68 @@ public interface PostHogFlagDefinitionCacheProvider {
      * The data should use the shared local-evaluation definitions shape returned by PostHog's
      * `/flags/definitions` endpoint: `flags`, `group_type_mapping`, and `cohorts`.
      */
-    public fun getFlagDefinitions(): Map<String, Any?>?
+    public fun getFlagDefinitions(): CompletionStage<Map<String, Any?>?>
 
     /**
      * Return true when this SDK instance should fetch definitions from PostHog.
      */
-    public fun shouldFetchFlagDefinitions(): Boolean
+    public fun shouldFetchFlagDefinitions(): CompletionStage<Boolean>
 
     /**
      * Called with flag definitions after this SDK instance successfully fetches fresh definitions from PostHog.
      *
      * Implementations are responsible for serializing and storing this data in their cache backend.
      */
-    public fun onFlagDefinitionsReceived(data: Map<String, Any?>): Unit
+    public fun onFlagDefinitionsReceived(data: Map<String, Any?>): CompletionStage<Void?>
 
     /**
      * Clean up any resources held by the provider, such as distributed locks.
      */
-    public fun shutdown(): Unit
+    public fun shutdown(): CompletionStage<Void?>
+}
+
+/**
+ * Blocking convenience base class for [PostHogFlagDefinitionCacheProvider].
+ *
+ * Extend this when your cache backend is synchronous. Async implementations should
+ * implement [PostHogFlagDefinitionCacheProvider] directly and return their own
+ * [CompletionStage] values.
+ */
+public abstract class PostHogBlockingFlagDefinitionCacheProvider : PostHogFlagDefinitionCacheProvider {
+    /**
+     * Return cached flag definitions, or null when the cache is empty or unavailable.
+     */
+    public abstract fun getFlagDefinitionsBlocking(): Map<String, Any?>?
+
+    /**
+     * Return true when this SDK instance should fetch definitions from PostHog.
+     */
+    public abstract fun shouldFetchFlagDefinitionsBlocking(): Boolean
+
+    /**
+     * Store freshly fetched definitions in the backing cache.
+     */
+    public abstract fun onFlagDefinitionsReceivedBlocking(data: Map<String, Any?>): Unit
+
+    /**
+     * Clean up any resources held by the provider, such as distributed locks.
+     */
+    public open fun shutdownBlocking() {
+    }
+
+    public final override fun getFlagDefinitions(): CompletionStage<Map<String, Any?>?> =
+        CompletableFuture.completedFuture(getFlagDefinitionsBlocking())
+
+    public final override fun shouldFetchFlagDefinitions(): CompletionStage<Boolean> =
+        CompletableFuture.completedFuture(shouldFetchFlagDefinitionsBlocking())
+
+    public final override fun onFlagDefinitionsReceived(data: Map<String, Any?>): CompletionStage<Void?> {
+        onFlagDefinitionsReceivedBlocking(data)
+        return CompletableFuture.completedFuture<Void?>(null)
+    }
+
+    public final override fun shutdown(): CompletionStage<Void?> {
+        shutdownBlocking()
+        return CompletableFuture.completedFuture<Void?>(null)
+    }
 }

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -479,7 +479,7 @@ internal class PostHogFeatureFlags(
             // Success: update ETag (or clear if server stopped sending one)
             etag = response.etag
 
-            val cacheData = serializeFlagDefinitionCacheData(apiResponse)
+            val cacheData = buildFlagDefinitionCacheData(apiResponse)
             applyFlagDefinitions(
                 flags = apiResponse.flags,
                 groupTypeMapping = apiResponse.groupTypeMapping,
@@ -526,7 +526,7 @@ internal class PostHogFeatureFlags(
         val provider = flagDefinitionCacheProvider ?: return false
         return try {
             val cachedData = provider.getFlagDefinitions() ?: return false
-            val response = config.serializer.deserialize<com.posthog.internal.LocalEvaluationResponse>(StringReader(cachedData))
+            val response = parseFlagDefinitionCacheData(cachedData)
             applyFlagDefinitions(
                 flags = response.flags,
                 groupTypeMapping = response.groupTypeMapping,
@@ -541,7 +541,13 @@ internal class PostHogFeatureFlags(
         }
     }
 
-    private fun serializeFlagDefinitionCacheData(response: LocalEvaluationResponse): String? {
+    private fun parseFlagDefinitionCacheData(data: Map<String, Any?>): LocalEvaluationResponse {
+        val writer = StringWriter()
+        config.serializer.serialize(data, writer)
+        return config.serializer.deserialize(StringReader(writer.toString()))
+    }
+
+    private fun buildFlagDefinitionCacheData(response: LocalEvaluationResponse): Map<String, Any?>? {
         return try {
             val cacheData: Map<String, Any?> =
                 mapOf(
@@ -551,14 +557,14 @@ internal class PostHogFeatureFlags(
                 )
             val writer = StringWriter()
             config.serializer.serialize(cacheData, writer)
-            writer.toString()
+            config.serializer.deserialize<Map<String, Any?>>(StringReader(writer.toString()))
         } catch (e: Throwable) {
-            config.logger.log("Error serializing flag definitions for cache provider: ${e.message}")
+            config.logger.log("Error preparing flag definitions for cache provider: ${e.message}")
             null
         }
     }
 
-    private fun storeFlagDefinitionsInCache(data: String) {
+    private fun storeFlagDefinitionsInCache(data: Map<String, Any?>) {
         val provider = flagDefinitionCacheProvider ?: return
         try {
             provider.onFlagDefinitionsReceived(data)

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -18,6 +18,10 @@ import java.io.StringWriter
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 internal class PostHogFeatureFlags(
     private val config: PostHogConfig,
@@ -514,18 +518,23 @@ internal class PostHogFeatureFlags(
 
     private fun shouldFetchFlagDefinitions(): Boolean {
         val provider = flagDefinitionCacheProvider ?: return true
-        return try {
+        return awaitFlagDefinitionCacheProvider(
+            errorDescription = "Error in flag definition cache provider shouldFetchFlagDefinitions",
+        ) {
             provider.shouldFetchFlagDefinitions()
-        } catch (e: Throwable) {
-            config.logger.log("Error in flag definition cache provider shouldFetchFlagDefinitions: ${e.message}")
-            true
-        }
+        } ?: true
     }
 
     private fun loadFeatureFlagDefinitionsFromCache(): Boolean {
         val provider = flagDefinitionCacheProvider ?: return false
+        val cachedData =
+            awaitFlagDefinitionCacheProvider(
+                errorDescription = "Error loading feature flag definitions from cache provider",
+            ) {
+                provider.getFlagDefinitions()
+            } ?: return false
+
         return try {
-            val cachedData = provider.getFlagDefinitions() ?: return false
             val response = parseFlagDefinitionCacheData(cachedData)
             applyFlagDefinitions(
                 flags = response.flags,
@@ -538,6 +547,37 @@ internal class PostHogFeatureFlags(
         } catch (e: Throwable) {
             config.logger.log("Error loading feature flag definitions from cache provider: ${e.message}")
             false
+        }
+    }
+
+    private fun <T> awaitFlagDefinitionCacheProvider(
+        errorDescription: String,
+        call: () -> CompletionStage<T>,
+    ): T? {
+        val future =
+            try {
+                call().toCompletableFuture()
+            } catch (e: Throwable) {
+                config.logger.log("$errorDescription: ${e.message}")
+                return null
+            }
+
+        return try {
+            future.get(FLAG_DEFINITION_CACHE_PROVIDER_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            config.logger.log("$errorDescription: interrupted")
+            null
+        } catch (e: TimeoutException) {
+            future.cancel(true)
+            config.logger.log("$errorDescription: timed out after ${FLAG_DEFINITION_CACHE_PROVIDER_TIMEOUT_MS}ms")
+            null
+        } catch (e: ExecutionException) {
+            config.logger.log("$errorDescription: ${e.cause?.message ?: e.message}")
+            null
+        } catch (e: Throwable) {
+            config.logger.log("$errorDescription: ${e.message}")
+            null
         }
     }
 
@@ -566,10 +606,10 @@ internal class PostHogFeatureFlags(
 
     private fun storeFlagDefinitionsInCache(data: Map<String, Any?>) {
         val provider = flagDefinitionCacheProvider ?: return
-        try {
+        awaitFlagDefinitionCacheProvider(
+            errorDescription = "Error storing feature flag definitions in cache provider",
+        ) {
             provider.onFlagDefinitionsReceived(data)
-        } catch (e: Throwable) {
-            config.logger.log("Error storing feature flag definitions in cache provider: ${e.message}")
         }
     }
 
@@ -675,10 +715,10 @@ internal class PostHogFeatureFlags(
 
     private fun shutdownFlagDefinitionCacheProvider() {
         val provider = flagDefinitionCacheProvider ?: return
-        try {
+        awaitFlagDefinitionCacheProvider(
+            errorDescription = "Error shutting down flag definition cache provider",
+        ) {
             provider.shutdown()
-        } catch (e: Throwable) {
-            config.logger.log("Error shutting down flag definition cache provider: ${e.message}")
         }
     }
 
@@ -957,6 +997,7 @@ internal class PostHogFeatureFlags(
     internal companion object {
         internal const val LOCAL_EVALUATION_REASON_CODE: String = "local_evaluation"
         internal const val LOCAL_EVALUATION_REASON_DESCRIPTION: String = "Evaluated locally"
+        private const val FLAG_DEFINITION_CACHE_PROVIDER_TIMEOUT_MS: Long = 10_000
 
         private val EMPTY_PROPERTIES: Map<String, Any?> = emptyMap()
         private val EMPTY_COHORT_PROPERTIES: Map<String, PropertyGroup> = emptyMap()

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -10,6 +10,8 @@ import com.posthog.internal.PostHogApiError
 import com.posthog.internal.PostHogFeatureFlagsInterface
 import com.posthog.internal.PostHogFlagsResponse
 import com.posthog.internal.PropertyGroup
+import com.posthog.server.PostHogFlagDefinitionCacheData
+import com.posthog.server.PostHogFlagDefinitionCacheProvider
 import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
@@ -25,6 +27,7 @@ internal class PostHogFeatureFlags(
     private val pollIntervalSeconds: Int = 30,
     private val onFeatureFlags: PostHogOnFeatureFlags? = null,
     private val pollerEnabled: Boolean = true,
+    private val flagDefinitionCacheProvider: PostHogFlagDefinitionCacheProvider? = null,
 ) : PostHogFeatureFlagsInterface {
     private val cache =
         PostHogFeatureFlagCache(
@@ -398,10 +401,11 @@ internal class PostHogFeatureFlags(
 
     override fun shutDown() {
         stopPoller()
+        shutdownFlagDefinitionCacheProvider()
     }
 
     /**
-     * Load feature flag definitions from the API for local evaluation.
+     * Load feature flag definitions from a shared cache or from the API for local evaluation.
      * Uses ETag for conditional requests to reduce bandwidth when flags haven't changed.
      */
     public fun loadFeatureFlagDefinitions() {
@@ -435,7 +439,25 @@ internal class PostHogFeatureFlags(
             isLoading = true
         }
 
+        var shouldFetch = true
+
         try {
+            shouldFetch = shouldFetchFlagDefinitions()
+
+            if (!shouldFetch) {
+                val loadedFromCache = loadFeatureFlagDefinitionsFromCache()
+                if (loadedFromCache) {
+                    return
+                }
+
+                if (definitionsLoaded) {
+                    config.logger.log("Flag definition cache empty, keeping existing definitions")
+                    return
+                }
+
+                config.logger.log("Flag definition cache empty before initial load, falling back to API")
+            }
+
             config.logger.log("Loading feature flags for local evaluation")
             val response = api.localEvaluation(personalApiKey, etag)
 
@@ -455,22 +477,25 @@ internal class PostHogFeatureFlags(
             // Success: update ETag (or clear if server stopped sending one)
             etag = response.etag
 
-            synchronized(loadLock) {
-                featureFlags = apiResponse.flags
-                flagDefinitions = apiResponse.flags?.associateBy { it.key }
-                cohorts = apiResponse.cohorts
-                groupTypeMapping = apiResponse.groupTypeMapping
-                definitionsLoaded = true
-                definitionsLoadedAt = System.currentTimeMillis()
-            }
+            val cacheData =
+                PostHogFlagDefinitionCacheData(
+                    flags = apiResponse.flags ?: emptyList(),
+                    groupTypeMapping = apiResponse.groupTypeMapping ?: emptyMap(),
+                    cohorts = apiResponse.cohorts ?: emptyMap(),
+                )
+            applyFlagDefinitions(
+                flags = apiResponse.flags,
+                groupTypeMapping = apiResponse.groupTypeMapping,
+                cohorts = apiResponse.cohorts,
+            )
 
             config.logger.log("Loaded ${apiResponse.flags?.size ?: 0} feature flags for local evaluation")
 
-            try {
-                onFeatureFlags?.loaded()
-            } catch (e: Throwable) {
-                config.logger.log("Error in onFeatureFlags callback: ${e.message}")
+            if (shouldFetch) {
+                storeFlagDefinitionsInCache(cacheData)
             }
+
+            notifyFeatureFlagsLoaded()
         } catch (e: PostHogApiError) {
             // Clear ETag on API errors (4xx/5xx) so next request starts fresh
             etag = null
@@ -487,6 +512,66 @@ internal class PostHogFeatureFlags(
                 isLoading = false
                 loadLock.notifyAll()
             }
+        }
+    }
+
+    private fun shouldFetchFlagDefinitions(): Boolean {
+        val provider = flagDefinitionCacheProvider ?: return true
+        return try {
+            provider.shouldFetchFlagDefinitions()
+        } catch (e: Throwable) {
+            config.logger.log("Error in flag definition cache provider shouldFetchFlagDefinitions: ${e.message}")
+            true
+        }
+    }
+
+    private fun loadFeatureFlagDefinitionsFromCache(): Boolean {
+        val provider = flagDefinitionCacheProvider ?: return false
+        return try {
+            val cachedData = provider.getFlagDefinitions() ?: return false
+            applyFlagDefinitions(
+                flags = cachedData.flags,
+                groupTypeMapping = cachedData.groupTypeMapping,
+                cohorts = cachedData.cohorts,
+            )
+            config.logger.log("Loaded ${cachedData.flags.size} feature flags from flag definition cache")
+            notifyFeatureFlagsLoaded()
+            true
+        } catch (e: Throwable) {
+            config.logger.log("Error loading feature flag definitions from cache provider: ${e.message}")
+            false
+        }
+    }
+
+    private fun storeFlagDefinitionsInCache(data: PostHogFlagDefinitionCacheData) {
+        val provider = flagDefinitionCacheProvider ?: return
+        try {
+            provider.onFlagDefinitionsReceived(data)
+        } catch (e: Throwable) {
+            config.logger.log("Error storing feature flag definitions in cache provider: ${e.message}")
+        }
+    }
+
+    private fun applyFlagDefinitions(
+        flags: List<FlagDefinition>?,
+        groupTypeMapping: Map<String, String>?,
+        cohorts: Map<String, PropertyGroup>?,
+    ) {
+        synchronized(loadLock) {
+            featureFlags = flags
+            flagDefinitions = flags?.associateBy { it.key }
+            this.cohorts = cohorts
+            this.groupTypeMapping = groupTypeMapping
+            definitionsLoaded = true
+            definitionsLoadedAt = System.currentTimeMillis()
+        }
+    }
+
+    private fun notifyFeatureFlagsLoaded() {
+        try {
+            onFeatureFlags?.loaded()
+        } catch (e: Throwable) {
+            config.logger.log("Error in onFeatureFlags callback: ${e.message}")
         }
     }
 
@@ -564,6 +649,15 @@ internal class PostHogFeatureFlags(
         synchronized(this) {
             poller?.stop()
             poller = null
+        }
+    }
+
+    private fun shutdownFlagDefinitionCacheProvider() {
+        val provider = flagDefinitionCacheProvider ?: return
+        try {
+            provider.shutdown()
+        } catch (e: Throwable) {
+            config.logger.log("Error shutting down flag definition cache provider: ${e.message}")
         }
     }
 

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -5,14 +5,16 @@ import com.posthog.PostHogConfig
 import com.posthog.PostHogOnFeatureFlags
 import com.posthog.internal.FeatureFlag
 import com.posthog.internal.FlagDefinition
+import com.posthog.internal.LocalEvaluationResponse
 import com.posthog.internal.PostHogApi
 import com.posthog.internal.PostHogApiError
 import com.posthog.internal.PostHogFeatureFlagsInterface
 import com.posthog.internal.PostHogFlagsResponse
 import com.posthog.internal.PropertyGroup
-import com.posthog.server.PostHogFlagDefinitionCacheData
 import com.posthog.server.PostHogFlagDefinitionCacheProvider
 import java.io.IOException
+import java.io.StringReader
+import java.io.StringWriter
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -477,12 +479,7 @@ internal class PostHogFeatureFlags(
             // Success: update ETag (or clear if server stopped sending one)
             etag = response.etag
 
-            val cacheData =
-                PostHogFlagDefinitionCacheData(
-                    flags = apiResponse.flags ?: emptyList(),
-                    groupTypeMapping = apiResponse.groupTypeMapping ?: emptyMap(),
-                    cohorts = apiResponse.cohorts ?: emptyMap(),
-                )
+            val cacheData = serializeFlagDefinitionCacheData(apiResponse)
             applyFlagDefinitions(
                 flags = apiResponse.flags,
                 groupTypeMapping = apiResponse.groupTypeMapping,
@@ -491,7 +488,7 @@ internal class PostHogFeatureFlags(
 
             config.logger.log("Loaded ${apiResponse.flags?.size ?: 0} feature flags for local evaluation")
 
-            if (shouldFetch) {
+            if (shouldFetch && cacheData != null) {
                 storeFlagDefinitionsInCache(cacheData)
             }
 
@@ -529,12 +526,13 @@ internal class PostHogFeatureFlags(
         val provider = flagDefinitionCacheProvider ?: return false
         return try {
             val cachedData = provider.getFlagDefinitions() ?: return false
+            val response = config.serializer.deserialize<com.posthog.internal.LocalEvaluationResponse>(StringReader(cachedData))
             applyFlagDefinitions(
-                flags = cachedData.flags,
-                groupTypeMapping = cachedData.groupTypeMapping,
-                cohorts = cachedData.cohorts,
+                flags = response.flags,
+                groupTypeMapping = response.groupTypeMapping,
+                cohorts = response.cohorts,
             )
-            config.logger.log("Loaded ${cachedData.flags.size} feature flags from flag definition cache")
+            config.logger.log("Loaded ${response.flags?.size ?: 0} feature flags from flag definition cache")
             notifyFeatureFlagsLoaded()
             true
         } catch (e: Throwable) {
@@ -543,7 +541,24 @@ internal class PostHogFeatureFlags(
         }
     }
 
-    private fun storeFlagDefinitionsInCache(data: PostHogFlagDefinitionCacheData) {
+    private fun serializeFlagDefinitionCacheData(response: LocalEvaluationResponse): String? {
+        return try {
+            val cacheData: Map<String, Any?> =
+                mapOf(
+                    "flags" to (response.flags ?: emptyList<FlagDefinition>()),
+                    "group_type_mapping" to (response.groupTypeMapping ?: emptyMap<String, String>()),
+                    "cohorts" to (response.cohorts ?: emptyMap<String, PropertyGroup>()),
+                )
+            val writer = StringWriter()
+            config.serializer.serialize(cacheData, writer)
+            writer.toString()
+        } catch (e: Throwable) {
+            config.logger.log("Error serializing flag definitions for cache provider: ${e.message}")
+            null
+        }
+    }
+
+    private fun storeFlagDefinitionsInCache(data: String) {
         val provider = flagDefinitionCacheProvider ?: return
         try {
             provider.onFlagDefinitionsReceived(data)

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -28,6 +28,7 @@ internal class PostHogConfigTest {
         assertNull(config.proxy)
         assertEquals(PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_SIZE, config.featureFlagCacheSize)
         assertEquals(PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS, config.featureFlagCacheMaxAgeMs)
+        assertNull(config.flagDefinitionCacheProvider)
     }
 
     @Test
@@ -445,6 +446,8 @@ internal class PostHogConfigTest {
         config.flushIntervalSeconds = 120
         config.featureFlagCacheSize = 500
         config.featureFlagCacheMaxAgeMs = 600000
+        val flagDefinitionCacheProvider = NoOpFlagDefinitionCacheProvider()
+        config.flagDefinitionCacheProvider = flagDefinitionCacheProvider
 
         assertEquals(true, config.debug)
         assertEquals(false, config.sendFeatureFlagEvent)
@@ -456,6 +459,7 @@ internal class PostHogConfigTest {
         assertEquals(120, config.flushIntervalSeconds)
         assertEquals(500, config.featureFlagCacheSize)
         assertEquals(600000, config.featureFlagCacheMaxAgeMs)
+        assertEquals(flagDefinitionCacheProvider, config.flagDefinitionCacheProvider)
     }
 
     @Test
@@ -610,5 +614,40 @@ internal class PostHogConfigTest {
                 .evaluationContexts(null)
                 .build()
         assertNull(config.evaluationContexts)
+    }
+
+    @Test
+    fun `constructor sets flagDefinitionCacheProvider to null by default`() {
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        assertNull(config.flagDefinitionCacheProvider)
+    }
+
+    @Test
+    fun `flagDefinitionCacheProvider property accepts provider`() {
+        val provider = NoOpFlagDefinitionCacheProvider()
+        val config = PostHogConfig(apiKey = TEST_API_KEY)
+        config.flagDefinitionCacheProvider = provider
+        assertEquals(provider, config.flagDefinitionCacheProvider)
+    }
+
+    @Test
+    fun `builder flagDefinitionCacheProvider method sets value and returns builder`() {
+        val provider = NoOpFlagDefinitionCacheProvider()
+        val builder = PostHogConfig.builder(TEST_API_KEY)
+        val result = builder.flagDefinitionCacheProvider(provider)
+        assertEquals(builder, result)
+
+        val config = builder.build()
+        assertEquals(provider, config.flagDefinitionCacheProvider)
+    }
+
+    private class NoOpFlagDefinitionCacheProvider : PostHogFlagDefinitionCacheProvider {
+        override fun getFlagDefinitions(): PostHogFlagDefinitionCacheData? = null
+
+        override fun shouldFetchFlagDefinitions(): Boolean = true
+
+        override fun onFlagDefinitionsReceived(data: PostHogFlagDefinitionCacheData) = Unit
+
+        override fun shutdown() = Unit
     }
 }

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -642,11 +642,11 @@ internal class PostHogConfigTest {
     }
 
     private class NoOpFlagDefinitionCacheProvider : PostHogFlagDefinitionCacheProvider {
-        override fun getFlagDefinitions(): String? = null
+        override fun getFlagDefinitions(): Map<String, Any?>? = null
 
         override fun shouldFetchFlagDefinitions(): Boolean = true
 
-        override fun onFlagDefinitionsReceived(data: String) = Unit
+        override fun onFlagDefinitionsReceived(data: Map<String, Any?>) = Unit
 
         override fun shutdown() = Unit
     }

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -641,13 +641,13 @@ internal class PostHogConfigTest {
         assertEquals(provider, config.flagDefinitionCacheProvider)
     }
 
-    private class NoOpFlagDefinitionCacheProvider : PostHogFlagDefinitionCacheProvider {
-        override fun getFlagDefinitions(): Map<String, Any?>? = null
+    private class NoOpFlagDefinitionCacheProvider : PostHogBlockingFlagDefinitionCacheProvider() {
+        override fun getFlagDefinitionsBlocking(): Map<String, Any?>? = null
 
-        override fun shouldFetchFlagDefinitions(): Boolean = true
+        override fun shouldFetchFlagDefinitionsBlocking(): Boolean = true
 
-        override fun onFlagDefinitionsReceived(data: Map<String, Any?>) = Unit
+        override fun onFlagDefinitionsReceivedBlocking(data: Map<String, Any?>) = Unit
 
-        override fun shutdown() = Unit
+        override fun shutdownBlocking() = Unit
     }
 }

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -642,11 +642,11 @@ internal class PostHogConfigTest {
     }
 
     private class NoOpFlagDefinitionCacheProvider : PostHogFlagDefinitionCacheProvider {
-        override fun getFlagDefinitions(): PostHogFlagDefinitionCacheData? = null
+        override fun getFlagDefinitions(): String? = null
 
         override fun shouldFetchFlagDefinitions(): Boolean = true
 
-        override fun onFlagDefinitionsReceived(data: PostHogFlagDefinitionCacheData) = Unit
+        override fun onFlagDefinitionsReceived(data: String) = Unit
 
         override fun shutdown() = Unit
     }

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1825,6 +1825,67 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `stored flag definition cache JSON preserves complex endpoint shape`() {
+        val logger = TestLogger()
+        val mockServer = createMockHttp(jsonResponse(createCohortLocalEvaluationResponse()))
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        val cachedJson = provider.lastReceivedData ?: ""
+        assertTrue(cachedJson.contains("\"group_type_mapping\":"))
+        assertTrue(cachedJson.contains("\"operator\":\"not_regex\""))
+        assertTrue(cachedJson.contains("\"type\":\"person\""))
+        assertTrue(cachedJson.contains("\"type\":\"cohort\""))
+        assertFalse(cachedJson.contains("NOT_REGEX"))
+        assertFalse(cachedJson.contains("\"values\":{\"values\""))
+
+        val cacheProvider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = cachedJson,
+                shouldFetch = false,
+            )
+        val cacheFeatureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = cacheProvider,
+            )
+
+        cacheFeatureFlags.loadFeatureFlagDefinitions()
+        val cachedResult =
+            cacheFeatureFlags.getFeatureFlag(
+                key = "cohort-member",
+                defaultValue = false,
+                distinctId = "user-123",
+                personProperties = mapOf("email" to "example@example.com"),
+            )
+
+        assertEquals(true, cachedResult)
+        assertEquals(1, mockServer.requestCount)
+
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `flag definition cache data uses endpoint JSON with snake case group mapping`() {
         val logger = TestLogger()
         val mockServer = MockWebServer()

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -19,6 +19,8 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import java.io.StringReader
+import java.io.StringWriter
+import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -1571,6 +1573,80 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `loadFeatureFlagDefinitions falls back to API when provider get throws on cold load`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("get-error-fallback-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                shouldFetch = false,
+                throwOnGet = true,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(1, provider.getCalls)
+        assertEquals(0, provider.onReceivedCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("get-error-fallback-flag", false, "test-user"))
+        assertTrue(logger.containsLog("Error loading feature flag definitions from cache provider"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions keeps existing definitions when provider get throws after load`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("existing-after-get-error-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        provider.shouldFetch = false
+        provider.throwOnGet = true
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(1, provider.getCalls)
+        assertEquals(1, provider.onReceivedCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("existing-after-get-error-flag", false, "test-user"))
+        assertTrue(logger.containsLog("Error loading feature flag definitions from cache provider"))
+        assertTrue(logger.containsLog("keeping existing definitions"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `loadFeatureFlagDefinitions does not store definitions on 304 Not Modified`() {
         val logger = TestLogger()
         val localEvalResponse = createLocalEvaluationResponse("etag-cache-flag")
@@ -1599,6 +1675,280 @@ internal class PostHogFeatureFlagsTest {
 
         assertEquals(2, mockServer.requestCount)
         assertEquals(1, provider.onReceivedCalls)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions picks up updated cached definitions on subsequent polls`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheData(config, "cached-flag-v1"),
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        provider.cacheData = createFlagDefinitionCacheData(config, "cached-flag-v2")
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(0, mockServer.requestCount)
+        assertEquals(2, provider.shouldFetchCalls)
+        assertEquals(2, provider.getCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("cached-flag-v2", false, "test-user"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `cached group flag uses group type mapping from provider`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheData(config, "cached-group-flag", aggregationGroupTypeIndex = 2),
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        val result =
+            featureFlags.getFeatureFlag(
+                key = "cached-group-flag",
+                defaultValue = false,
+                distinctId = "user-123",
+                groups = mapOf("organization" to "org-456"),
+                groupProperties = mapOf("org-456" to mapOf("plan" to "enterprise")),
+            )
+
+        assertEquals(true, result)
+        assertEquals(0, mockServer.requestCount)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `cached inactive flag evaluates false without remote fallback`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val inactiveFlagJson = createLocalEvaluationResponse("inactive-cache-flag").replace("\"active\": true", "\"active\": false")
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheDataFromJson(config, inactiveFlagJson),
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        val result = featureFlags.getFeatureFlag("inactive-cache-flag", true, "test-user")
+
+        assertEquals(false, result)
+        assertEquals(0, mockServer.requestCount)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `cached cohort flag uses cohorts from provider`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheDataFromJson(config, createCohortLocalEvaluationResponse()),
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        val result =
+            featureFlags.getFeatureFlag(
+                key = "cohort-member",
+                defaultValue = false,
+                distinctId = "user-123",
+                personProperties = mapOf("email" to "example@example.com"),
+            )
+
+        assertEquals(true, result)
+        assertEquals(0, mockServer.requestCount)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `flag definition cache data round trips through JSON with snake case group mapping`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val writer = StringWriter()
+        config.serializer.serialize(createFlagDefinitionCacheData(config, "roundtrip-cache-flag"), writer)
+        val json = writer.toString()
+        val roundTrippedData =
+            config.serializer.deserialize<PostHogFlagDefinitionCacheData>(
+                StringReader(json),
+            )
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = roundTrippedData,
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertTrue(json.contains("group_type_mapping"))
+        assertEquals("account", roundTrippedData.groupTypeMapping["0"])
+        assertEquals(true, featureFlags.getFeatureFlag("roundtrip-cache-flag", false, "test-user"))
+        assertEquals(0, mockServer.requestCount)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `concurrent cache loads share one provider read`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheData(config, "concurrent-cache-flag"),
+                shouldFetch = false,
+                delayOnGetMs = 300,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+        val startLatch = CountDownLatch(1)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val threads =
+            (1..5).map {
+                Thread {
+                    try {
+                        startLatch.await()
+                        featureFlags.loadFeatureFlagDefinitions()
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    }
+                }
+            }
+
+        threads.forEach { it.start() }
+        startLatch.countDown()
+        threads.forEach { it.join() }
+
+        assertTrue(errors.isEmpty(), "Unexpected errors: $errors")
+        assertEquals(0, mockServer.requestCount)
+        assertEquals(1, provider.shouldFetchCalls)
+        assertEquals(1, provider.getCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("concurrent-cache-flag", false, "test-user"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `shutdown calls provider after definitions loaded from cache`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheData(config, "shutdown-cache-flag"),
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        featureFlags.shutDown()
+
+        assertEquals(0, mockServer.requestCount)
+        assertEquals(1, provider.shutdownCalls)
 
         mockServer.shutdown()
     }
@@ -1645,10 +1995,20 @@ internal class PostHogFeatureFlagsTest {
     private fun createFlagDefinitionCacheData(
         config: com.posthog.PostHogConfig,
         flagKey: String,
+        aggregationGroupTypeIndex: Int? = null,
+    ): PostHogFlagDefinitionCacheData =
+        createFlagDefinitionCacheDataFromJson(
+            config,
+            createLocalEvaluationResponse(flagKey, aggregationGroupTypeIndex = aggregationGroupTypeIndex),
+        )
+
+    private fun createFlagDefinitionCacheDataFromJson(
+        config: com.posthog.PostHogConfig,
+        json: String,
     ): PostHogFlagDefinitionCacheData {
         val response =
             config.serializer.deserialize<LocalEvaluationResponse>(
-                StringReader(createLocalEvaluationResponse(flagKey)),
+                StringReader(json),
             )
         return PostHogFlagDefinitionCacheData(
             flags = response.flags ?: emptyList(),
@@ -1657,13 +2017,99 @@ internal class PostHogFeatureFlagsTest {
         )
     }
 
+    private fun createCohortLocalEvaluationResponse(): String =
+        """
+        {
+            "flags": [
+                {
+                    "id": 26,
+                    "name": "Cohort Member",
+                    "key": "cohort-member",
+                    "active": true,
+                    "filters": {
+                        "groups": [
+                            {
+                                "properties": [
+                                    {
+                                        "key": "id",
+                                        "value": 2,
+                                        "operator": "in",
+                                        "type": "cohort",
+                                        "negation": false
+                                    }
+                                ],
+                                "rollout_percentage": 100
+                            }
+                        ]
+                    },
+                    "version": 2
+                }
+            ],
+            "group_type_mapping": {},
+            "cohorts": {
+                "2": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "operator": "not_regex",
+                                    "type": "person",
+                                    "value": "@hedgebox.net$"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "id",
+                                    "type": "cohort",
+                                    "negation": true,
+                                    "value": 3
+                                },
+                                {
+                                    "key": "email",
+                                    "operator": "is_set",
+                                    "type": "person",
+                                    "negation": false,
+                                    "value": "is_set"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "3": {
+                    "type": "OR",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "email",
+                                    "operator": "regex",
+                                    "type": "person",
+                                    "negation": false,
+                                    "value": "@gmail.com"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+        """.trimIndent()
+
     private class TestFlagDefinitionCacheProvider(
         var cacheData: PostHogFlagDefinitionCacheData? = null,
         var shouldFetch: Boolean = true,
-        private val throwOnShouldFetch: Boolean = false,
-        private val throwOnGet: Boolean = false,
-        private val throwOnReceived: Boolean = false,
-        private val throwOnShutdown: Boolean = false,
+        var throwOnShouldFetch: Boolean = false,
+        var throwOnGet: Boolean = false,
+        var throwOnReceived: Boolean = false,
+        var throwOnShutdown: Boolean = false,
+        var delayOnGetMs: Long = 0,
     ) : PostHogFlagDefinitionCacheProvider {
         var shouldFetchCalls = 0
         var getCalls = 0
@@ -1673,6 +2119,9 @@ internal class PostHogFeatureFlagsTest {
 
         override fun getFlagDefinitions(): PostHogFlagDefinitionCacheData? {
             getCalls += 1
+            if (delayOnGetMs > 0) {
+                Thread.sleep(delayOnGetMs)
+            }
             if (throwOnGet) {
                 throw IllegalStateException("get failed")
             }

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1,6 +1,7 @@
 package com.posthog.server.internal
 
 import com.posthog.internal.PostHogApi
+import com.posthog.server.PostHogBlockingFlagDefinitionCacheProvider
 import com.posthog.server.PostHogFlagDefinitionCacheProvider
 import com.posthog.server.TestLogger
 import com.posthog.server.createEmptyFlagsResponse
@@ -19,6 +20,8 @@ import okhttp3.mockwebserver.RecordedRequest
 import java.io.StringReader
 import java.io.StringWriter
 import java.util.Collections
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -1435,6 +1438,77 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `loadFeatureFlagDefinitions awaits async cached definitions when provider skips fetch`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val delegate =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheData(config, "async-cached-flag"),
+                shouldFetch = false,
+                delayOnGetMs = 50,
+            )
+        val provider = AsyncTestFlagDefinitionCacheProvider(delegate)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(0, mockServer.requestCount)
+        assertEquals(1, delegate.shouldFetchCalls)
+        assertEquals(1, delegate.getCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("async-cached-flag", false, "test-user"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions awaits async store when provider should fetch`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("async-api-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val delegate = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val provider = AsyncTestFlagDefinitionCacheProvider(delegate)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(1, delegate.shouldFetchCalls)
+        assertEquals(0, delegate.getCalls)
+        assertEquals(1, delegate.onReceivedCalls)
+        assertTrue(serializeFlagDefinitionCacheData(config, delegate.lastReceivedData).contains("\"key\":\"async-api-flag\""))
+        assertEquals(true, featureFlags.getFeatureFlag("async-api-flag", false, "test-user"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `loadFeatureFlagDefinitions fetches and stores definitions when provider should fetch`() {
         val logger = TestLogger()
         val mockServer =
@@ -2161,6 +2235,32 @@ internal class PostHogFeatureFlagsTest {
         }
         """.trimIndent()
 
+    private class AsyncTestFlagDefinitionCacheProvider(
+        private val delegate: TestFlagDefinitionCacheProvider,
+    ) : PostHogFlagDefinitionCacheProvider {
+        override fun getFlagDefinitions(): CompletionStage<Map<String, Any?>?> =
+            CompletableFuture.supplyAsync<Map<String, Any?>?> {
+                delegate.getFlagDefinitionsBlocking()
+            }
+
+        override fun shouldFetchFlagDefinitions(): CompletionStage<Boolean> =
+            CompletableFuture.supplyAsync<Boolean> {
+                delegate.shouldFetchFlagDefinitionsBlocking()
+            }
+
+        override fun onFlagDefinitionsReceived(data: Map<String, Any?>): CompletionStage<Void?> =
+            CompletableFuture.supplyAsync<Void?> {
+                delegate.onFlagDefinitionsReceivedBlocking(data)
+                null
+            }
+
+        override fun shutdown(): CompletionStage<Void?> =
+            CompletableFuture.supplyAsync<Void?> {
+                delegate.shutdownBlocking()
+                null
+            }
+    }
+
     private class TestFlagDefinitionCacheProvider(
         var cacheData: Map<String, Any?>? = null,
         var shouldFetch: Boolean = true,
@@ -2169,14 +2269,14 @@ internal class PostHogFeatureFlagsTest {
         var throwOnReceived: Boolean = false,
         var throwOnShutdown: Boolean = false,
         var delayOnGetMs: Long = 0,
-    ) : PostHogFlagDefinitionCacheProvider {
+    ) : PostHogBlockingFlagDefinitionCacheProvider() {
         var shouldFetchCalls = 0
         var getCalls = 0
         var onReceivedCalls = 0
         var shutdownCalls = 0
         var lastReceivedData: Map<String, Any?>? = null
 
-        override fun getFlagDefinitions(): Map<String, Any?>? {
+        override fun getFlagDefinitionsBlocking(): Map<String, Any?>? {
             getCalls += 1
             if (delayOnGetMs > 0) {
                 Thread.sleep(delayOnGetMs)
@@ -2187,7 +2287,7 @@ internal class PostHogFeatureFlagsTest {
             return cacheData
         }
 
-        override fun shouldFetchFlagDefinitions(): Boolean {
+        override fun shouldFetchFlagDefinitionsBlocking(): Boolean {
             shouldFetchCalls += 1
             if (throwOnShouldFetch) {
                 throw IllegalStateException("should fetch failed")
@@ -2195,7 +2295,7 @@ internal class PostHogFeatureFlagsTest {
             return shouldFetch
         }
 
-        override fun onFlagDefinitionsReceived(data: Map<String, Any?>) {
+        override fun onFlagDefinitionsReceivedBlocking(data: Map<String, Any?>) {
             onReceivedCalls += 1
             lastReceivedData = data
             if (throwOnReceived) {
@@ -2203,7 +2303,7 @@ internal class PostHogFeatureFlagsTest {
             }
         }
 
-        override fun shutdown() {
+        override fun shutdownBlocking() {
             shutdownCalls += 1
             if (throwOnShutdown) {
                 throw IllegalStateException("shutdown failed")

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1,6 +1,9 @@
 package com.posthog.server.internal
 
+import com.posthog.internal.LocalEvaluationResponse
 import com.posthog.internal.PostHogApi
+import com.posthog.server.PostHogFlagDefinitionCacheData
+import com.posthog.server.PostHogFlagDefinitionCacheProvider
 import com.posthog.server.TestLogger
 import com.posthog.server.createEmptyFlagsResponse
 import com.posthog.server.createFlagsResponse
@@ -15,6 +18,7 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import java.io.StringReader
 import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -1392,5 +1396,310 @@ internal class PostHogFeatureFlagsTest {
         assertEquals(true, result)
 
         mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions uses cached definitions when provider skips fetch`() {
+        val logger = TestLogger()
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                cacheData = createFlagDefinitionCacheData(config, "cached-flag"),
+                shouldFetch = false,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(0, mockServer.requestCount)
+        assertEquals(1, provider.shouldFetchCalls)
+        assertEquals(1, provider.getCalls)
+        assertEquals(0, provider.onReceivedCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("cached-flag", false, "test-user"))
+        assertTrue(logger.containsLog("Loaded 1 feature flags from flag definition cache"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions fetches and stores definitions when provider should fetch`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("api-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(1, provider.shouldFetchCalls)
+        assertEquals(0, provider.getCalls)
+        assertEquals(1, provider.onReceivedCalls)
+        assertEquals("api-flag", provider.lastReceivedData?.flags?.single()?.key)
+        assertEquals(true, featureFlags.getFeatureFlag("api-flag", false, "test-user"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions falls back to API on cold cache miss without storing as follower`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("fallback-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(shouldFetch = false)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(1, provider.getCalls)
+        assertEquals(0, provider.onReceivedCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("fallback-flag", false, "test-user"))
+        assertTrue(logger.containsLog("falling back to API"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions keeps existing definitions on follower cache miss`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("existing-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        provider.shouldFetch = false
+        provider.cacheData = null
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(2, provider.shouldFetchCalls)
+        assertEquals(1, provider.getCalls)
+        assertEquals(1, provider.onReceivedCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("existing-flag", false, "test-user"))
+        assertTrue(logger.containsLog("keeping existing definitions"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions defaults to API fetch when provider shouldFetch throws`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("api-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(throwOnShouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(1, mockServer.requestCount)
+        assertEquals(1, provider.onReceivedCalls)
+        assertEquals(true, featureFlags.getFeatureFlag("api-flag", false, "test-user"))
+        assertTrue(logger.containsLog("shouldFetchFlagDefinitions"))
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `loadFeatureFlagDefinitions does not store definitions on 304 Not Modified`() {
+        val logger = TestLogger()
+        val localEvalResponse = createLocalEvaluationResponse("etag-cache-flag")
+        val mockServer = MockWebServer()
+        mockServer.start()
+        mockServer.enqueue(jsonResponseWithEtag(localEvalResponse, "\"etag-cache\""))
+        mockServer.enqueue(notModifiedResponse("\"etag-cache\""))
+
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        featureFlags.loadFeatureFlagDefinitions()
+
+        assertEquals(2, mockServer.requestCount)
+        assertEquals(1, provider.onReceivedCalls)
+
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `provider write and shutdown errors are logged without clearing definitions`() {
+        val logger = TestLogger()
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("resilient-flag")),
+            )
+        val config = createTestConfig(logger, mockServer.url("/").toString())
+        val api = PostHogApi(config)
+        val provider =
+            TestFlagDefinitionCacheProvider(
+                shouldFetch = true,
+                throwOnReceived = true,
+                throwOnShutdown = true,
+            )
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = provider,
+            )
+
+        featureFlags.loadFeatureFlagDefinitions()
+        featureFlags.shutDown()
+
+        assertEquals(true, featureFlags.getFeatureFlag("resilient-flag", false, "test-user"))
+        assertEquals(1, provider.onReceivedCalls)
+        assertEquals(1, provider.shutdownCalls)
+        assertTrue(logger.containsLog("Error storing feature flag definitions in cache provider"))
+        assertTrue(logger.containsLog("Error shutting down flag definition cache provider"))
+
+        mockServer.shutdown()
+    }
+
+    private fun createFlagDefinitionCacheData(
+        config: com.posthog.PostHogConfig,
+        flagKey: String,
+    ): PostHogFlagDefinitionCacheData {
+        val response =
+            config.serializer.deserialize<LocalEvaluationResponse>(
+                StringReader(createLocalEvaluationResponse(flagKey)),
+            )
+        return PostHogFlagDefinitionCacheData(
+            flags = response.flags ?: emptyList(),
+            groupTypeMapping = response.groupTypeMapping ?: emptyMap(),
+            cohorts = response.cohorts ?: emptyMap(),
+        )
+    }
+
+    private class TestFlagDefinitionCacheProvider(
+        var cacheData: PostHogFlagDefinitionCacheData? = null,
+        var shouldFetch: Boolean = true,
+        private val throwOnShouldFetch: Boolean = false,
+        private val throwOnGet: Boolean = false,
+        private val throwOnReceived: Boolean = false,
+        private val throwOnShutdown: Boolean = false,
+    ) : PostHogFlagDefinitionCacheProvider {
+        var shouldFetchCalls = 0
+        var getCalls = 0
+        var onReceivedCalls = 0
+        var shutdownCalls = 0
+        var lastReceivedData: PostHogFlagDefinitionCacheData? = null
+
+        override fun getFlagDefinitions(): PostHogFlagDefinitionCacheData? {
+            getCalls += 1
+            if (throwOnGet) {
+                throw IllegalStateException("get failed")
+            }
+            return cacheData
+        }
+
+        override fun shouldFetchFlagDefinitions(): Boolean {
+            shouldFetchCalls += 1
+            if (throwOnShouldFetch) {
+                throw IllegalStateException("should fetch failed")
+            }
+            return shouldFetch
+        }
+
+        override fun onFlagDefinitionsReceived(data: PostHogFlagDefinitionCacheData) {
+            onReceivedCalls += 1
+            lastReceivedData = data
+            if (throwOnReceived) {
+                throw IllegalStateException("write failed")
+            }
+        }
+
+        override fun shutdown() {
+            shutdownCalls += 1
+            if (throwOnShutdown) {
+                throw IllegalStateException("shutdown failed")
+            }
+        }
     }
 }

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -16,6 +16,8 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import java.io.StringReader
+import java.io.StringWriter
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
@@ -1460,7 +1462,7 @@ internal class PostHogFeatureFlagsTest {
         assertEquals(1, provider.shouldFetchCalls)
         assertEquals(0, provider.getCalls)
         assertEquals(1, provider.onReceivedCalls)
-        assertTrue(provider.lastReceivedData?.contains("\"key\":\"api-flag\"") == true)
+        assertTrue(serializeFlagDefinitionCacheData(config, provider.lastReceivedData).contains("\"key\":\"api-flag\""))
         assertEquals(true, featureFlags.getFeatureFlag("api-flag", false, "test-user"))
 
         mockServer.shutdown()
@@ -1845,7 +1847,8 @@ internal class PostHogFeatureFlagsTest {
 
         featureFlags.loadFeatureFlagDefinitions()
 
-        val cachedJson = provider.lastReceivedData ?: ""
+        val cachedData = provider.lastReceivedData
+        val cachedJson = serializeFlagDefinitionCacheData(config, cachedData)
         assertTrue(cachedJson.contains("\"group_type_mapping\":"))
         assertTrue(cachedJson.contains("\"operator\":\"not_regex\""))
         assertTrue(cachedJson.contains("\"type\":\"person\""))
@@ -1855,7 +1858,7 @@ internal class PostHogFeatureFlagsTest {
 
         val cacheProvider =
             TestFlagDefinitionCacheProvider(
-                cacheData = cachedJson,
+                cacheData = roundTripFlagDefinitionCacheData(config, cachedData),
                 shouldFetch = false,
             )
         val cacheFeatureFlags =
@@ -1891,11 +1894,12 @@ internal class PostHogFeatureFlagsTest {
         val mockServer = MockWebServer()
         mockServer.start()
         val config = createTestConfig(logger, mockServer.url("/").toString())
-        val json = createFlagDefinitionCacheData(config, "roundtrip-cache-flag")
+        val data = createFlagDefinitionCacheData(config, "roundtrip-cache-flag")
+        val json = serializeFlagDefinitionCacheData(config, data)
         val api = PostHogApi(config)
         val provider =
             TestFlagDefinitionCacheProvider(
-                cacheData = json,
+                cacheData = data,
                 shouldFetch = false,
             )
         val featureFlags =
@@ -2047,7 +2051,7 @@ internal class PostHogFeatureFlagsTest {
         config: com.posthog.PostHogConfig,
         flagKey: String,
         aggregationGroupTypeIndex: Int? = null,
-    ): String =
+    ): Map<String, Any?> =
         createFlagDefinitionCacheDataFromJson(
             config,
             createLocalEvaluationResponse(flagKey, aggregationGroupTypeIndex = aggregationGroupTypeIndex),
@@ -2056,7 +2060,21 @@ internal class PostHogFeatureFlagsTest {
     private fun createFlagDefinitionCacheDataFromJson(
         config: com.posthog.PostHogConfig,
         json: String,
-    ): String = json
+    ): Map<String, Any?> = config.serializer.deserialize(StringReader(json))
+
+    private fun serializeFlagDefinitionCacheData(
+        config: com.posthog.PostHogConfig,
+        data: Map<String, Any?>?,
+    ): String {
+        val writer = StringWriter()
+        config.serializer.serialize(data ?: emptyMap<String, Any?>(), writer)
+        return writer.toString()
+    }
+
+    private fun roundTripFlagDefinitionCacheData(
+        config: com.posthog.PostHogConfig,
+        data: Map<String, Any?>?,
+    ): Map<String, Any?> = config.serializer.deserialize(StringReader(serializeFlagDefinitionCacheData(config, data)))
 
     private fun createCohortLocalEvaluationResponse(): String =
         """
@@ -2144,7 +2162,7 @@ internal class PostHogFeatureFlagsTest {
         """.trimIndent()
 
     private class TestFlagDefinitionCacheProvider(
-        var cacheData: String? = null,
+        var cacheData: Map<String, Any?>? = null,
         var shouldFetch: Boolean = true,
         var throwOnShouldFetch: Boolean = false,
         var throwOnGet: Boolean = false,
@@ -2156,9 +2174,9 @@ internal class PostHogFeatureFlagsTest {
         var getCalls = 0
         var onReceivedCalls = 0
         var shutdownCalls = 0
-        var lastReceivedData: String? = null
+        var lastReceivedData: Map<String, Any?>? = null
 
-        override fun getFlagDefinitions(): String? {
+        override fun getFlagDefinitions(): Map<String, Any?>? {
             getCalls += 1
             if (delayOnGetMs > 0) {
                 Thread.sleep(delayOnGetMs)
@@ -2177,7 +2195,7 @@ internal class PostHogFeatureFlagsTest {
             return shouldFetch
         }
 
-        override fun onFlagDefinitionsReceived(data: String) {
+        override fun onFlagDefinitionsReceived(data: Map<String, Any?>) {
             onReceivedCalls += 1
             lastReceivedData = data
             if (throwOnReceived) {

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1,8 +1,6 @@
 package com.posthog.server.internal
 
-import com.posthog.internal.LocalEvaluationResponse
 import com.posthog.internal.PostHogApi
-import com.posthog.server.PostHogFlagDefinitionCacheData
 import com.posthog.server.PostHogFlagDefinitionCacheProvider
 import com.posthog.server.TestLogger
 import com.posthog.server.createEmptyFlagsResponse
@@ -18,8 +16,6 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
-import java.io.StringReader
-import java.io.StringWriter
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import kotlin.test.Test
@@ -1464,7 +1460,7 @@ internal class PostHogFeatureFlagsTest {
         assertEquals(1, provider.shouldFetchCalls)
         assertEquals(0, provider.getCalls)
         assertEquals(1, provider.onReceivedCalls)
-        assertEquals("api-flag", provider.lastReceivedData?.flags?.single()?.key)
+        assertTrue(provider.lastReceivedData?.contains("\"key\":\"api-flag\"") == true)
         assertEquals(true, featureFlags.getFeatureFlag("api-flag", false, "test-user"))
 
         mockServer.shutdown()
@@ -1829,22 +1825,16 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
-    fun `flag definition cache data round trips through JSON with snake case group mapping`() {
+    fun `flag definition cache data uses endpoint JSON with snake case group mapping`() {
         val logger = TestLogger()
         val mockServer = MockWebServer()
         mockServer.start()
         val config = createTestConfig(logger, mockServer.url("/").toString())
-        val writer = StringWriter()
-        config.serializer.serialize(createFlagDefinitionCacheData(config, "roundtrip-cache-flag"), writer)
-        val json = writer.toString()
-        val roundTrippedData =
-            config.serializer.deserialize<PostHogFlagDefinitionCacheData>(
-                StringReader(json),
-            )
+        val json = createFlagDefinitionCacheData(config, "roundtrip-cache-flag")
         val api = PostHogApi(config)
         val provider =
             TestFlagDefinitionCacheProvider(
-                cacheData = roundTrippedData,
+                cacheData = json,
                 shouldFetch = false,
             )
         val featureFlags =
@@ -1862,7 +1852,7 @@ internal class PostHogFeatureFlagsTest {
         featureFlags.loadFeatureFlagDefinitions()
 
         assertTrue(json.contains("group_type_mapping"))
-        assertEquals("account", roundTrippedData.groupTypeMapping["0"])
+        assertFalse(json.contains("groupTypeMapping"))
         assertEquals(true, featureFlags.getFeatureFlag("roundtrip-cache-flag", false, "test-user"))
         assertEquals(0, mockServer.requestCount)
 
@@ -1996,7 +1986,7 @@ internal class PostHogFeatureFlagsTest {
         config: com.posthog.PostHogConfig,
         flagKey: String,
         aggregationGroupTypeIndex: Int? = null,
-    ): PostHogFlagDefinitionCacheData =
+    ): String =
         createFlagDefinitionCacheDataFromJson(
             config,
             createLocalEvaluationResponse(flagKey, aggregationGroupTypeIndex = aggregationGroupTypeIndex),
@@ -2005,17 +1995,7 @@ internal class PostHogFeatureFlagsTest {
     private fun createFlagDefinitionCacheDataFromJson(
         config: com.posthog.PostHogConfig,
         json: String,
-    ): PostHogFlagDefinitionCacheData {
-        val response =
-            config.serializer.deserialize<LocalEvaluationResponse>(
-                StringReader(json),
-            )
-        return PostHogFlagDefinitionCacheData(
-            flags = response.flags ?: emptyList(),
-            groupTypeMapping = response.groupTypeMapping ?: emptyMap(),
-            cohorts = response.cohorts ?: emptyMap(),
-        )
-    }
+    ): String = json
 
     private fun createCohortLocalEvaluationResponse(): String =
         """
@@ -2103,7 +2083,7 @@ internal class PostHogFeatureFlagsTest {
         """.trimIndent()
 
     private class TestFlagDefinitionCacheProvider(
-        var cacheData: PostHogFlagDefinitionCacheData? = null,
+        var cacheData: String? = null,
         var shouldFetch: Boolean = true,
         var throwOnShouldFetch: Boolean = false,
         var throwOnGet: Boolean = false,
@@ -2115,9 +2095,9 @@ internal class PostHogFeatureFlagsTest {
         var getCalls = 0
         var onReceivedCalls = 0
         var shutdownCalls = 0
-        var lastReceivedData: PostHogFlagDefinitionCacheData? = null
+        var lastReceivedData: String? = null
 
-        override fun getFlagDefinitions(): PostHogFlagDefinitionCacheData? {
+        override fun getFlagDefinitions(): String? {
             getCalls += 1
             if (delayOnGetMs > 0) {
                 Thread.sleep(delayOnGetMs)
@@ -2136,7 +2116,7 @@ internal class PostHogFeatureFlagsTest {
             return shouldFetch
         }
 
-        override fun onFlagDefinitionsReceived(data: PostHogFlagDefinitionCacheData) {
+        override fun onFlagDefinitionsReceived(data: String) {
             onReceivedCalls += 1
             lastReceivedData = data
             if (throwOnReceived) {

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1543,179 +1543,80 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
-    fun `loadFeatureFlagDefinitions falls back to API on cold cache miss without storing as follower`() {
-        val logger = TestLogger()
-        val mockServer =
-            createMockHttp(
-                jsonResponse(createLocalEvaluationResponse("fallback-flag")),
-            )
-        val config = createTestConfig(logger, mockServer.url("/").toString())
-        val api = PostHogApi(config)
-        val provider = TestFlagDefinitionCacheProvider(shouldFetch = false)
-        val featureFlags =
-            PostHogFeatureFlags(
-                config,
-                api,
-                60000,
-                100,
-                localEvaluation = true,
-                personalApiKey = "test-personal-key",
-                pollerEnabled = false,
-                flagDefinitionCacheProvider = provider,
-            )
+    fun `loadFeatureFlagDefinitions API fallback cases keep local evaluation available`() {
+        flagDefinitionCacheApiFallbackCases.forEach { testCase ->
+            val logger = TestLogger()
+            val mockServer =
+                createMockHttp(
+                    jsonResponse(createLocalEvaluationResponse(testCase.flagKey)),
+                )
+            val config = createTestConfig(logger, mockServer.url("/").toString())
+            val api = PostHogApi(config)
+            val provider = TestFlagDefinitionCacheProvider().apply(testCase.configureProvider)
+            val featureFlags =
+                PostHogFeatureFlags(
+                    config,
+                    api,
+                    60000,
+                    100,
+                    localEvaluation = true,
+                    personalApiKey = "test-personal-key",
+                    pollerEnabled = false,
+                    flagDefinitionCacheProvider = provider,
+                )
 
-        featureFlags.loadFeatureFlagDefinitions()
+            featureFlags.loadFeatureFlagDefinitions()
 
-        assertEquals(1, mockServer.requestCount)
-        assertEquals(1, provider.getCalls)
-        assertEquals(0, provider.onReceivedCalls)
-        assertEquals(true, featureFlags.getFeatureFlag("fallback-flag", false, "test-user"))
-        assertTrue(logger.containsLog("falling back to API"))
+            assertEquals(1, mockServer.requestCount, "${testCase.name}: request count")
+            assertEquals(1, provider.shouldFetchCalls, "${testCase.name}: shouldFetch calls")
+            assertEquals(testCase.expectedGetCalls, provider.getCalls, "${testCase.name}: get calls")
+            assertEquals(testCase.expectedOnReceivedCalls, provider.onReceivedCalls, "${testCase.name}: onReceived calls")
+            assertEquals(true, featureFlags.getFeatureFlag(testCase.flagKey, false, "test-user"), "${testCase.name}: flag result")
+            assertTrue(logger.containsLog(testCase.expectedLog), "${testCase.name}: expected log")
 
-        mockServer.shutdown()
+            mockServer.shutdown()
+        }
     }
 
     @Test
-    fun `loadFeatureFlagDefinitions keeps existing definitions on follower cache miss`() {
-        val logger = TestLogger()
-        val mockServer =
-            createMockHttp(
-                jsonResponse(createLocalEvaluationResponse("existing-flag")),
-            )
-        val config = createTestConfig(logger, mockServer.url("/").toString())
-        val api = PostHogApi(config)
-        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
-        val featureFlags =
-            PostHogFeatureFlags(
-                config,
-                api,
-                60000,
-                100,
-                localEvaluation = true,
-                personalApiKey = "test-personal-key",
-                pollerEnabled = false,
-                flagDefinitionCacheProvider = provider,
-            )
+    fun `loadFeatureFlagDefinitions keeps existing definitions when follower cache is unavailable`() {
+        flagDefinitionCacheKeepExistingCases.forEach { testCase ->
+            val logger = TestLogger()
+            val mockServer =
+                createMockHttp(
+                    jsonResponse(createLocalEvaluationResponse(testCase.flagKey)),
+                )
+            val config = createTestConfig(logger, mockServer.url("/").toString())
+            val api = PostHogApi(config)
+            val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
+            val featureFlags =
+                PostHogFeatureFlags(
+                    config,
+                    api,
+                    60000,
+                    100,
+                    localEvaluation = true,
+                    personalApiKey = "test-personal-key",
+                    pollerEnabled = false,
+                    flagDefinitionCacheProvider = provider,
+                )
 
-        featureFlags.loadFeatureFlagDefinitions()
-        provider.shouldFetch = false
-        provider.cacheData = null
-        featureFlags.loadFeatureFlagDefinitions()
+            featureFlags.loadFeatureFlagDefinitions()
+            provider.apply(testCase.configureProviderAfterWarmLoad)
+            featureFlags.loadFeatureFlagDefinitions()
 
-        assertEquals(1, mockServer.requestCount)
-        assertEquals(2, provider.shouldFetchCalls)
-        assertEquals(1, provider.getCalls)
-        assertEquals(1, provider.onReceivedCalls)
-        assertEquals(true, featureFlags.getFeatureFlag("existing-flag", false, "test-user"))
-        assertTrue(logger.containsLog("keeping existing definitions"))
+            assertEquals(1, mockServer.requestCount, "${testCase.name}: request count")
+            assertEquals(2, provider.shouldFetchCalls, "${testCase.name}: shouldFetch calls")
+            assertEquals(1, provider.getCalls, "${testCase.name}: get calls")
+            assertEquals(1, provider.onReceivedCalls, "${testCase.name}: onReceived calls")
+            assertEquals(true, featureFlags.getFeatureFlag(testCase.flagKey, false, "test-user"), "${testCase.name}: flag result")
+            assertTrue(logger.containsLog("keeping existing definitions"), "${testCase.name}: expected stale-definition log")
+            testCase.expectedAdditionalLog?.let {
+                assertTrue(logger.containsLog(it), "${testCase.name}: expected additional log")
+            }
 
-        mockServer.shutdown()
-    }
-
-    @Test
-    fun `loadFeatureFlagDefinitions defaults to API fetch when provider shouldFetch throws`() {
-        val logger = TestLogger()
-        val mockServer =
-            createMockHttp(
-                jsonResponse(createLocalEvaluationResponse("api-flag")),
-            )
-        val config = createTestConfig(logger, mockServer.url("/").toString())
-        val api = PostHogApi(config)
-        val provider = TestFlagDefinitionCacheProvider(throwOnShouldFetch = true)
-        val featureFlags =
-            PostHogFeatureFlags(
-                config,
-                api,
-                60000,
-                100,
-                localEvaluation = true,
-                personalApiKey = "test-personal-key",
-                pollerEnabled = false,
-                flagDefinitionCacheProvider = provider,
-            )
-
-        featureFlags.loadFeatureFlagDefinitions()
-
-        assertEquals(1, mockServer.requestCount)
-        assertEquals(1, provider.onReceivedCalls)
-        assertEquals(true, featureFlags.getFeatureFlag("api-flag", false, "test-user"))
-        assertTrue(logger.containsLog("shouldFetchFlagDefinitions"))
-
-        mockServer.shutdown()
-    }
-
-    @Test
-    fun `loadFeatureFlagDefinitions falls back to API when provider get throws on cold load`() {
-        val logger = TestLogger()
-        val mockServer =
-            createMockHttp(
-                jsonResponse(createLocalEvaluationResponse("get-error-fallback-flag")),
-            )
-        val config = createTestConfig(logger, mockServer.url("/").toString())
-        val api = PostHogApi(config)
-        val provider =
-            TestFlagDefinitionCacheProvider(
-                shouldFetch = false,
-                throwOnGet = true,
-            )
-        val featureFlags =
-            PostHogFeatureFlags(
-                config,
-                api,
-                60000,
-                100,
-                localEvaluation = true,
-                personalApiKey = "test-personal-key",
-                pollerEnabled = false,
-                flagDefinitionCacheProvider = provider,
-            )
-
-        featureFlags.loadFeatureFlagDefinitions()
-
-        assertEquals(1, mockServer.requestCount)
-        assertEquals(1, provider.getCalls)
-        assertEquals(0, provider.onReceivedCalls)
-        assertEquals(true, featureFlags.getFeatureFlag("get-error-fallback-flag", false, "test-user"))
-        assertTrue(logger.containsLog("Error loading feature flag definitions from cache provider"))
-
-        mockServer.shutdown()
-    }
-
-    @Test
-    fun `loadFeatureFlagDefinitions keeps existing definitions when provider get throws after load`() {
-        val logger = TestLogger()
-        val mockServer =
-            createMockHttp(
-                jsonResponse(createLocalEvaluationResponse("existing-after-get-error-flag")),
-            )
-        val config = createTestConfig(logger, mockServer.url("/").toString())
-        val api = PostHogApi(config)
-        val provider = TestFlagDefinitionCacheProvider(shouldFetch = true)
-        val featureFlags =
-            PostHogFeatureFlags(
-                config,
-                api,
-                60000,
-                100,
-                localEvaluation = true,
-                personalApiKey = "test-personal-key",
-                pollerEnabled = false,
-                flagDefinitionCacheProvider = provider,
-            )
-
-        featureFlags.loadFeatureFlagDefinitions()
-        provider.shouldFetch = false
-        provider.throwOnGet = true
-        featureFlags.loadFeatureFlagDefinitions()
-
-        assertEquals(1, mockServer.requestCount)
-        assertEquals(1, provider.getCalls)
-        assertEquals(1, provider.onReceivedCalls)
-        assertEquals(true, featureFlags.getFeatureFlag("existing-after-get-error-flag", false, "test-user"))
-        assertTrue(logger.containsLog("Error loading feature flag definitions from cache provider"))
-        assertTrue(logger.containsLog("keeping existing definitions"))
-
-        mockServer.shutdown()
+            mockServer.shutdown()
+        }
     }
 
     @Test
@@ -2234,6 +2135,74 @@ internal class PostHogFeatureFlagsTest {
             }
         }
         """.trimIndent()
+
+    private data class FlagDefinitionCacheApiFallbackCase(
+        val name: String,
+        val flagKey: String,
+        val configureProvider: TestFlagDefinitionCacheProvider.() -> Unit,
+        val expectedGetCalls: Int,
+        val expectedOnReceivedCalls: Int,
+        val expectedLog: String,
+    )
+
+    private data class FlagDefinitionCacheKeepExistingCase(
+        val name: String,
+        val flagKey: String,
+        val configureProviderAfterWarmLoad: TestFlagDefinitionCacheProvider.() -> Unit,
+        val expectedAdditionalLog: String? = null,
+    )
+
+    private val flagDefinitionCacheApiFallbackCases =
+        listOf(
+            FlagDefinitionCacheApiFallbackCase(
+                name = "cold cache miss",
+                flagKey = "fallback-flag",
+                configureProvider = { shouldFetch = false },
+                expectedGetCalls = 1,
+                expectedOnReceivedCalls = 0,
+                expectedLog = "falling back to API",
+            ),
+            FlagDefinitionCacheApiFallbackCase(
+                name = "shouldFetch throws",
+                flagKey = "api-flag",
+                configureProvider = { throwOnShouldFetch = true },
+                expectedGetCalls = 0,
+                expectedOnReceivedCalls = 1,
+                expectedLog = "shouldFetchFlagDefinitions",
+            ),
+            FlagDefinitionCacheApiFallbackCase(
+                name = "cache read throws on cold load",
+                flagKey = "get-error-fallback-flag",
+                configureProvider = {
+                    shouldFetch = false
+                    throwOnGet = true
+                },
+                expectedGetCalls = 1,
+                expectedOnReceivedCalls = 0,
+                expectedLog = "Error loading feature flag definitions from cache provider",
+            ),
+        )
+
+    private val flagDefinitionCacheKeepExistingCases =
+        listOf(
+            FlagDefinitionCacheKeepExistingCase(
+                name = "cache miss after warm load",
+                flagKey = "existing-flag",
+                configureProviderAfterWarmLoad = {
+                    shouldFetch = false
+                    cacheData = null
+                },
+            ),
+            FlagDefinitionCacheKeepExistingCase(
+                name = "cache read throws after warm load",
+                flagKey = "existing-after-get-error-flag",
+                configureProviderAfterWarmLoad = {
+                    shouldFetch = false
+                    throwOnGet = true
+                },
+                expectedAdditionalLog = "Error loading feature flag definitions from cache provider",
+            ),
+        )
 
     private class AsyncTestFlagDefinitionCacheProvider(
         private val delegate: TestFlagDefinitionCacheProvider,

--- a/posthog/src/main/java/com/posthog/internal/GsonPropertyOperatorAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/GsonPropertyOperatorAdapter.kt
@@ -3,10 +3,14 @@ package com.posthog.internal
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import java.lang.reflect.Type
 
 internal class GsonPropertyOperatorAdapter :
-    JsonDeserializer<PropertyOperator> {
+    JsonDeserializer<PropertyOperator>,
+    JsonSerializer<PropertyOperator> {
     override fun deserialize(
         json: JsonElement,
         typeOfT: Type,
@@ -14,4 +18,42 @@ internal class GsonPropertyOperatorAdapter :
     ): PropertyOperator? {
         return PropertyOperator.fromStringOrNull(json.asString)
     }
+
+    override fun serialize(
+        src: PropertyOperator?,
+        typeOfSrc: Type,
+        context: JsonSerializationContext,
+    ): JsonElement? {
+        return src?.let { JsonPrimitive(it.toApiString()) }
+    }
+
+    private fun PropertyOperator.toApiString(): String =
+        when (this) {
+            PropertyOperator.UNKNOWN -> "unknown"
+            PropertyOperator.EXACT -> "exact"
+            PropertyOperator.IS_NOT -> "is_not"
+            PropertyOperator.IS_SET -> "is_set"
+            PropertyOperator.IS_NOT_SET -> "is_not_set"
+            PropertyOperator.ICONTAINS -> "icontains"
+            PropertyOperator.NOT_ICONTAINS -> "not_icontains"
+            PropertyOperator.REGEX -> "regex"
+            PropertyOperator.NOT_REGEX -> "not_regex"
+            PropertyOperator.IN -> "in"
+            PropertyOperator.GT -> "gt"
+            PropertyOperator.GTE -> "gte"
+            PropertyOperator.LT -> "lt"
+            PropertyOperator.LTE -> "lte"
+            PropertyOperator.IS_DATE_BEFORE -> "is_date_before"
+            PropertyOperator.IS_DATE_AFTER -> "is_date_after"
+            PropertyOperator.FLAG_EVALUATES_TO -> "flag_evaluates_to"
+            PropertyOperator.SEMVER_EQ -> "semver_eq"
+            PropertyOperator.SEMVER_NEQ -> "semver_neq"
+            PropertyOperator.SEMVER_GT -> "semver_gt"
+            PropertyOperator.SEMVER_GTE -> "semver_gte"
+            PropertyOperator.SEMVER_LT -> "semver_lt"
+            PropertyOperator.SEMVER_LTE -> "semver_lte"
+            PropertyOperator.SEMVER_TILDE -> "semver_tilde"
+            PropertyOperator.SEMVER_CARET -> "semver_caret"
+            PropertyOperator.SEMVER_WILDCARD -> "semver_wildcard"
+        }
 }

--- a/posthog/src/main/java/com/posthog/internal/GsonPropertyTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/GsonPropertyTypeAdapter.kt
@@ -3,10 +3,14 @@ package com.posthog.internal
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import java.lang.reflect.Type
 
 internal class GsonPropertyTypeAdapter :
-    JsonDeserializer<PropertyType> {
+    JsonDeserializer<PropertyType>,
+    JsonSerializer<PropertyType> {
     override fun deserialize(
         json: JsonElement,
         typeOfT: Type,
@@ -14,4 +18,19 @@ internal class GsonPropertyTypeAdapter :
     ): PropertyType? {
         return PropertyType.fromStringOrNull(json.asString)
     }
+
+    override fun serialize(
+        src: PropertyType?,
+        typeOfSrc: Type,
+        context: JsonSerializationContext,
+    ): JsonElement? {
+        return src?.let { JsonPrimitive(it.toApiString()) }
+    }
+
+    private fun PropertyType.toApiString(): String =
+        when (this) {
+            PropertyType.COHORT -> "cohort"
+            PropertyType.FLAG -> "flag"
+            PropertyType.PERSON -> "person"
+        }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationDeserializers.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationDeserializers.kt
@@ -3,6 +3,8 @@ package com.posthog.internal
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
 import com.google.gson.stream.MalformedJsonException
 import com.posthog.PostHogInternal
 import java.lang.reflect.Type
@@ -154,5 +156,27 @@ public class PropertyValueDeserializer : JsonDeserializer<PropertyValue> {
             negation = negation,
             dependencyChain = dependencyChain,
         )
+    }
+}
+
+internal class GsonPropertyValueAdapter : JsonDeserializer<PropertyValue>, JsonSerializer<PropertyValue> {
+    private val deserializer = PropertyValueDeserializer()
+
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext,
+    ): PropertyValue? = deserializer.deserialize(json, typeOfT, context)
+
+    override fun serialize(
+        src: PropertyValue?,
+        typeOfSrc: Type,
+        context: JsonSerializationContext,
+    ): JsonElement? {
+        return when (src) {
+            is PropertyValue.FlagProperties -> context.serialize(src.values)
+            is PropertyValue.PropertyGroups -> context.serialize(src.values)
+            null -> null
+        }
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogSerializer.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogSerializer.kt
@@ -78,7 +78,7 @@ public class PostHogSerializer(private val config: PostHogConfig) {
             registerTypeAdapter(SurveyQuestionBranching::class.java, GsonSurveyQuestionBranchingAdapter(config))
             // local evaluation
             registerTypeAdapter(PropertyGroup::class.java, PropertyGroupDeserializer())
-            registerTypeAdapter(PropertyValue::class.java, PropertyValueDeserializer())
+            registerTypeAdapter(PropertyValue::class.java, GsonPropertyValueAdapter())
             registerTypeAdapter(PropertyOperator::class.java, GsonPropertyOperatorAdapter())
             registerTypeAdapter(PropertyType::class.java, GsonPropertyTypeAdapter())
         }.create()


### PR DESCRIPTION
## :bulb: Motivation and Context

Adds the ability to integrate custom caching for local-evaluation feature flag definitions in `posthog-server`, matching the shared flag definition cache provider pattern available in other server SDKs.

This lets multiple server SDK instances coordinate definition fetching: one instance can fetch fresh definitions and publish them to a shared cache while others read definitions from that cache. The provider API is async-capable via `CompletionStage`, with `PostHogBlockingFlagDefinitionCacheProvider` for synchronous cache backends.

This also updates core local-evaluation serialization so cached definitions round-trip using endpoint-compatible JSON for nested property values, property operators, and property types.

## :green_heart: How did you test it?

- `./gradlew spotlessCheck :posthog-server:apiCheck :posthog-server:test --tests "com.posthog.server.internal.PostHogFeatureFlagsTest" --tests "com.posthog.server.PostHogConfigTest"`
- `./gradlew :posthog-server:test`
- Java compile/runtime smoke for both `PostHogFlagDefinitionCacheProvider` and `PostHogBlockingFlagDefinitionCacheProvider`
- Live PostHog Cloud smoke against `/flags/definitions` with an async provider:
  - `run_id=real-ph-android-provider-live-1780672229570`
  - leader fetched and stored definitions
  - follower loaded definitions from cache without a valid API host and did not write back

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
