### PR TITLE
chore: update Sentry license attribution

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -22,7 +22,7 @@ SOFTWARE.
 
 ---
 
-Some files in this codebase contain code from getsentry/sentry-android-gradle-plugin by Software, Inc. dba Sentry.
+Some files in this codebase contain code from getsentry/sentry-android-gradle-plugin.
 In such cases it is explicitly stated in the file header. This license only applies to the relevant code in such cases.
 
 MIT License

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/DirectoryOutputTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/DirectoryOutputTask.kt
@@ -1,4 +1,6 @@
-// borrowed from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/DirectoryOutputTask.kt#L3
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/InjectPostHogMetaPropertiesIntoAssetsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/InjectPostHogMetaPropertiesIntoAssetsTask.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/InjectSentryMetaPropertiesIntoAssetsTask.kt#L31
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/OutputPaths.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/OutputPaths.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/sourcecontext/OutputPaths.kt#L1-L2
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryPlugin.kt#L9
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogCliExecTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogCliExecTask.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryCliExecTask.kt#L13
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogGenerateMapIdTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogGenerateMapIdTask.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryGenerateProguardUuidTask.kt#L12
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogTasksProvider.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogTasksProvider.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/SentryTasksProvider.kt#L10
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/SentryUploadProguardMappingsTask.kt#L16
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PropertiesFileOutputTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PropertiesFileOutputTask.kt
@@ -1,4 +1,6 @@
-// copied from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/tasks/PropertiesFileOutputTask.kt#L6
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/TasksUtils.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/TasksUtils.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/tasks.kt#L5
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/Utils.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/Utils.kt
@@ -1,4 +1,6 @@
-// adapted from https://github.com/getsentry/sentry-android-gradle-plugin/blob/0ce926822756c8379e281bed8c33237a400c9582/plugin-build/src/main/kotlin/io/sentry/android/gradle/util/Files.kt#L5
+// Portions of this file are derived from getsentry/sentry-android-gradle-plugin
+// Copyright (c) 2020 Sentry
+// Licensed under the MIT License: https://github.com/getsentry/sentry-android-gradle-plugin/blob/main/LICENSE
 
 package com.posthog.android
 


### PR DESCRIPTION
## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clarifies attribution for code derived from `getsentry/sentry-android-gradle-plugin` and aligns the repository license notice with the file headers.

## :green_heart: How did you test it?

Not run (license/header-only changes).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
