### PR TITLE
fix: keep session replay active across identify/reset

### DIFF
--- a/.changeset/session-replay-rearm-after-identity.md
+++ b/.changeset/session-replay-rearm-after-identity.md
@@ -1,5 +1,6 @@
 ---
 "posthog": patch
+"posthog-android": patch
 ---
 
 Keep session replay recording active after an in-session `identify()`/`reset()` instead of disabling it until the next app restart.

--- a/.changeset/session-replay-rearm-after-identity.md
+++ b/.changeset/session-replay-rearm-after-identity.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Keep session replay recording active after an in-session `identify()`/`reset()` instead of disabling it until the next app restart.

--- a/.changeset/session-replay-rearm-after-identity.md
+++ b/.changeset/session-replay-rearm-after-identity.md
@@ -3,4 +3,4 @@
 "posthog-android": patch
 ---
 
-Keep session replay recording active after an in-session `identify()`/`reset()` instead of disabling it until the next app restart.
+Keep session replay, error tracking, and network performance capture active after an in-session `identify()`/`reset()` instead of disabling them until the next app restart.

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -115,8 +115,6 @@ internal class PostHogSharedPreferences(
         val edit = sharedPreferences.edit()
 
         synchronized(lock) {
-            // Keep STRINGIFIED_KEYS in sync with what survives so preserved serialized values
-            // (e.g. SESSION_REPLAY) still deserialize on read.
             val survivingStringifiedKeys = getStringifiedKeys().filterTo(mutableSetOf()) { except.contains(it) }
 
             val it = sharedPreferences.all.iterator()

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -122,6 +122,7 @@ internal class PostHogSharedPreferences(
             val it = sharedPreferences.all.iterator()
             while (it.hasNext()) {
                 val entry = it.next()
+                // STRINGIFIED_KEYS is metadata, rebuilt below; never let the data loop remove it.
                 if (entry.key == STRINGIFIED_KEYS || except.contains(entry.key)) {
                     continue
                 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -119,8 +119,9 @@ internal class PostHogSharedPreferences(
             // It is itself a stored key, so it is excluded from removal below and rebuilt from the survivors.
             val survivingStringifiedKeys = getStringifiedKeys().filterTo(mutableSetOf()) { except.contains(it) }
 
-            // Snapshot the keys before removing. SharedPreferences.all can be backed by the live map,
-            // so removing entries mid-iteration risks a ConcurrentModificationException.
+            // Read sharedPreferences.all once (each access allocates a fresh snapshot) and build the
+            // removal list up front. STRINGIFIED_KEYS is excluded here because it is rebuilt below from
+            // the survivors rather than removed, so a preserved serialized value still deserializes on read.
             val keysToRemove =
                 sharedPreferences.all.keys.filter {
                     it != STRINGIFIED_KEYS && !except.contains(it)

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -115,12 +115,23 @@ internal class PostHogSharedPreferences(
         val edit = sharedPreferences.edit()
 
         synchronized(lock) {
+            // Keep STRINGIFIED_KEYS in sync with what survives so preserved serialized values
+            // (e.g. SESSION_REPLAY) still deserialize on read.
+            val survivingStringifiedKeys = getStringifiedKeys().filterTo(mutableSetOf()) { except.contains(it) }
+
             val it = sharedPreferences.all.iterator()
             while (it.hasNext()) {
                 val entry = it.next()
-                if (!except.contains(entry.key)) {
-                    edit.remove(entry.key)
+                if (entry.key == STRINGIFIED_KEYS || except.contains(entry.key)) {
+                    continue
                 }
+                edit.remove(entry.key)
+            }
+
+            if (survivingStringifiedKeys.isEmpty()) {
+                edit.remove(STRINGIFIED_KEYS)
+            } else {
+                edit.putStringSet(STRINGIFIED_KEYS, survivingStringifiedKeys)
             }
 
             edit.apply()

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -115,17 +115,17 @@ internal class PostHogSharedPreferences(
         val edit = sharedPreferences.edit()
 
         synchronized(lock) {
+            // Invariant: STRINGIFIED_KEYS must list exactly the serialized (Map/List) keys that survive.
+            // It is itself a stored key, so it is excluded from removal below and rebuilt from the survivors.
             val survivingStringifiedKeys = getStringifiedKeys().filterTo(mutableSetOf()) { except.contains(it) }
 
-            val it = sharedPreferences.all.iterator()
-            while (it.hasNext()) {
-                val entry = it.next()
-                // STRINGIFIED_KEYS is metadata, rebuilt below; never let the data loop remove it.
-                if (entry.key == STRINGIFIED_KEYS || except.contains(entry.key)) {
-                    continue
+            // Snapshot the keys before removing. SharedPreferences.all can be backed by the live map,
+            // so removing entries mid-iteration risks a ConcurrentModificationException.
+            val keysToRemove =
+                sharedPreferences.all.keys.filter {
+                    it != STRINGIFIED_KEYS && !except.contains(it)
                 }
-                edit.remove(entry.key)
-            }
+            keysToRemove.forEach { edit.remove(it) }
 
             if (survivingStringifiedKeys.isEmpty()) {
                 edit.remove(STRINGIFIED_KEYS)

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -202,6 +202,27 @@ internal class PostHogSharedPreferencesTests {
     }
 
     @Test
+    fun `clear preserves a plain key and a stringified key without cross-contaminating STRINGIFIED_KEYS`() {
+        val sut = getSut()
+
+        // Mirrors the production reset() except-list: a plain string (like DEVICE_ID) alongside a
+        // serialized map (like SESSION_REPLAY). The plain key must NOT leak into STRINGIFIED_KEYS,
+        // or it would later be treated as JSON and corrupt on read.
+        sut.setValue("device", "abc-123") // plain string, not stringified
+        sut.setValue("sessionReplay", mapOf("endpoint" to "/b/")) // serialized, survives
+        sut.setValue("drop", mapOf("x" to "1")) // serialized, removed
+
+        sut.clear(except = listOf("device", "sessionReplay"))
+
+        assertEquals("abc-123", sut.getValue("device"))
+        assertEquals(mapOf("endpoint" to "/b/"), sut.getValue("sessionReplay"))
+        assertNull(sut.getValue("drop"))
+        @Suppress("UNCHECKED_CAST")
+        val stringifiedKeys = sut.getValue(STRINGIFIED_KEYS) as? Set<String>
+        assertEquals(setOf("sessionReplay"), stringifiedKeys)
+    }
+
+    @Test
     fun `preferences removes item`() {
         val sut = getSut()
 

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -152,6 +152,23 @@ internal class PostHogSharedPreferencesTests {
     }
 
     @Test
+    fun `preferences clear keeps a preserved stringified value deserializable`() {
+        val sut = getSut()
+
+        // A Map value is serialized to JSON and tracked in STRINGIFIED_KEYS; when it survives a
+        // partial clear it must still deserialize back to a Map ("sessionReplay" stands in for
+        // SESSION_REPLAY, which is internal to the posthog module).
+        val recordingConfig = mapOf("endpoint" to "/b/")
+        sut.setValue("sessionReplay", recordingConfig)
+        sut.setValue("scratch", mapOf("foo" to "bar"))
+
+        sut.clear(except = listOf("sessionReplay"))
+
+        assertEquals(recordingConfig, sut.getValue("sessionReplay"))
+        assertNull(sut.getValue("scratch"))
+    }
+
+    @Test
     fun `preferences removes item`() {
         val sut = getSut()
 

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -169,6 +169,39 @@ internal class PostHogSharedPreferencesTests {
     }
 
     @Test
+    fun `clear without surviving stringified keys removes the STRINGIFIED_KEYS entry`() {
+        val sut = getSut()
+
+        sut.setValue("scratch", mapOf("foo" to "bar")) // serialized, tracked in STRINGIFIED_KEYS
+        sut.setValue("plain", "keep-me") // a plain string, not stringified
+
+        sut.clear(except = listOf("plain"))
+
+        assertEquals("keep-me", sut.getValue("plain"))
+        assertNull(sut.getValue("scratch"))
+        // No stringified value survived, so the metadata entry must be removed entirely.
+        assertNull(sut.getValue(STRINGIFIED_KEYS))
+    }
+
+    @Test
+    fun `clear prunes STRINGIFIED_KEYS to only the surviving stringified keys`() {
+        val sut = getSut()
+
+        sut.setValue("keep", mapOf("a" to "1")) // serialized, survives
+        sut.setValue("drop", mapOf("b" to "2")) // serialized, removed
+
+        sut.clear(except = listOf("keep"))
+
+        // Survivor still deserializes back to a Map; the dropped key is gone.
+        assertEquals(mapOf("a" to "1"), sut.getValue("keep"))
+        assertNull(sut.getValue("drop"))
+        // STRINGIFIED_KEYS must list only the survivor, not a stale entry for the removed "drop".
+        @Suppress("UNCHECKED_CAST")
+        val stringifiedKeys = sut.getValue(STRINGIFIED_KEYS) as? Set<String>
+        assertEquals(setOf("keep"), stringifiedKeys)
+    }
+
+    @Test
     fun `preferences removes item`() {
         val sut = getSut()
 

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -18,7 +18,6 @@ import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
-import com.posthog.internal.PostHogPreferences.Companion.STRINGIFIED_KEYS
 import com.posthog.internal.PostHogPreferences.Companion.VERSION
 import com.posthog.internal.PostHogPrintLogger
 import com.posthog.internal.PostHogQueue
@@ -1493,8 +1492,8 @@ public class PostHog private constructor(
         // and under-sending "Application Updated" events. Preserve DEVICE_ID to maintain
         // stable feature flag bucketing across identity changes.
         // Preserve SESSION_REPLAY (project-level recording config, not user data) so replay can re-arm
-        // after an identity change without an app restart; STRINGIFIED_KEYS keeps it deserializable.
-        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY, STRINGIFIED_KEYS)
+        // after an identity change without an app restart.
+        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY)
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)
         if (config?.reuseAnonymousId == true) {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -11,8 +11,10 @@ import com.posthog.internal.PostHogOnRemoteConfigLoaded
 import com.posthog.internal.PostHogPreferences.Companion.ALL_INTERNAL_KEYS
 import com.posthog.internal.PostHogPreferences.Companion.ANONYMOUS_ID
 import com.posthog.internal.PostHogPreferences.Companion.BUILD
+import com.posthog.internal.PostHogPreferences.Companion.CAPTURE_PERFORMANCE
 import com.posthog.internal.PostHogPreferences.Companion.DEVICE_ID
 import com.posthog.internal.PostHogPreferences.Companion.DISTINCT_ID
+import com.posthog.internal.PostHogPreferences.Companion.ERROR_TRACKING
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
@@ -1491,9 +1493,9 @@ public class PostHog private constructor(
         // Preserve BUILD and VERSION to prevent over-sending "Application Installed" events
         // and under-sending "Application Updated" events. Preserve DEVICE_ID to maintain
         // stable feature flag bucketing across identity changes.
-        // Preserve SESSION_REPLAY (project-level recording config, not user data) so replay can re-arm
-        // after an identity change without an app restart.
-        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY)
+        // Preserve SESSION_REPLAY, ERROR_TRACKING, and CAPTURE_PERFORMANCE (project-level config from
+        // /config, not user data) so each can re-arm after an identity change without an app restart.
+        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE)
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)
         if (config?.reuseAnonymousId == true) {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -17,6 +17,8 @@ import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
+import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
+import com.posthog.internal.PostHogPreferences.Companion.STRINGIFIED_KEYS
 import com.posthog.internal.PostHogPreferences.Companion.VERSION
 import com.posthog.internal.PostHogPrintLogger
 import com.posthog.internal.PostHogQueue
@@ -1490,7 +1492,9 @@ public class PostHog private constructor(
         // Preserve BUILD and VERSION to prevent over-sending "Application Installed" events
         // and under-sending "Application Updated" events. Preserve DEVICE_ID to maintain
         // stable feature flag bucketing across identity changes.
-        val except = mutableListOf(VERSION, BUILD, DEVICE_ID)
+        // Preserve SESSION_REPLAY (project-level recording config, not user data) so replay can re-arm
+        // after an identity change without an app restart; STRINGIFIED_KEYS keeps it deserializable.
+        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY, STRINGIFIED_KEYS)
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)
         if (config?.reuseAnonymousId == true) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -405,12 +405,13 @@ public class PostHogRemoteConfig(
             config.logger.log("No cached session replay config to re-evaluate; replay stays disabled.")
             return
         }
-        // persist = false: just read from the cache, no need to write it back.
         processSessionRecordingConfig(recordingConfig, persist = false)
     }
 
     private fun processSessionRecordingConfig(
         sessionRecording: Any?,
+        // persist=true writes the config to the cache (the /config path); false only evaluates it
+        // in-memory (the /flags re-arm path, which just read it from that same cache).
         persist: Boolean = true,
     ) {
         when (sessionRecording) {
@@ -511,7 +512,6 @@ public class PostHogRemoteConfig(
             config.logger.log("No cached error tracking config to re-evaluate; autocapture stays disabled.")
             return
         }
-        // persist = false: just read from the cache, no need to write it back.
         processErrorTrackingConfig(errorTracking, persist = false)
     }
 
@@ -565,7 +565,6 @@ public class PostHogRemoteConfig(
             config.logger.log("No cached capture performance config to re-evaluate; network timing stays disabled.")
             return
         }
-        // persist = false: just read from the cache, no need to write it back.
         processCapturePerformanceConfig(capturePerformance, persist = false)
     }
 
@@ -647,6 +646,12 @@ public class PostHogRemoteConfig(
                             """Feature flags are quota limited, flags could not be updated.
                                     Learn more about billing limits at https://posthog.com/docs/billing/limits-alerts""",
                         )
+                        // Flags are quota limited, but session replay / error tracking / capture
+                        // performance config come from /config (not flags), so still re-arm them from
+                        // the cache against the flags we already have, instead of leaving them disabled.
+                        reevaluateSessionReplayFromCachedConfig()
+                        reevaluateCapturePerformanceFromCachedConfig()
+                        reevaluateErrorTrackingFromCachedConfig()
                         return@let
                     }
 
@@ -1227,8 +1232,9 @@ public class PostHogRemoteConfig(
 
         synchronized(remoteConfigLock) {
             clearSurveys()
-            // Zero the in-memory flags but keep the cached config so a reload can re-arm them
-            // (an explicit `false` from /config still evicts the cache).
+            // Zero the in-memory flags but keep the cached config so a reload can re-arm them.
+            // Deliberately NOT clearErrorTracking()/clearCapturePerformance(): those also evict the
+            // cache. An explicit `false` from /config is the only path that evicts.
             autoCaptureExceptions = false
             captureNetworkTiming = false
         }

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -398,10 +398,14 @@ public class PostHogRemoteConfig(
         return milliseconds
     }
 
-    // Re-evaluates sessionReplayFlagActive from the persisted config (survives reset) + current flags.
-    private fun reevaluateSessionReplayFromStoredConfig() {
+    // Re-evaluates sessionReplayFlagActive from the cached config (survives reset) + current flags.
+    private fun reevaluateSessionReplayFromCachedConfig() {
         @Suppress("UNCHECKED_CAST")
-        val recordingConfig = config.cachePreferences?.getValue(SESSION_REPLAY) as? Map<String, Any?> ?: return
+        val recordingConfig = config.cachePreferences?.getValue(SESSION_REPLAY) as? Map<String, Any?>
+        if (recordingConfig == null) {
+            config.logger.log("No cached session replay config to re-evaluate; replay stays disabled.")
+            return
+        }
         sessionReplayFlagActive = isRecordingActive(this.featureFlags ?: mapOf(), recordingConfig)
     }
 
@@ -650,7 +654,7 @@ public class PostHogRemoteConfig(
                     if (responseSessionRecording != null) {
                         processSessionRecordingConfig(responseSessionRecording)
                     } else {
-                        reevaluateSessionReplayFromStoredConfig()
+                        reevaluateSessionReplayFromCachedConfig()
                     }
 
                     // TODO: surveys depends on remoteConfig for now

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -398,7 +398,7 @@ public class PostHogRemoteConfig(
         return milliseconds
     }
 
-    // Re-evaluates sessionReplayFlagActive from the cached config (survives reset) + current flags.
+    // Restores the full recording config from cache (survives reset), re-evaluated against current flags.
     private fun reevaluateSessionReplayFromCachedConfig() {
         @Suppress("UNCHECKED_CAST")
         val recordingConfig = config.cachePreferences?.getValue(SESSION_REPLAY) as? Map<String, Any?>
@@ -406,7 +406,7 @@ public class PostHogRemoteConfig(
             config.logger.log("No cached session replay config to re-evaluate; replay stays disabled.")
             return
         }
-        sessionReplayFlagActive = isRecordingActive(this.featureFlags ?: mapOf(), recordingConfig)
+        processSessionRecordingConfig(recordingConfig)
     }
 
     private fun processSessionRecordingConfig(sessionRecording: Any?) {
@@ -648,8 +648,7 @@ public class PostHogRemoteConfig(
                         this.featureFlagPayloads = normalizedPayloads
                     }
 
-                    // /flags omits sessionRecording (null) -> re-evaluate from the cached config instead of
-                    // clobbering it. An explicit value (e.g. Boolean false when remotely disabled) is still honored.
+                    // /flags usually omits sessionRecording; re-arm from cached config instead of clobbering it.
                     val responseSessionRecording = it.sessionRecording
                     if (responseSessionRecording != null) {
                         processSessionRecordingConfig(responseSessionRecording)

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -83,6 +83,10 @@ public class PostHogRemoteConfig(
     @Volatile
     private var sessionReplayFlagActive = false
 
+    // Last sessionRecording config from /config, kept so /flags reloads can re-evaluate without re-fetching it.
+    @Volatile
+    private var lastSessionRecordingConfig: Map<String, Any?>? = null
+
     @Volatile
     private var hasSurveys = false
 
@@ -398,6 +402,12 @@ public class PostHogRemoteConfig(
         return milliseconds
     }
 
+    // Re-evaluates sessionReplayFlagActive from the cached config + current flags.
+    private fun reevaluateSessionReplayFromLastConfig() {
+        val recordingConfig = lastSessionRecordingConfig ?: return
+        sessionReplayFlagActive = isRecordingActive(this.featureFlags ?: mapOf(), recordingConfig)
+    }
+
     private fun processSessionRecordingConfig(sessionRecording: Any?) {
         when (sessionRecording) {
             is Boolean -> {
@@ -405,6 +415,7 @@ public class PostHogRemoteConfig(
                 // so we don't enable sessionReplayFlagActive here
                 sessionReplayFlagActive = false
                 consoleLogRecordingEnabled = false
+                lastSessionRecordingConfig = null
 
                 if (!sessionRecording) {
                     config.cachePreferences?.remove(SESSION_REPLAY)
@@ -423,6 +434,9 @@ public class PostHogRemoteConfig(
                         ?: config.snapshotEndpoint
 
                     sessionReplayFlagActive = isRecordingActive(this.featureFlags ?: mapOf(), it)
+
+                    // Cache so /flags reloads and reset()/identify() can re-evaluate without re-fetching /config.
+                    lastSessionRecordingConfig = it
 
                     consoleLogRecordingEnabled = it["consoleLogRecordingEnabled"] as? Boolean ?: false
 
@@ -637,8 +651,13 @@ public class PostHogRemoteConfig(
                         this.featureFlagPayloads = normalizedPayloads
                     }
 
-                    // since flags might have changed, we need to check if session recording is active again
-                    processSessionRecordingConfig(it.sessionRecording)
+                    // /flags doesn't carry sessionRecording; re-evaluate from the cached config instead of clobbering it.
+                    val responseSessionRecording = it.sessionRecording
+                    if (responseSessionRecording is Map<*, *>) {
+                        processSessionRecordingConfig(responseSessionRecording)
+                    } else {
+                        reevaluateSessionReplayFromLastConfig()
+                    }
 
                     // TODO: surveys depends on remoteConfig for now
                     // otherwise surveysHandler?.onSurveysLoaded will be called multiple times
@@ -764,6 +783,8 @@ public class PostHogRemoteConfig(
 
                 if (sessionRecording != null) {
                     sessionReplayFlagActive = isRecordingActive(flags ?: mapOf(), sessionRecording)
+
+                    lastSessionRecordingConfig = sessionRecording
 
                     config.snapshotEndpoint = sessionRecording["endpoint"] as? String
                         ?: config.snapshotEndpoint

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -83,10 +83,6 @@ public class PostHogRemoteConfig(
     @Volatile
     private var sessionReplayFlagActive = false
 
-    // Last sessionRecording config from /config, kept so /flags reloads can re-evaluate without re-fetching it.
-    @Volatile
-    private var lastSessionRecordingConfig: Map<String, Any?>? = null
-
     @Volatile
     private var hasSurveys = false
 
@@ -402,9 +398,10 @@ public class PostHogRemoteConfig(
         return milliseconds
     }
 
-    // Re-evaluates sessionReplayFlagActive from the cached config + current flags.
-    private fun reevaluateSessionReplayFromLastConfig() {
-        val recordingConfig = lastSessionRecordingConfig ?: return
+    // Re-evaluates sessionReplayFlagActive from the persisted config (survives reset) + current flags.
+    private fun reevaluateSessionReplayFromStoredConfig() {
+        @Suppress("UNCHECKED_CAST")
+        val recordingConfig = config.cachePreferences?.getValue(SESSION_REPLAY) as? Map<String, Any?> ?: return
         sessionReplayFlagActive = isRecordingActive(this.featureFlags ?: mapOf(), recordingConfig)
     }
 
@@ -415,7 +412,6 @@ public class PostHogRemoteConfig(
                 // so we don't enable sessionReplayFlagActive here
                 sessionReplayFlagActive = false
                 consoleLogRecordingEnabled = false
-                lastSessionRecordingConfig = null
 
                 if (!sessionRecording) {
                     config.cachePreferences?.remove(SESSION_REPLAY)
@@ -434,9 +430,6 @@ public class PostHogRemoteConfig(
                         ?: config.snapshotEndpoint
 
                     sessionReplayFlagActive = isRecordingActive(this.featureFlags ?: mapOf(), it)
-
-                    // Cache so /flags reloads and reset()/identify() can re-evaluate without re-fetching /config.
-                    lastSessionRecordingConfig = it
 
                     consoleLogRecordingEnabled = it["consoleLogRecordingEnabled"] as? Boolean ?: false
 
@@ -657,7 +650,7 @@ public class PostHogRemoteConfig(
                     if (responseSessionRecording != null) {
                         processSessionRecordingConfig(responseSessionRecording)
                     } else {
-                        reevaluateSessionReplayFromLastConfig()
+                        reevaluateSessionReplayFromStoredConfig()
                     }
 
                     // TODO: surveys depends on remoteConfig for now
@@ -784,8 +777,6 @@ public class PostHogRemoteConfig(
 
                 if (sessionRecording != null) {
                     sessionReplayFlagActive = isRecordingActive(flags ?: mapOf(), sessionRecording)
-
-                    lastSessionRecordingConfig = sessionRecording
 
                     config.snapshotEndpoint = sessionRecording["endpoint"] as? String
                         ?: config.snapshotEndpoint
@@ -1209,6 +1200,7 @@ public class PostHogRemoteConfig(
         resetPersonPropertiesForFlags()
         resetGroupPropertiesForFlags()
 
-        config.cachePreferences?.remove(SESSION_REPLAY)
+        // SESSION_REPLAY config is intentionally kept (project-level, not user data) so the next
+        // /flags reload can re-arm replay without waiting for an app restart.
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -228,6 +228,8 @@ public class PostHogRemoteConfig(
 
                 response?.let {
                     synchronized(remoteConfigLock) {
+                        // /config is the only source of these configs; the /flags reload re-arms
+                        // them from the cache (reevaluate*FromCachedConfig). Don't move onto /flags.
                         processSessionRecordingConfig(it.sessionRecording)
                         processSurveys(it.surveys)
                         processErrorTrackingConfig(it.errorTracking)
@@ -400,16 +402,19 @@ public class PostHogRemoteConfig(
 
     // Restores the full recording config from cache (survives reset), re-evaluated against current flags.
     private fun reevaluateSessionReplayFromCachedConfig() {
-        @Suppress("UNCHECKED_CAST")
-        val recordingConfig = config.cachePreferences?.getValue(SESSION_REPLAY) as? Map<String, Any?>
+        val recordingConfig = config.cachePreferences?.getValue(SESSION_REPLAY)
         if (recordingConfig == null) {
             config.logger.log("No cached session replay config to re-evaluate; replay stays disabled.")
             return
         }
-        processSessionRecordingConfig(recordingConfig)
+        // persist = false: just read from the cache, no need to write it back.
+        processSessionRecordingConfig(recordingConfig, persist = false)
     }
 
-    private fun processSessionRecordingConfig(sessionRecording: Any?) {
+    private fun processSessionRecordingConfig(
+        sessionRecording: Any?,
+        persist: Boolean = true,
+    ) {
         when (sessionRecording) {
             is Boolean -> {
                 // if sessionRecording is a Boolean, its always disabled
@@ -443,7 +448,9 @@ public class PostHogRemoteConfig(
 
                     sessionRecordingMinimumDurationMs = parseMinimumDurationMs(it["minimumDurationMilliseconds"])
 
-                    config.cachePreferences?.setValue(SESSION_REPLAY, it)
+                    if (persist) {
+                        config.cachePreferences?.setValue(SESSION_REPLAY, it)
+                    }
 
                     // TODO:
                     // networkPayloadCapture -> Boolean or null, can also be networkPayloadCapture={recordBody=true, recordHeaders=true},
@@ -461,7 +468,10 @@ public class PostHogRemoteConfig(
         config.cachePreferences?.remove(ERROR_TRACKING)
     }
 
-    private fun processErrorTrackingConfig(errorTracking: Any?) {
+    private fun processErrorTrackingConfig(
+        errorTracking: Any?,
+        persist: Boolean = true,
+    ) {
         when (errorTracking) {
             is Boolean -> {
                 // if errorTracking is a Boolean, it's always false (disabled)
@@ -472,7 +482,9 @@ public class PostHogRemoteConfig(
                 (errorTracking as? Map<String, Any>)?.let {
                     val autocaptureExceptions = it["autocaptureExceptions"]
                     autoCaptureExceptions = autocaptureExceptions as? Boolean ?: false
-                    config.cachePreferences?.setValue(ERROR_TRACKING, it)
+                    if (persist) {
+                        config.cachePreferences?.setValue(ERROR_TRACKING, it)
+                    }
                 }
             }
             else -> {
@@ -494,12 +506,26 @@ public class PostHogRemoteConfig(
         }
     }
 
+    // Restores error tracking config from cache (survives reset); re-armed on a /flags reload.
+    private fun reevaluateErrorTrackingFromCachedConfig() {
+        val errorTracking = config.cachePreferences?.getValue(ERROR_TRACKING)
+        if (errorTracking == null) {
+            config.logger.log("No cached error tracking config to re-evaluate; autocapture stays disabled.")
+            return
+        }
+        // persist = false: just read from the cache, no need to write it back.
+        processErrorTrackingConfig(errorTracking, persist = false)
+    }
+
     private fun clearCapturePerformance() {
         captureNetworkTiming = false
         config.cachePreferences?.remove(CAPTURE_PERFORMANCE)
     }
 
-    private fun processCapturePerformanceConfig(capturePerformance: Any?) {
+    private fun processCapturePerformanceConfig(
+        capturePerformance: Any?,
+        persist: Boolean = true,
+    ) {
         when (capturePerformance) {
             is Boolean -> {
                 // if capturePerformance is a Boolean, it's always false (disabled)
@@ -510,7 +536,9 @@ public class PostHogRemoteConfig(
                 (capturePerformance as? Map<String, Any?>)?.let {
                     val networkTiming = it["network_timing"]
                     captureNetworkTiming = networkTiming as? Boolean ?: false
-                    config.cachePreferences?.setValue(CAPTURE_PERFORMANCE, it)
+                    if (persist) {
+                        config.cachePreferences?.setValue(CAPTURE_PERFORMANCE, it)
+                    }
                 }
             }
             else -> {
@@ -530,6 +558,17 @@ public class PostHogRemoteConfig(
                 }
             }
         }
+    }
+
+    // Restores capture performance config from cache (survives reset); re-armed on a /flags reload.
+    private fun reevaluateCapturePerformanceFromCachedConfig() {
+        val capturePerformance = config.cachePreferences?.getValue(CAPTURE_PERFORMANCE)
+        if (capturePerformance == null) {
+            config.logger.log("No cached capture performance config to re-evaluate; network timing stays disabled.")
+            return
+        }
+        // persist = false: just read from the cache, no need to write it back.
+        processCapturePerformanceConfig(capturePerformance, persist = false)
     }
 
     /**
@@ -656,11 +695,10 @@ public class PostHogRemoteConfig(
                     // otherwise surveysHandler?.onSurveysLoaded will be called multiple times
                     // processSurveys(it.surveys)
 
-                    // only process values if not yet processed by remote config
-                    if (notifyRemoteConfigLoaded) {
-                        processCapturePerformanceConfig(it.capturePerformance)
-                        processErrorTrackingConfig(it.errorTracking)
-                    }
+                    // error tracking & capture performance config come from /config, not /flags;
+                    // re-arm from the cached config like session replay above.
+                    reevaluateCapturePerformanceFromCachedConfig()
+                    reevaluateErrorTrackingFromCachedConfig()
                 }
                 config.cachePreferences?.let { preferences ->
                     val flags = this.flags ?: mapOf()
@@ -1191,15 +1229,17 @@ public class PostHogRemoteConfig(
 
         synchronized(remoteConfigLock) {
             clearSurveys()
-            clearErrorTracking()
-            clearCapturePerformance()
+            // Zero the in-memory flags but keep the cached config so a reload can re-arm them
+            // (an explicit `false` from /config still evicts the cache).
+            autoCaptureExceptions = false
+            captureNetworkTiming = false
         }
 
         // Clear person and group properties for flags
         resetPersonPropertiesForFlags()
         resetGroupPropertiesForFlags()
 
-        // SESSION_REPLAY config is intentionally kept (project-level, not user data) so the next
-        // /flags reload can re-arm replay without waiting for an app restart.
+        // SESSION_REPLAY, ERROR_TRACKING, and CAPTURE_PERFORMANCE are intentionally kept (project-level,
+        // not user data) so a reload can re-arm each without an app restart.
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -228,8 +228,6 @@ public class PostHogRemoteConfig(
 
                 response?.let {
                     synchronized(remoteConfigLock) {
-                        // /config is the only source of these configs; the /flags reload re-arms
-                        // them from the cache (reevaluate*FromCachedConfig). Don't move onto /flags.
                         processSessionRecordingConfig(it.sessionRecording)
                         processSurveys(it.surveys)
                         processErrorTrackingConfig(it.errorTracking)

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -648,13 +648,9 @@ public class PostHogRemoteConfig(
                         this.featureFlagPayloads = normalizedPayloads
                     }
 
-                    // /flags usually omits sessionRecording; re-arm from cached config instead of clobbering it.
-                    val responseSessionRecording = it.sessionRecording
-                    if (responseSessionRecording != null) {
-                        processSessionRecordingConfig(responseSessionRecording)
-                    } else {
-                        reevaluateSessionReplayFromCachedConfig()
-                    }
+                    // /flags carries flag evaluations only; session recording config comes from
+                    // /config. Re-arm from the cached config, re-evaluated against the new flags.
+                    reevaluateSessionReplayFromCachedConfig()
 
                     // TODO: surveys depends on remoteConfig for now
                     // otherwise surveysHandler?.onSurveysLoaded will be called multiple times

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -651,9 +651,10 @@ public class PostHogRemoteConfig(
                         this.featureFlagPayloads = normalizedPayloads
                     }
 
-                    // /flags doesn't carry sessionRecording; re-evaluate from the cached config instead of clobbering it.
+                    // /flags omits sessionRecording (null) -> re-evaluate from the cached config instead of
+                    // clobbering it. An explicit value (e.g. Boolean false when remotely disabled) is still honored.
                     val responseSessionRecording = it.sessionRecording
-                    if (responseSessionRecording is Map<*, *>) {
+                    if (responseSessionRecording != null) {
                         processSessionRecordingConfig(responseSessionRecording)
                     } else {
                         reevaluateSessionReplayFromLastConfig()

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -3,6 +3,8 @@ package com.posthog
 import com.posthog.internal.PostHogBatchEvent
 import com.posthog.internal.PostHogContext
 import com.posthog.internal.PostHogMemoryPreferences
+import com.posthog.internal.PostHogPreferences.Companion.CAPTURE_PERFORMANCE
+import com.posthog.internal.PostHogPreferences.Companion.ERROR_TRACKING
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.GROUP_PROPERTIES_FOR_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROPERTIES_FOR_FLAGS
@@ -3232,12 +3234,14 @@ internal class PostHogTest {
     }
 
     @Test
-    fun `SESSION_REPLAY config is preserved across reset`() {
+    fun `project-level remote config is preserved across reset`() {
         val http = mockHttp()
         val url = http.url("/")
 
         val cachePreferences = PostHogMemoryPreferences()
         cachePreferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/"))
+        cachePreferences.setValue(ERROR_TRACKING, mapOf("autocaptureExceptions" to true))
+        cachePreferences.setValue(CAPTURE_PERFORMANCE, mapOf("network_timing" to true))
 
         val sut =
             getSut(
@@ -3250,8 +3254,10 @@ internal class PostHogTest {
         sut.identify("user-123")
         sut.reset()
 
-        // reset() keeps the recording config so replay can re-arm on the next /flags reload.
+        // reset() keeps the project-level config so each can re-arm on the next /flags reload.
         assertNotNull(cachePreferences.getValue(SESSION_REPLAY))
+        assertNotNull(cachePreferences.getValue(ERROR_TRACKING))
+        assertNotNull(cachePreferences.getValue(CAPTURE_PERFORMANCE))
 
         sut.close()
     }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -3232,6 +3232,31 @@ internal class PostHogTest {
     }
 
     @Test
+    fun `SESSION_REPLAY config is preserved across reset`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val cachePreferences = PostHogMemoryPreferences()
+        cachePreferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/"))
+
+        val sut =
+            getSut(
+                url.toString(),
+                preloadFeatureFlags = false,
+                reloadFeatureFlags = false,
+                cachePreferences = cachePreferences,
+            )
+
+        sut.identify("user-123")
+        sut.reset()
+
+        // reset() keeps the recording config so replay can re-arm on the next /flags reload.
+        assertNotNull(cachePreferences.getValue(SESSION_REPLAY))
+
+        sut.close()
+    }
+
+    @Test
     fun `device_id is sent in flags request`() {
         val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
         val responseFlagsApi = file.readText()

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -2235,12 +2235,18 @@ internal class PostHogTest {
         )
         val url = http.url("/")
 
+        // Recording config comes from /config (cached); the /flags reload re-arms from the cache and
+        // evaluates the linked flag, which is what fires $feature_flag_called.
+        val cachePreferences = PostHogMemoryPreferences()
+        cachePreferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/", "linkedFlag" to "session-replay-flag"))
+
         val integration = PostHogSessionReplayHandlerFake(true)
         val sut =
             getSut(
                 url.toString(),
                 preloadFeatureFlags = false,
                 integration = integration,
+                cachePreferences = cachePreferences,
             )
 
         sut.reloadFeatureFlags()
@@ -2281,6 +2287,11 @@ internal class PostHogTest {
         )
         val url = http.url("/")
 
+        // Recording config comes from /config (cached); the /flags reload re-arms from the cache and
+        // evaluates the linked flag. With sendFeatureFlagEvent = false, no $feature_flag_called fires.
+        val cachePreferences = PostHogMemoryPreferences()
+        cachePreferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/", "linkedFlag" to "session-replay-flag"))
+
         val integration = PostHogSessionReplayHandlerFake(true)
         val sut =
             getSut(
@@ -2288,6 +2299,7 @@ internal class PostHogTest {
                 preloadFeatureFlags = false,
                 integration = integration,
                 sendFeatureFlagEvent = false,
+                cachePreferences = cachePreferences,
             )
 
         sut.reloadFeatureFlags()

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -233,6 +233,85 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
+    fun `re-arm on reset turns replay off when the new user is outside the linked-flag rollout`() {
+        // /config cached a linkedFlag recording config; replay is gated on the flag per user.
+        preferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/", "linkedFlag" to "session-replay-flag"))
+
+        // First user is in the rollout (flag true), second is outside it (flag false).
+        val inRollout = File("src/test/resources/json/basic-flags-recording-bool-linked-enabled.json").readText()
+        val outOfRollout = File("src/test/resources/json/basic-flags-recording-bool-linked-disabled.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(inRollout))
+        http.enqueue(MockResponse().setBody(outOfRollout))
+        val sut = getSut(host = http.url("/").toString())
+
+        val firstLatch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "user-in-rollout",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { firstLatch.countDown() },
+        )
+        assertTrue(firstLatch.await(5, TimeUnit.SECONDS), "first flags load should complete")
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        sut.clear()
+
+        val secondLatch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "user-outside-rollout",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { secondLatch.countDown() },
+        )
+        assertTrue(secondLatch.await(5, TimeUnit.SECONDS), "second flags load should complete")
+
+        // Re-arm must re-evaluate the linked flag against the new user and stay OFF, not blindly true.
+        assertFalse(sut.isSessionReplayFlagActive())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `re-arm survives the Gson round-trip for a variant linked flag`() {
+        val http =
+            mockHttp(
+                response =
+                    MockResponse()
+                        .setBody(File("src/test/resources/json/basic-flags-recording-bool-linked-variant-match.json").readText()),
+            )
+        val sut = getSut(host = http.url("/").toString())
+
+        // Mirror the on-disk cache: serialize then read back the way PostHogSharedPreferences does,
+        // so the nested linkedFlag map goes through the real Gson round-trip the device hit.
+        val serializer = config!!.serializer
+        val original =
+            mapOf(
+                "endpoint" to "/b/",
+                "linkedFlag" to mapOf("flag" to "session-replay-flag", "variant" to "variant-1"),
+            )
+
+        @Suppress("UNCHECKED_CAST")
+        val roundTripped = serializer.deserializeString(serializer.serializeObject(original)!!) as Map<String, Any?>
+        preferences.setValue(SESSION_REPLAY, roundTripped)
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        // The variant linkedFlag must still match after the JSON round-trip.
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
     fun `returns session replay enabled after remote config API call`() {
         val file = File("src/test/resources/json/basic-remote-config-no-flags.json")
 
@@ -258,6 +337,70 @@ internal class PostHogRemoteConfigTest {
         http.shutdown()
 
         assertFalse(sut.isSessionReplayFlagActive())
+    }
+
+    @Test
+    fun `explicit sessionRecording false from remote config evicts the cached recording config`() {
+        // Stale cache from when the project had replay enabled.
+        preferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/"))
+
+        // basic-remote-config-features-disabled.json carries sessionRecording: false.
+        val disabled = File("src/test/resources/json/basic-remote-config-features-disabled.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(disabled))
+        val sut = getSut(host = http.url("/").toString())
+
+        sut.loadRemoteConfig("my_identify", anonymousId = "anonId", emptyMap())
+        executor.shutdownAndAwaitTermination()
+
+        assertFalse(sut.isSessionReplayFlagActive())
+        // The cache must be evicted, otherwise a later reset()+reload could re-arm a disabled project.
+        assertNull(preferences.getValue(SESSION_REPLAY))
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `explicit errorTracking false from remote config evicts the cached config`() {
+        // Stale cache from when the project had autocapture enabled.
+        preferences.setValue(ERROR_TRACKING, mapOf("autocaptureExceptions" to true))
+
+        // basic-remote-config-features-disabled.json carries errorTracking: false.
+        val disabled = File("src/test/resources/json/basic-remote-config-features-disabled.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(disabled))
+        val sut = getSut(host = http.url("/").toString())
+        config!!.errorTrackingConfig.autoCapture = true
+
+        sut.loadRemoteConfig("my_identify", anonymousId = "anonId", emptyMap())
+        executor.shutdownAndAwaitTermination()
+
+        assertFalse(sut.isAutocaptureExceptionsEnabled())
+        // Must evict the cache, else a later reset()+reload could re-arm a disabled project.
+        assertNull(preferences.getValue(ERROR_TRACKING))
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `explicit capturePerformance false from remote config evicts the cached config`() {
+        // Stale cache from when the project had network timing enabled.
+        preferences.setValue(CAPTURE_PERFORMANCE, mapOf("network_timing" to true))
+
+        // basic-remote-config-features-disabled.json carries capturePerformance: false.
+        val disabled = File("src/test/resources/json/basic-remote-config-features-disabled.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(disabled))
+        val sut = getSut(host = http.url("/").toString())
+
+        sut.loadRemoteConfig("my_identify", anonymousId = "anonId", emptyMap())
+        executor.shutdownAndAwaitTermination()
+
+        assertFalse(sut.isCaptureNetworkTimingEnabled())
+        // Must evict the cache, else a later reset()+reload could re-arm a disabled project.
+        assertNull(preferences.getValue(CAPTURE_PERFORMANCE))
+
+        sut.clear()
+        http.shutdown()
     }
 
     private fun testFlagsCallback(pathname: String) {
@@ -842,7 +985,7 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
-    fun `clear removes cached error tracking config`() {
+    fun `clear keeps cached error tracking config so it can re-arm`() {
         val cachedConfig = mapOf("autocaptureExceptions" to true)
         preferences.setValue(ERROR_TRACKING, cachedConfig)
 
@@ -866,8 +1009,9 @@ internal class PostHogRemoteConfigTest {
 
         sut.clear()
 
+        // reset() zeroes the in-memory flag but keeps the project-level config so a reload can re-arm it.
         assertFalse(sut.isAutocaptureExceptionsEnabled())
-        assertEquals(null, preferences.getValue(ERROR_TRACKING))
+        assertEquals(cachedConfig, preferences.getValue(ERROR_TRACKING))
 
         http.shutdown()
     }
@@ -897,7 +1041,7 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
-    fun `clear removes cached capture performance config`() {
+    fun `clear keeps cached capture performance config so it can re-arm`() {
         val cachedConfig = mapOf("network_timing" to true)
         preferences.setValue(CAPTURE_PERFORMANCE, cachedConfig)
 
@@ -915,8 +1059,9 @@ internal class PostHogRemoteConfigTest {
 
         sut.clear()
 
+        // reset() zeroes the in-memory flag but keeps the project-level config so a reload can re-arm it.
         assertFalse(sut.isCaptureNetworkTimingEnabled())
-        assertEquals(null, preferences.getValue(CAPTURE_PERFORMANCE))
+        assertEquals(cachedConfig, preferences.getValue(CAPTURE_PERFORMANCE))
 
         http.shutdown()
     }
@@ -1059,26 +1204,39 @@ internal class PostHogRemoteConfigTest {
     // --- Flags-only path tests (loadFeatureFlags -> executeFeatureFlags) ---
 
     @Test
-    fun `loadFeatureFlags processes errorTracking and capturePerformance from flags API`() {
-        val file = File("src/test/resources/json/basic-flags-with-remote-config-features.json")
+    fun `re-arms error tracking and capture performance from cached config after reset`() {
+        // /config cached these; production /flags omits them, so the reload must re-arm from the cache.
+        preferences.setValue(ERROR_TRACKING, mapOf("autocaptureExceptions" to true))
+        preferences.setValue(CAPTURE_PERFORMANCE, mapOf("network_timing" to true))
 
-        val http =
-            mockHttp(
-                response =
-                    MockResponse()
-                        .setBody(file.readText()),
-            )
+        val withoutConfig = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(withoutConfig))
+        http.enqueue(MockResponse().setBody(withoutConfig))
         val url = http.url("/")
 
         val sut = getSut(host = url.toString())
         config!!.errorTrackingConfig.autoCapture = true
 
-        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap())
-
-        executor.shutdownAndAwaitTermination()
-
+        // Preloaded from cache at construction.
         assertTrue(sut.isAutocaptureExceptionsEnabled())
-        assertTrue(sut.isConsoleLogRecordingEnabled())
+        assertTrue(sut.isCaptureNetworkTimingEnabled())
+
+        // reset() zeroes the in-memory flags but keeps the cached config.
+        sut.clear()
+        assertFalse(sut.isAutocaptureExceptionsEnabled())
+        assertFalse(sut.isCaptureNetworkTimingEnabled())
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        // Re-armed from cache, not clobbered to false by the absent config on /flags.
+        assertTrue(sut.isAutocaptureExceptionsEnabled())
         assertTrue(sut.isCaptureNetworkTimingEnabled())
 
         sut.clear()

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -90,6 +90,36 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
+    fun `re-arms session replay on a quota-limited flags reload`() {
+        // Project config lives in /config (cached); a flags reload that is quota-limited for
+        // feature_flags must still re-arm replay instead of leaving it disabled until app restart.
+        preferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/"))
+
+        val quotaLimited = File("src/test/resources/json/basic-flags-quota-limited.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(quotaLimited))
+        val sut = getSut(host = http.url("/").toString())
+
+        // reset() zeroes the in-memory flag but keeps the cached config.
+        sut.clear()
+        assertFalse(sut.isSessionReplayFlagActive())
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        // Re-armed from the cached config despite the flag quota limit.
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
     fun `re-arm on a flags reload restores consoleLogRecordingEnabled from the cached config`() {
         preferences.setValue(SESSION_REPLAY, mapOf("consoleLogRecordingEnabled" to true))
 
@@ -1238,6 +1268,40 @@ internal class PostHogRemoteConfigTest {
         // Re-armed from cache, not clobbered to false by the absent config on /flags.
         assertTrue(sut.isAutocaptureExceptionsEnabled())
         assertTrue(sut.isCaptureNetworkTimingEnabled())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `flags reload with no cached error tracking or capture performance does not re-arm them`() {
+        // Nothing cached, so the reevaluate* null-cache early-return must be a no-op: a reload after
+        // reset() leaves both flags zeroed instead of re-arming them from a non-existent cache.
+        val withoutConfig = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(withoutConfig))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+        // Local autocapture is on, so a true result could only come from the (absent) remote config.
+        config!!.errorTrackingConfig.autoCapture = true
+
+        // reset() zeroes both in-memory flags (captureNetworkTiming defaults to true, so this matters).
+        sut.clear()
+        assertFalse(sut.isAutocaptureExceptionsEnabled())
+        assertFalse(sut.isCaptureNetworkTimingEnabled())
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        // Still off: the empty cache means there is nothing to re-arm.
+        assertFalse(sut.isAutocaptureExceptionsEnabled())
+        assertFalse(sut.isCaptureNetworkTimingEnabled())
 
         sut.clear()
         http.shutdown()

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -146,9 +146,41 @@ internal class PostHogRemoteConfigTest {
         )
         assertTrue(secondLatch.await(5, TimeUnit.SECONDS), "second flags load should complete")
 
-        // Explicit false turns replay off and drops the cached config.
+        // A response that explicitly carries false turns replay off and drops the cached config.
         assertFalse(sut.isSessionReplayFlagActive())
         assertNull(preferences.getValue(SESSION_REPLAY))
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `re-arm on a flags reload restores consoleLogRecordingEnabled from the cached config`() {
+        preferences.setValue(SESSION_REPLAY, mapOf("consoleLogRecordingEnabled" to true))
+
+        // /flags omits sessionRecording, so the reload must re-arm from the cached config.
+        val withoutRecording = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(withoutRecording))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        assertTrue(sut.isConsoleLogRecordingEnabled())
+
+        sut.clear()
+        assertFalse(sut.isConsoleLogRecordingEnabled())
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        // Restored from cache, not left clobbered to false.
+        assertTrue(sut.isConsoleLogRecordingEnabled())
 
         sut.clear()
         http.shutdown()

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -75,9 +75,8 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
-    fun `keeps session replay active on a flags reload that omits sessionRecording`() {
-        // The first /flags load carries the recording config; the second omits it,
-        // which is what production /flags responses look like (config comes from /config).
+    fun `re-arms session replay after reset on a flags reload that omits sessionRecording`() {
+        // First load carries the recording config; the second omits it, like production /flags.
         val withRecording = File("src/test/resources/json/basic-flags-recording.json").readText()
         val withoutRecording = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
 
@@ -94,7 +93,48 @@ internal class PostHogRemoteConfigTest {
             emptyMap(),
             onFeatureFlags = PostHogOnFeatureFlags { firstLatch.countDown() },
         )
-        firstLatch.await(5, TimeUnit.SECONDS)
+        assertTrue(firstLatch.await(5, TimeUnit.SECONDS), "first flags load should complete")
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        // reset() zeroes the in-memory flag but keeps the cached config.
+        sut.clear()
+        assertFalse(sut.isSessionReplayFlagActive())
+
+        val secondLatch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { secondLatch.countDown() },
+        )
+        assertTrue(secondLatch.await(5, TimeUnit.SECONDS), "second flags load should complete")
+
+        // Must re-arm from the cached config, not stay clobbered to false.
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `explicit sessionRecording false on a flags reload disables replay`() {
+        val withRecording = File("src/test/resources/json/basic-flags-recording.json").readText()
+        val withFalse = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json").readText()
+
+        val http = mockHttp(response = MockResponse().setBody(withRecording))
+        http.enqueue(MockResponse().setBody(withFalse))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        val firstLatch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { firstLatch.countDown() },
+        )
+        assertTrue(firstLatch.await(5, TimeUnit.SECONDS), "first flags load should complete")
         assertTrue(sut.isSessionReplayFlagActive())
 
         val secondLatch = CountDownLatch(1)
@@ -104,11 +144,35 @@ internal class PostHogRemoteConfigTest {
             emptyMap(),
             onFeatureFlags = PostHogOnFeatureFlags { secondLatch.countDown() },
         )
-        secondLatch.await(5, TimeUnit.SECONDS)
+        assertTrue(secondLatch.await(5, TimeUnit.SECONDS), "second flags load should complete")
 
-        // The reload omits sessionRecording: it must re-evaluate from the cached config
-        // instead of clobbering the flag to false.
-        assertTrue(sut.isSessionReplayFlagActive())
+        // Explicit false turns replay off and drops the cached config.
+        assertFalse(sut.isSessionReplayFlagActive())
+        assertNull(preferences.getValue(SESSION_REPLAY))
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `flags reload without a cached recording config leaves replay inactive`() {
+        val withoutRecording = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
+
+        val http = mockHttp(response = MockResponse().setBody(withoutRecording))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        assertFalse(sut.isSessionReplayFlagActive())
 
         sut.clear()
         http.shutdown()

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -48,39 +48,12 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
-    fun `returns session replay enabled after flags API call`() {
-        val file = File("src/test/resources/json/basic-flags-recording.json")
+    fun `re-arms session replay after reset on a flags reload`() {
+        // /config cached the recording config; production /flags omits it.
+        preferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/"))
 
-        val http =
-            mockHttp(
-                response =
-                    MockResponse()
-                        .setBody(file.readText()),
-            )
-        val url = http.url("/")
-
-        val sut = getSut(host = url.toString())
-
-        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap())
-
-        executor.shutdownAndAwaitTermination()
-
-        assertTrue(sut.isSessionReplayFlagActive())
-        assertEquals("/b/", config?.snapshotEndpoint)
-
-        sut.clear()
-        http.shutdown()
-
-        assertFalse(sut.isSessionReplayFlagActive())
-    }
-
-    @Test
-    fun `re-arms session replay after reset on a flags reload that omits sessionRecording`() {
-        // First load carries the recording config; the second omits it, like production /flags.
-        val withRecording = File("src/test/resources/json/basic-flags-recording.json").readText()
         val withoutRecording = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
-
-        val http = mockHttp(response = MockResponse().setBody(withRecording))
+        val http = mockHttp(response = MockResponse().setBody(withoutRecording))
         http.enqueue(MockResponse().setBody(withoutRecording))
         val url = http.url("/")
 
@@ -111,44 +84,6 @@ internal class PostHogRemoteConfigTest {
 
         // Must re-arm from the cached config, not stay clobbered to false.
         assertTrue(sut.isSessionReplayFlagActive())
-
-        sut.clear()
-        http.shutdown()
-    }
-
-    @Test
-    fun `explicit sessionRecording false on a flags reload disables replay`() {
-        val withRecording = File("src/test/resources/json/basic-flags-recording.json").readText()
-        val withFalse = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json").readText()
-
-        val http = mockHttp(response = MockResponse().setBody(withRecording))
-        http.enqueue(MockResponse().setBody(withFalse))
-        val url = http.url("/")
-
-        val sut = getSut(host = url.toString())
-
-        val firstLatch = CountDownLatch(1)
-        sut.loadFeatureFlags(
-            "my_identify",
-            anonymousId = "anonId",
-            emptyMap(),
-            onFeatureFlags = PostHogOnFeatureFlags { firstLatch.countDown() },
-        )
-        assertTrue(firstLatch.await(5, TimeUnit.SECONDS), "first flags load should complete")
-        assertTrue(sut.isSessionReplayFlagActive())
-
-        val secondLatch = CountDownLatch(1)
-        sut.loadFeatureFlags(
-            "my_identify",
-            anonymousId = "anonId",
-            emptyMap(),
-            onFeatureFlags = PostHogOnFeatureFlags { secondLatch.countDown() },
-        )
-        assertTrue(secondLatch.await(5, TimeUnit.SECONDS), "second flags load should complete")
-
-        // A response that explicitly carries false turns replay off and drops the cached config.
-        assertFalse(sut.isSessionReplayFlagActive())
-        assertNull(preferences.getValue(SESSION_REPLAY))
 
         sut.clear()
         http.shutdown()
@@ -232,100 +167,69 @@ internal class PostHogRemoteConfigTest {
         http.shutdown()
     }
 
-    @Test
-    fun `returns isSessionReplayFlagActive true if bool linked flag is enabled`() {
-        val file = File("src/test/resources/json/basic-flags-recording-bool-linked-enabled.json")
+    // The linkedFlag config comes from /config (cached); a /flags reload re-evaluates it against the
+    // new flags. Seed the cache, then load the flags fixture so reevaluate runs over those flags.
+    private fun assertReplayActiveForLinkedFlag(
+        cachedRecording: Map<String, Any?>,
+        flagsFixture: String,
+        expectedActive: Boolean,
+    ) {
+        preferences.setValue(SESSION_REPLAY, cachedRecording)
 
-        val http =
-            mockHttp(
-                response =
-                    MockResponse()
-                        .setBody(file.readText()),
-            )
-        val url = http.url("/")
-
-        val sut = getSut(host = url.toString())
+        val http = mockHttp(response = MockResponse().setBody(File(flagsFixture).readText()))
+        val sut = getSut(host = http.url("/").toString())
 
         sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap())
-
         executor.shutdownAndAwaitTermination()
 
-        assertTrue(sut.isSessionReplayFlagActive())
+        assertEquals(expectedActive, sut.isSessionReplayFlagActive())
 
         sut.clear()
         http.shutdown()
+    }
+
+    @Test
+    fun `returns isSessionReplayFlagActive true if bool linked flag is enabled`() {
+        assertReplayActiveForLinkedFlag(
+            cachedRecording = mapOf("endpoint" to "/b/", "linkedFlag" to "session-replay-flag"),
+            flagsFixture = "src/test/resources/json/basic-flags-recording-bool-linked-enabled.json",
+            expectedActive = true,
+        )
     }
 
     @Test
     fun `returns isSessionReplayFlagActive false if bool linked flag is disabled`() {
-        val file = File("src/test/resources/json/basic-flags-recording-bool-linked-disabled.json")
-
-        val http =
-            mockHttp(
-                response =
-                    MockResponse()
-                        .setBody(file.readText()),
-            )
-        val url = http.url("/")
-
-        val sut = getSut(host = url.toString())
-
-        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap())
-
-        executor.shutdownAndAwaitTermination()
-
-        assertFalse(sut.isSessionReplayFlagActive())
-
-        sut.clear()
-        http.shutdown()
+        assertReplayActiveForLinkedFlag(
+            cachedRecording = mapOf("endpoint" to "/b/", "linkedFlag" to "session-replay-flag"),
+            flagsFixture = "src/test/resources/json/basic-flags-recording-bool-linked-disabled.json",
+            expectedActive = false,
+        )
     }
 
     @Test
     fun `returns isSessionReplayFlagActive true if multi variant linked flag is a match`() {
-        val file = File("src/test/resources/json/basic-flags-recording-bool-linked-variant-match.json")
-
-        val http =
-            mockHttp(
-                response =
-                    MockResponse()
-                        .setBody(file.readText()),
-            )
-        val url = http.url("/")
-
-        val sut = getSut(host = url.toString())
-
-        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap())
-
-        executor.shutdownAndAwaitTermination()
-
-        assertTrue(sut.isSessionReplayFlagActive())
-
-        sut.clear()
-        http.shutdown()
+        assertReplayActiveForLinkedFlag(
+            cachedRecording =
+                mapOf(
+                    "endpoint" to "/b/",
+                    "linkedFlag" to mapOf("flag" to "session-replay-flag", "variant" to "variant-1"),
+                ),
+            flagsFixture = "src/test/resources/json/basic-flags-recording-bool-linked-variant-match.json",
+            expectedActive = true,
+        )
     }
 
     @Test
     fun `returns isSessionReplayFlagActive false if multi variant linked flag is not a match`() {
-        val file = File("src/test/resources/json/basic-flags-recording-bool-linked-variant-not-match.json")
-
-        val http =
-            mockHttp(
-                response =
-                    MockResponse()
-                        .setBody(file.readText()),
-            )
-        val url = http.url("/")
-
-        val sut = getSut(host = url.toString())
-
-        sut.loadFeatureFlags("my_identify", anonymousId = "anonId", emptyMap())
-
-        executor.shutdownAndAwaitTermination()
-
-        assertFalse(sut.isSessionReplayFlagActive())
-
-        sut.clear()
-        http.shutdown()
+        assertReplayActiveForLinkedFlag(
+            cachedRecording =
+                mapOf(
+                    "endpoint" to "/b/",
+                    "linkedFlag" to mapOf("flag" to "session-replay-flag", "variant" to "variant-1"),
+                ),
+            flagsFixture = "src/test/resources/json/basic-flags-recording-bool-linked-variant-not-match.json",
+            expectedActive = false,
+        )
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -75,6 +75,46 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
+    fun `keeps session replay active on a flags reload that omits sessionRecording`() {
+        // The first /flags load carries the recording config; the second omits it,
+        // which is what production /flags responses look like (config comes from /config).
+        val withRecording = File("src/test/resources/json/basic-flags-recording.json").readText()
+        val withoutRecording = File("src/test/resources/json/basic-flags-no-session-recording.json").readText()
+
+        val http = mockHttp(response = MockResponse().setBody(withRecording))
+        http.enqueue(MockResponse().setBody(withoutRecording))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        val firstLatch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { firstLatch.countDown() },
+        )
+        firstLatch.await(5, TimeUnit.SECONDS)
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        val secondLatch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { secondLatch.countDown() },
+        )
+        secondLatch.await(5, TimeUnit.SECONDS)
+
+        // The reload omits sessionRecording: it must re-evaluate from the cached config
+        // instead of clobbering the flag to false.
+        assertTrue(sut.isSessionReplayFlagActive())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
     fun `read session replay config from start`() {
         val flags = mapOf("endpoint" to "/b/")
         preferences.setValue(SESSION_REPLAY, flags)

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -120,6 +120,40 @@ internal class PostHogRemoteConfigTest {
     }
 
     @Test
+    fun `re-arms error tracking and capture performance on a quota-limited flags reload`() {
+        // Error tracking & capture performance also come from /config (cached); a flags reload that is
+        // quota-limited for feature_flags must still re-arm them instead of leaving them disabled.
+        preferences.setValue(ERROR_TRACKING, mapOf("autocaptureExceptions" to true))
+        preferences.setValue(CAPTURE_PERFORMANCE, mapOf("network_timing" to true))
+
+        val quotaLimited = File("src/test/resources/json/basic-flags-quota-limited.json").readText()
+        val http = mockHttp(response = MockResponse().setBody(quotaLimited))
+        val sut = getSut(host = http.url("/").toString())
+        config!!.errorTrackingConfig.autoCapture = true
+
+        // reset() zeroes the in-memory flags but keeps the cached config.
+        sut.clear()
+        assertFalse(sut.isAutocaptureExceptionsEnabled())
+        assertFalse(sut.isCaptureNetworkTimingEnabled())
+
+        val latch = CountDownLatch(1)
+        sut.loadFeatureFlags(
+            "my_identify",
+            anonymousId = "anonId",
+            emptyMap(),
+            onFeatureFlags = PostHogOnFeatureFlags { latch.countDown() },
+        )
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "flags load should complete")
+
+        // Re-armed from the cached config despite the flag quota limit.
+        assertTrue(sut.isAutocaptureExceptionsEnabled())
+        assertTrue(sut.isCaptureNetworkTimingEnabled())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
     fun `re-arm on a flags reload restores consoleLogRecordingEnabled from the cached config`() {
         preferences.setValue(SESSION_REPLAY, mapOf("consoleLogRecordingEnabled" to true))
 

--- a/posthog/src/test/resources/json/basic-flags-no-session-recording.json
+++ b/posthog/src/test/resources/json/basic-flags-no-session-recording.json
@@ -1,0 +1,9 @@
+{
+  "errorsWhileComputingFlags": false,
+  "featureFlagPayloads": {
+    "4535-funnel-bar-viz": "true"
+  },
+  "featureFlags": {
+    "4535-funnel-bar-viz": true
+  }
+}

--- a/posthog/src/test/resources/json/basic-flags-quota-limited.json
+++ b/posthog/src/test/resources/json/basic-flags-quota-limited.json
@@ -1,0 +1,6 @@
+{
+  "errorsWhileComputingFlags": false,
+  "quotaLimited": ["feature_flags"],
+  "featureFlagPayloads": {},
+  "featureFlags": {}
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

https://posthoghelp.zendesk.com/agent/tickets/58925 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/61593)

After an in-session `identify()` / `reset()`, session replay stopped recording and only resumed after an app restart.

The recording config (linked flag, sample rate, endpoint) comes only from `/config`, fetched once at startup. A `/flags` reload (triggered by `identify()`/`reset()`) doesn't carry it, and the SDK was treating that absence as "recording disabled" — clearing the config and the recording flag until the next startup.

The same root cause affected two sibling project-level configs that also come only from `/config`: **error tracking** (`autocaptureExceptions`) and **network performance capture** (`network_timing`). Both were wiped on `reset()` and stayed off until an app restart. This PR fixes all three: their config is preserved across `reset()` and re-armed from the cache on the next `/flags` reload.

## :green_heart: How did you test it?

Verified on a real Android device: `isSessionReplayActive` goes `false → true` after `reset()` → `identify()` → reload, without an app restart. The configs are project-level, so keeping them across an identity change doesn't change behavior for disabled projects (cleared on an explicit `false` from `/config`) or linked-flag projects (re-evaluated against the new user's flags).

Added unit tests covering: re-arm across reset for all three configs; linked-flag re-evaluation turning replay OFF for a user outside the rollout; an explicit `false` from `/config` evicting each cached config; the Gson round-trip for a variant linked flag; and `STRINGIFIED_KEYS` pruning in the Android preferences `clear()`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
