### PR TITLE
fix: always invoke reloadFeatureFlags callback

### DIFF
--- a/.changeset/reload-flags-callback-contract.md
+++ b/.changeset/reload-flags-callback-contract.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+`reloadFeatureFlags` now always invokes its completion callback, including when the SDK is disabled/opted-out or the distinct ID is blank. Previously these early-returns skipped the callback, which could leave callers that await it (e.g. the Flutter SDK's `reloadFeatureFlags`) hanging indefinitely.

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1249,10 +1249,19 @@ public class PostHog private constructor(
         }
     }
 
+    // Invokes the feature flags callback, swallowing exceptions like runOnFeatureFlagsCallbacks.
+    private fun notifyFeatureFlagsCallback(onFeatureFlags: PostHogOnFeatureFlags?) {
+        try {
+            onFeatureFlags?.loaded()
+        } catch (e: Throwable) {
+            config?.logger?.log("Executing the feature flags callback failed: $e")
+        }
+    }
+
     public override fun reloadFeatureFlags(onFeatureFlags: PostHogOnFeatureFlags?) {
         if (!isEnabled()) {
             // Still invoke the callback so awaiting callers aren't left hanging.
-            onFeatureFlags?.loaded()
+            notifyFeatureFlagsCallback(onFeatureFlags)
             return
         }
         loadFeatureFlagsRequest(
@@ -1278,7 +1287,7 @@ public class PostHog private constructor(
         if (distinctId.isBlank()) {
             config?.logger?.log("Feature flags not loaded, distinctId is invalid: $distinctId")
             // Still invoke the callback so awaiting callers aren't left hanging.
-            onFeatureFlags?.loaded()
+            notifyFeatureFlagsCallback(onFeatureFlags)
             return
         }
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1251,6 +1251,8 @@ public class PostHog private constructor(
 
     public override fun reloadFeatureFlags(onFeatureFlags: PostHogOnFeatureFlags?) {
         if (!isEnabled()) {
+            // Still invoke the callback so awaiting callers aren't left hanging.
+            onFeatureFlags?.loaded()
             return
         }
         loadFeatureFlagsRequest(
@@ -1275,6 +1277,8 @@ public class PostHog private constructor(
 
         if (distinctId.isBlank()) {
             config?.logger?.log("Feature flags not loaded, distinctId is invalid: $distinctId")
+            // Still invoke the callback so awaiting callers aren't left hanging.
+            onFeatureFlags?.loaded()
             return
         }
 

--- a/posthog/src/test/java/com/posthog/PostHogFeatureFlagsTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogFeatureFlagsTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 internal class PostHogFeatureFlagsTest {
     @get:Rule
@@ -373,5 +374,20 @@ internal class PostHogFeatureFlagsTest {
         assertEquals(defaultValue, theEvent?.properties!!["\$feature_flag_response"])
         assertEquals("nonExistentFlag", theEvent.properties!!["\$feature_flag"])
         sut.close()
+    }
+
+    @Test
+    fun `reloadFeatureFlags invokes callback when not enabled`() {
+        val http = mockHttp()
+        val url = http.url("/")
+        val sut = getSut(url.toString(), preloadFeatureFlags = false)
+        sut.close()
+
+        var called = false
+        sut.reloadFeatureFlags { called = true }
+
+        // isEnabled() is false after close(), so reloadFeatureFlags early-returns. The
+        // callback must still fire (synchronously) rather than leave awaiting callers hanging.
+        assertTrue(called)
     }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

https://posthoghelp.zendesk.com/agent/tickets/58925 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61593)

`reloadFeatureFlags(onFeatureFlags)` promises to invoke `onFeatureFlags` when the reload finishes, but several early-returns skipped it:

- `if (!isEnabled())` — SDK disabled or opted-out
- `if (distinctId.isBlank())` in `loadFeatureFlagsRequest`

When the callback is never invoked, any caller awaiting it stalls. This surfaced via the Flutter SDK, whose `reloadFeatureFlags()` returns a `Future` that completes from this callback — `await Posthog().reloadFeatureFlags()` would hang forever in those states. (Once execution reaches the network load, the callback already fires on every outcome via `executeFeatureFlags`, so only the front-door guards were affected.)

## :green_heart: How did you test it?

`./gradlew :posthog:compileKotlin` passes. Existing `reloadFeatureFlags` behavior is unchanged on the normal path; the change only adds the callback invocation to the two guard returns. Happy to add a unit test asserting the callback fires when `!isEnabled()` if preferred.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
