### PR TITLE
refactor: reduce Java duplicate candidates

### DIFF
--- a/.changeset/sharp-queue-files.md
+++ b/.changeset/sharp-queue-files.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Add QueueFile regression coverage for endian-safe header and element persistence.

--- a/posthog-samples/posthog-java-sample/src/main/java/com/posthog/java/sample/PostHogJavaExample.java
+++ b/posthog-samples/posthog-java-sample/src/main/java/com/posthog/java/sample/PostHogJavaExample.java
@@ -136,13 +136,26 @@ public class PostHogJavaExample {
         }
     }
 
-    private static void runCaptureExamples(PostHogInterface posthog) {
+    private static void printSectionHeader(String title) {
         System.out.println("\n" + "=".repeat(60));
-        System.out.println("CAPTURE EVENTS");
+        System.out.println(title);
         System.out.println("=".repeat(60));
+    }
 
+    private static String startUserExample(String title) {
+        printSectionHeader(title);
         String distinctId = "user_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
         System.out.println("\nUsing distinct ID: " + distinctId);
+        return distinctId;
+    }
+
+    private static void flushEvents(PostHogInterface posthog) {
+        posthog.flush();
+        System.out.println("   Events sent to PostHog");
+    }
+
+    private static void runCaptureExamples(PostHogInterface posthog) {
+        String distinctId = startUserExample("CAPTURE EVENTS");
 
         // Simple capture
         System.out.println("\nCapturing 'page_view' event...");
@@ -165,17 +178,11 @@ public class PostHogJavaExample {
 
         // Flush to ensure events are sent
         System.out.println("\nFlushing events...");
-        posthog.flush();
-        System.out.println("   Events sent to PostHog");
+        flushEvents(posthog);
     }
 
     private static void runIdentifyExamples(PostHogInterface posthog) {
-        System.out.println("\n" + "=".repeat(60));
-        System.out.println("IDENTIFY USERS");
-        System.out.println("=".repeat(60));
-
-        String distinctId = "user_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
-        System.out.println("\nUsing distinct ID: " + distinctId);
+        String distinctId = startUserExample("IDENTIFY USERS");
 
         // Identify with properties
         System.out.println("\nIdentifying user with properties...");
@@ -199,17 +206,11 @@ public class PostHogJavaExample {
         posthog.alias(distinctId, "user_alias_" + distinctId.substring(5));
         System.out.println("   Alias created");
 
-        posthog.flush();
-        System.out.println("   Events sent to PostHog");
+        flushEvents(posthog);
     }
 
     private static void runFeatureFlagExamples(PostHogInterface posthog) {
-        System.out.println("\n" + "=".repeat(60));
-        System.out.println("FEATURE FLAGS (Remote Evaluation)");
-        System.out.println("=".repeat(60));
-
-        String distinctId = "user_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
-        System.out.println("\nUsing distinct ID: " + distinctId);
+        String distinctId = startUserExample("FEATURE FLAGS (Remote Evaluation)");
 
         // Check a simple boolean flag
         System.out.println("\nChecking feature flag 'beta-feature'...");
@@ -240,9 +241,7 @@ public class PostHogJavaExample {
     }
 
     private static void runLocalEvaluationExample(PostHogInterface posthog, boolean hasPersonalApiKey) {
-        System.out.println("\n" + "=".repeat(60));
-        System.out.println("LOCAL EVALUATION WITH ETAG POLLING");
-        System.out.println("=".repeat(60));
+        printSectionHeader("LOCAL EVALUATION WITH ETAG POLLING");
 
         if (!hasPersonalApiKey) {
             System.out.println("\nThis example requires a Personal API Key to be set.");
@@ -291,12 +290,7 @@ public class PostHogJavaExample {
     }
 
     private static void runErrorTrackingExample(PostHogInterface posthog) {
-        System.out.println("\n" + "=".repeat(60));
-        System.out.println("ERROR TRACKING");
-        System.out.println("=".repeat(60));
-
-        String distinctId = "user_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
-        System.out.println("\nUsing distinct ID: " + distinctId);
+        String distinctId = startUserExample("ERROR TRACKING");
 
         System.out.println("\nCapturing an exception...");
         try {
@@ -309,8 +303,7 @@ public class PostHogJavaExample {
             System.out.println("   Exception captured: " + e.getMessage());
         }
 
-        posthog.flush();
-        System.out.println("   Events sent to PostHog");
+        flushEvents(posthog);
     }
 
     private static void runAllExamples(PostHogInterface posthog, boolean hasPersonalApiKey) {

--- a/posthog/src/main/java/com/posthog/internal/QueueFile.java
+++ b/posthog/src/main/java/com/posthog/internal/QueueFile.java
@@ -217,18 +217,12 @@ final class QueueFile implements Closeable, Iterable<byte[]> {
      * {@link RandomAccessFile#writeInt}.
      */
     private static void writeInt(byte[] buffer, int offset, int value) {
-        buffer[offset    ] = (byte) (value >> 24);
-        buffer[offset + 1] = (byte) (value >> 16);
-        buffer[offset + 2] = (byte) (value >> 8);
-        buffer[offset + 3] = (byte) value;
+        writeBigEndian(buffer, offset, value, Integer.BYTES);
     }
 
     /** Reads an {@code int} from the {@code byte[]}. */
     private static int readInt(byte[] buffer, int offset) {
-        return ((buffer[offset    ] & 0xff) << 24)
-                +  ((buffer[offset + 1] & 0xff) << 16)
-                +  ((buffer[offset + 2] & 0xff) << 8)
-                +   (buffer[offset + 3] & 0xff);
+        return (int) readBigEndian(buffer, offset, Integer.BYTES);
     }
 
     /**
@@ -236,26 +230,26 @@ final class QueueFile implements Closeable, Iterable<byte[]> {
      * {@link RandomAccessFile#writeLong}.
      */
     private static void writeLong(byte[] buffer, int offset, long value) {
-        buffer[offset    ] = (byte) (value >> 56);
-        buffer[offset + 1] = (byte) (value >> 48);
-        buffer[offset + 2] = (byte) (value >> 40);
-        buffer[offset + 3] = (byte) (value >> 32);
-        buffer[offset + 4] = (byte) (value >> 24);
-        buffer[offset + 5] = (byte) (value >> 16);
-        buffer[offset + 6] = (byte) (value >> 8);
-        buffer[offset + 7] = (byte) value;
+        writeBigEndian(buffer, offset, value, Long.BYTES);
     }
 
     /** Reads an {@code long} from the {@code byte[]}. */
     private static long readLong(byte[] buffer, int offset) {
-        return ((buffer[offset    ] & 0xffL) << 56)
-                +  ((buffer[offset + 1] & 0xffL) << 48)
-                +  ((buffer[offset + 2] & 0xffL) << 40)
-                +  ((buffer[offset + 3] & 0xffL) << 32)
-                +  ((buffer[offset + 4] & 0xffL) << 24)
-                +  ((buffer[offset + 5] & 0xffL) << 16)
-                +  ((buffer[offset + 6] & 0xffL) << 8)
-                +   (buffer[offset + 7] & 0xffL);
+        return readBigEndian(buffer, offset, Long.BYTES);
+    }
+
+    private static void writeBigEndian(byte[] buffer, int offset, long value, int byteCount) {
+        for (int i = byteCount - 1; i >= 0; i--) {
+            buffer[offset + byteCount - 1 - i] = (byte) (value >> (i * 8));
+        }
+    }
+
+    private static long readBigEndian(byte[] buffer, int offset, int byteCount) {
+        long value = 0;
+        for (int i = 0; i < byteCount; i++) {
+            value = (value << 8) + (buffer[offset + i] & 0xffL);
+        }
+        return value;
     }
 
     /**
@@ -308,19 +302,7 @@ final class QueueFile implements Closeable, Iterable<byte[]> {
      * @param count # of bytes to write
      */
     private void ringWrite(long position, byte[] buffer, int offset, int count) throws IOException {
-        position = wrapPosition(position);
-        if (position + count <= fileLength) {
-            raf.seek(position);
-            raf.write(buffer, offset, count);
-        } else {
-            // The write overlaps the EOF.
-            // # of bytes to write before the EOF. Guaranteed to be less than Integer.MAX_VALUE.
-            int beforeEof = (int) (fileLength - position);
-            raf.seek(position);
-            raf.write(buffer, offset, beforeEof);
-            raf.seek(headerLength);
-            raf.write(buffer, offset + beforeEof, count - beforeEof);
-        }
+        ringTransfer(position, buffer, offset, count, true);
     }
 
     private void ringErase(long position, long length) throws IOException {
@@ -340,18 +322,30 @@ final class QueueFile implements Closeable, Iterable<byte[]> {
      * @param count # of bytes to read
      */
     void ringRead(long position, byte[] buffer, int offset, int count) throws IOException {
+        ringTransfer(position, buffer, offset, count, false);
+    }
+
+    private void ringTransfer(long position, byte[] buffer, int offset, int count, boolean write)
+            throws IOException {
         position = wrapPosition(position);
         if (position + count <= fileLength) {
-            raf.seek(position);
-            raf.readFully(buffer, offset, count);
+            transfer(position, buffer, offset, count, write);
+            return;
+        }
+
+        // The transfer overlaps the EOF.
+        // # of bytes to transfer before the EOF. Guaranteed to be less than Integer.MAX_VALUE.
+        int beforeEof = (int) (fileLength - position);
+        transfer(position, buffer, offset, beforeEof, write);
+        transfer(headerLength, buffer, offset + beforeEof, count - beforeEof, write);
+    }
+
+    private void transfer(long position, byte[] buffer, int offset, int count, boolean write) throws IOException {
+        raf.seek(position);
+        if (write) {
+            raf.write(buffer, offset, count);
         } else {
-            // The read overlaps the EOF.
-            // # of bytes to read before the EOF. Guaranteed to be less than Integer.MAX_VALUE.
-            int beforeEof = (int) (fileLength - position);
-            raf.seek(position);
-            raf.readFully(buffer, offset, beforeEof);
-            raf.seek(headerLength);
-            raf.readFully(buffer, offset + beforeEof, count - beforeEof);
+            raf.readFully(buffer, offset, count);
         }
     }
 

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -22,6 +22,9 @@ public class ThrowableCoercer {
         return false
     }
 
+    @Suppress("DEPRECATION")
+    private fun getThreadId(thread: Thread): Long = thread.id
+
     public fun fromThrowableToPostHogProperties(
         throwable: Throwable,
         inAppIncludes: List<String> = listOf(),
@@ -43,9 +46,9 @@ public class ThrowableCoercer {
             isFatal = throwable.isFatal
             mechanismType = throwable.mechanism
             currentThrowable = throwable.cause
-            threadId = throwable.thread.id
+            threadId = getThreadId(throwable.thread)
         } else {
-            threadId = Thread.currentThread().id
+            threadId = getThreadId(Thread.currentThread())
         }
 
         while (currentThrowable != null && circularDetector.add(currentThrowable)) {

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -47,6 +47,9 @@ internal class PostHogTest {
     private val responseFlagsApi = file.readText()
 
     @Suppress("DEPRECATION")
+    private fun getThreadId(thread: Thread): Long = thread.id
+
+    @Suppress("DEPRECATION")
     fun getSut(
         host: String,
         flushAt: Int = 1,
@@ -2404,7 +2407,7 @@ internal class PostHogTest {
         assertEquals("Exception", causeExceptionData["type"])
         assertEquals("I am the cause", causeExceptionData["value"])
 
-        val threadId = Thread.currentThread().id
+        val threadId = getThreadId(Thread.currentThread())
         // Verify both exceptions have the required structure
         // Check main exception structure
         assertEquals("RuntimeException", mainException["type"])
@@ -2502,7 +2505,7 @@ internal class PostHogTest {
         assertEquals("RuntimeException", mainException["type"])
         assertEquals("Test exception message", mainException["value"])
 
-        assertEquals(thread.id, (mainException["thread_id"] as Number).toLong())
+        assertEquals(getThreadId(thread), (mainException["thread_id"] as Number).toLong())
 
         // Verify mechanism structure for main exception
         val mechanism = mainException["mechanism"] as Map<*, *>

--- a/posthog/src/test/java/com/posthog/internal/QueueFileTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/QueueFileTest.kt
@@ -1,0 +1,77 @@
+package com.posthog.internal
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class QueueFileTest {
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    @Test
+    fun `versioned queue persists header and element lengths in big endian order`() {
+        val file = File(tmpDir.newFolder(), "queue-file")
+        val firstPayload = ByteArray(257) { it.toByte() }
+        val secondPayload = byteArrayOf(0x7f, 0x80.toByte(), 0xff.toByte())
+
+        QueueFile.Builder(file).build().use { queue ->
+            queue.add(firstPayload)
+            queue.add(secondPayload)
+        }
+
+        val fileBytes = file.readBytes()
+        assertEquals(bytes(0x80, 0x00, 0x00, 0x01), fileBytes.bytesAt(0..3))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00), fileBytes.bytesAt(4..11))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x02), fileBytes.bytesAt(12..15))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20), fileBytes.bytesAt(16..23))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x25), fileBytes.bytesAt(24..31))
+        assertEquals(bytes(0x00, 0x00, 0x01, 0x01), fileBytes.bytesAt(32..35))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x03), fileBytes.bytesAt(293..296))
+
+        assertQueueContents(file, false, firstPayload, secondPayload)
+    }
+
+    @Test
+    fun `legacy queue persists header and element lengths in big endian order`() {
+        val file = File(tmpDir.newFolder(), "queue-file")
+        val firstPayload = ByteArray(257) { it.toByte() }
+        val secondPayload = byteArrayOf(0x7f, 0x80.toByte(), 0xff.toByte())
+
+        QueueFile.Builder(file).forceLegacy(true).build().use { queue ->
+            queue.add(firstPayload)
+            queue.add(secondPayload)
+        }
+
+        val fileBytes = file.readBytes()
+        assertEquals(bytes(0x00, 0x00, 0x10, 0x00), fileBytes.bytesAt(0..3))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x02), fileBytes.bytesAt(4..7))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x10), fileBytes.bytesAt(8..11))
+        assertEquals(bytes(0x00, 0x00, 0x01, 0x15), fileBytes.bytesAt(12..15))
+        assertEquals(bytes(0x00, 0x00, 0x01, 0x01), fileBytes.bytesAt(16..19))
+        assertEquals(bytes(0x00, 0x00, 0x00, 0x03), fileBytes.bytesAt(277..280))
+
+        assertQueueContents(file, true, firstPayload, secondPayload)
+    }
+
+    private fun assertQueueContents(
+        file: File,
+        forceLegacy: Boolean,
+        vararg expectedPayloads: ByteArray,
+    ) {
+        QueueFile.Builder(file).forceLegacy(forceLegacy).build().use { queue ->
+            assertEquals(expectedPayloads.size, queue.size())
+            expectedPayloads.forEach { expectedPayload ->
+                assertEquals(expectedPayload.toList(), queue.peek()!!.toList())
+                queue.remove()
+            }
+            assertTrue(queue.isEmpty())
+        }
+    }
+
+    private fun ByteArray.bytesAt(range: IntRange): List<Byte> = sliceArray(range).toList()
+
+    private fun bytes(vararg values: Int): List<Byte> = values.map { it.toByte() }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

This is a PoC for running `dry4java` against the Java sources and reducing the duplicate candidates it reported.

The default scan found duplicated ring buffer wrapping logic in `QueueFile`, and a looser scan also flagged repeated helper/demo structure in the Java sample.

Changes:
- Extract shared `QueueFile` big-endian read/write helpers for int/long serialization.
- Share `QueueFile` ring-buffer wrapping logic between reads and writes.
- Extract small Java sample helpers for section headers, user example setup, and flushing output.

## :green_heart: How did you test it?

- `dry4java --threshold 0.82 /Users/marandaneto/Github/posthog-android` → no duplicate candidates found
- `dry4java --threshold 0.70 /Users/marandaneto/Github/posthog-android` → no duplicate candidates found
- `./gradlew :posthog:compileJava -x :posthog:compileKotlin`
- `./gradlew :posthog-samples:posthog-java-sample:compileJava -x :posthog:compileKotlin -x :posthog-server:compileKotlin`
- `git diff --check`

Note: a full compile currently hits existing Kotlin `-Werror` deprecation warnings for `Thread.id` in `ThrowableCoercer.kt`, unrelated to this PoC.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
