### PR TITLE
refactor: remove duplicated code paths

### DIFF
--- a/.changeset/dry4kotlin-refactor.md
+++ b/.changeset/dry4kotlin-refactor.md
@@ -1,0 +1,7 @@
+---
+"posthog": patch
+"posthog-android": patch
+"posthog-server": patch
+---
+
+Refactor duplicated internal code paths without changing SDK behavior.

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -214,20 +214,28 @@ public fun Bitmap.isValid(): Boolean {
         height > 0
 }
 
+private fun webpLossyFormat(): Bitmap.CompressFormat =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        Bitmap.CompressFormat.WEBP_LOSSY
+    } else {
+        Bitmap.CompressFormat.WEBP
+    }
+
+private fun webpLosslessFormat(): Bitmap.CompressFormat =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        Bitmap.CompressFormat.WEBP_LOSSLESS
+    } else {
+        Bitmap.CompressFormat.WEBP
+    }
+
 @PostHogInternal
 @Suppress("DEPRECATION")
 public fun Bitmap.webpBase64(quality: Int = 30): String? {
     if (!isValid()) {
         return null
     }
-    val format =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Bitmap.CompressFormat.WEBP_LOSSY
-        } else {
-            Bitmap.CompressFormat.WEBP
-        }
 
-    return base64(format, quality)
+    return base64(webpLossyFormat(), quality)
 }
 
 @PostHogInternal
@@ -240,19 +248,8 @@ public fun Bitmap.base64(
         return null
     }
 
-    val lossyFormat =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Bitmap.CompressFormat.WEBP_LOSSY
-        } else {
-            Bitmap.CompressFormat.WEBP
-        }
-
-    val losslessFormat =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            Bitmap.CompressFormat.WEBP_LOSSLESS
-        } else {
-            Bitmap.CompressFormat.WEBP
-        }
+    val lossyFormat = webpLossyFormat()
+    val losslessFormat = webpLosslessFormat()
 
     val htmlFormat =
         when (format) {

--- a/posthog-server/src/main/java/com/posthog/server/PostHogBuilderUtils.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogBuilderUtils.kt
@@ -1,0 +1,29 @@
+package com.posthog.server
+
+internal fun <K, V> MutableMap<K, V>?.putBuilderValue(
+    key: K,
+    value: V,
+): MutableMap<K, V> = (this ?: mutableMapOf()).apply { put(key, value) }
+
+internal fun <K, V> MutableMap<K, V>?.putBuilderValues(values: Map<K, V>): MutableMap<K, V> =
+    (this ?: mutableMapOf()).apply { putAll(values) }
+
+internal fun <T> MutableList<T>?.addBuilderValues(values: List<T>): MutableList<T> = (this ?: mutableListOf()).apply { addAll(values) }
+
+internal fun MutableMap<String, MutableMap<String, Any?>>?.putBuilderGroupProperty(
+    group: String,
+    key: String,
+    value: Any?,
+): MutableMap<String, MutableMap<String, Any?>> =
+    (this ?: mutableMapOf()).apply {
+        getOrPut(group) { mutableMapOf() }[key] = value
+    }
+
+internal fun MutableMap<String, MutableMap<String, Any?>>?.putBuilderGroupProperties(
+    groupProperties: Map<String, Map<String, Any?>>,
+): MutableMap<String, MutableMap<String, Any?>> =
+    (this ?: mutableMapOf()).apply {
+        groupProperties.forEach { (group, properties) ->
+            getOrPut(group) { mutableMapOf() }.putAll(properties)
+        }
+    }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogCaptureOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogCaptureOptions.kt
@@ -64,10 +64,7 @@ public class PostHogCaptureOptions private constructor(
             key: String,
             value: Any,
         ): Builder {
-            properties =
-                (properties ?: mutableMapOf()).apply {
-                    put(key, value)
-                }
+            properties = properties.putBuilderValue(key, value)
             return this
         }
 
@@ -78,10 +75,7 @@ public class PostHogCaptureOptions private constructor(
          * @return This builder.
          */
         public fun properties(properties: Map<String, Any>): Builder {
-            this.properties =
-                (this.properties ?: mutableMapOf()).apply {
-                    putAll(properties)
-                }
+            this.properties = this.properties.putBuilderValues(properties)
             return this
         }
 
@@ -97,10 +91,7 @@ public class PostHogCaptureOptions private constructor(
             key: String,
             value: Any,
         ): Builder {
-            this.userProperties =
-                (this.userProperties ?: mutableMapOf()).apply {
-                    put(key, value)
-                }
+            this.userProperties = this.userProperties.putBuilderValue(key, value)
             return this
         }
 
@@ -112,10 +103,7 @@ public class PostHogCaptureOptions private constructor(
          * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
          */
         public fun userProperties(userProperties: Map<String, Any>): Builder {
-            this.userProperties =
-                (this.userProperties ?: mutableMapOf()).apply {
-                    putAll(userProperties)
-                }
+            this.userProperties = this.userProperties.putBuilderValues(userProperties)
             return this
         }
 
@@ -131,10 +119,7 @@ public class PostHogCaptureOptions private constructor(
             key: String,
             value: Any,
         ): Builder {
-            this.userPropertiesSetOnce =
-                (this.userPropertiesSetOnce ?: mutableMapOf()).apply {
-                    put(key, value)
-                }
+            this.userPropertiesSetOnce = this.userPropertiesSetOnce.putBuilderValue(key, value)
             return this
         }
 
@@ -146,10 +131,7 @@ public class PostHogCaptureOptions private constructor(
          * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
          */
         public fun userPropertiesSetOnce(userPropertiesSetOnce: Map<String, Any>): Builder {
-            this.userPropertiesSetOnce =
-                (this.userPropertiesSetOnce ?: mutableMapOf()).apply {
-                    putAll(userPropertiesSetOnce)
-                }
+            this.userPropertiesSetOnce = this.userPropertiesSetOnce.putBuilderValues(userPropertiesSetOnce)
             return this
         }
 
@@ -165,10 +147,7 @@ public class PostHogCaptureOptions private constructor(
             type: String,
             key: String,
         ): Builder {
-            this.groups =
-                (this.groups ?: mutableMapOf()).apply {
-                    put(type, key)
-                }
+            this.groups = this.groups.putBuilderValue(type, key)
             return this
         }
 
@@ -180,10 +159,7 @@ public class PostHogCaptureOptions private constructor(
          * @see <a href="https://posthog.com/docs/product-analytics/group-analytics">Documentation: Group Analytics</a>
          */
         public fun groups(groups: Map<String, String>): Builder {
-            this.groups =
-                (this.groups ?: mutableMapOf()).apply {
-                    putAll(groups)
-                }
+            this.groups = this.groups.putBuilderValues(groups)
             return this
         }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHogEvaluateFlagsOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogEvaluateFlagsOptions.kt
@@ -53,7 +53,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
             type: String,
             key: String,
         ): Builder {
-            this.groups = (groups ?: mutableMapOf()).apply { put(type, key) }
+            this.groups = groups.putBuilderValue(type, key)
             return this
         }
 
@@ -64,7 +64,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
          * @return This builder.
          */
         public fun groups(groups: Map<String, String>): Builder {
-            this.groups = (this.groups ?: mutableMapOf()).apply { putAll(groups) }
+            this.groups = this.groups.putBuilderValues(groups)
             return this
         }
 
@@ -79,7 +79,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
             key: String,
             value: Any?,
         ): Builder {
-            this.personProperties = (personProperties ?: mutableMapOf()).apply { put(key, value) }
+            this.personProperties = personProperties.putBuilderValue(key, value)
             return this
         }
 
@@ -90,7 +90,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
          * @return This builder.
          */
         public fun personProperties(personProperties: Map<String, Any?>): Builder {
-            this.personProperties = (this.personProperties ?: mutableMapOf()).apply { putAll(personProperties) }
+            this.personProperties = this.personProperties.putBuilderValues(personProperties)
             return this
         }
 
@@ -107,9 +107,8 @@ public class PostHogEvaluateFlagsOptions private constructor(
             key: String,
             value: Any?,
         ): Builder {
-            val existing = groupProperties?.get(type)?.toMutableMap() ?: mutableMapOf()
-            existing[key] = value
-            this.groupProperties = (groupProperties ?: mutableMapOf()).apply { put(type, existing) }
+            val existing = groupProperties?.get(type)?.toMutableMap().putBuilderValue(key, value)
+            this.groupProperties = groupProperties.putBuilderValue(type, existing)
             return this
         }
 
@@ -120,7 +119,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
          * @return This builder.
          */
         public fun groupProperties(groupProperties: Map<String, Map<String, Any?>>): Builder {
-            this.groupProperties = (this.groupProperties ?: mutableMapOf()).apply { putAll(groupProperties) }
+            this.groupProperties = this.groupProperties.putBuilderValues(groupProperties)
             return this
         }
 
@@ -134,7 +133,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
          * @return This builder.
          */
         public fun flagKeys(flagKeys: List<String>): Builder {
-            this.flagKeys = (this.flagKeys ?: mutableListOf()).apply { addAll(flagKeys) }
+            this.flagKeys = this.flagKeys.addBuilderValues(flagKeys)
             return this
         }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagOptions.kt
@@ -55,10 +55,7 @@ public class PostHogFeatureFlagOptions private constructor(
             key: String,
             propValue: String,
         ): Builder {
-            groups =
-                (groups ?: mutableMapOf()).apply {
-                    put(key, propValue)
-                }
+            groups = groups.putBuilderValue(key, propValue)
             return this
         }
 
@@ -69,10 +66,7 @@ public class PostHogFeatureFlagOptions private constructor(
          * @return This builder.
          */
         public fun groups(groups: Map<String, String>): Builder {
-            this.groups =
-                (this.groups ?: mutableMapOf()).apply {
-                    putAll(groups)
-                }
+            this.groups = this.groups.putBuilderValues(groups)
             return this
         }
 
@@ -88,10 +82,7 @@ public class PostHogFeatureFlagOptions private constructor(
             key: String,
             propValue: Any?,
         ): Builder {
-            personProperties =
-                (personProperties ?: mutableMapOf()).apply {
-                    put(key, propValue)
-                }
+            personProperties = personProperties.putBuilderValue(key, propValue)
             return this
         }
 
@@ -103,10 +94,7 @@ public class PostHogFeatureFlagOptions private constructor(
          * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
          */
         public fun personProperties(userProperties: Map<String, Any?>): Builder {
-            this.personProperties =
-                (this.personProperties ?: mutableMapOf()).apply {
-                    putAll(userProperties)
-                }
+            this.personProperties = this.personProperties.putBuilderValues(userProperties)
             return this
         }
 
@@ -123,10 +111,7 @@ public class PostHogFeatureFlagOptions private constructor(
             key: String,
             propValue: Any?,
         ): Builder {
-            groupProperties =
-                (groupProperties ?: mutableMapOf()).apply {
-                    getOrPut(group) { mutableMapOf() }[key] = propValue
-                }
+            groupProperties = groupProperties.putBuilderGroupProperty(group, key, propValue)
             return this
         }
 
@@ -137,12 +122,7 @@ public class PostHogFeatureFlagOptions private constructor(
          * @return This builder.
          */
         public fun groupProperties(groupProperties: Map<String, Map<String, Any?>>): Builder {
-            this.groupProperties =
-                (this.groupProperties ?: mutableMapOf()).apply {
-                    groupProperties.forEach { (group, properties) ->
-                        getOrPut(group) { mutableMapOf() }.putAll(properties)
-                    }
-                }
+            this.groupProperties = this.groupProperties.putBuilderGroupProperties(groupProperties)
             return this
         }
 

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagResultOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagResultOptions.kt
@@ -57,10 +57,7 @@ public class PostHogFeatureFlagResultOptions private constructor(
             key: String,
             propValue: String,
         ): Builder {
-            groups =
-                (groups ?: mutableMapOf()).apply {
-                    put(key, propValue)
-                }
+            groups = groups.putBuilderValue(key, propValue)
             return this
         }
 
@@ -71,10 +68,7 @@ public class PostHogFeatureFlagResultOptions private constructor(
          * @return This builder.
          */
         public fun groups(groups: Map<String, String>): Builder {
-            this.groups =
-                (this.groups ?: mutableMapOf()).apply {
-                    putAll(groups)
-                }
+            this.groups = this.groups.putBuilderValues(groups)
             return this
         }
 
@@ -90,10 +84,7 @@ public class PostHogFeatureFlagResultOptions private constructor(
             key: String,
             propValue: Any?,
         ): Builder {
-            personProperties =
-                (personProperties ?: mutableMapOf()).apply {
-                    put(key, propValue)
-                }
+            personProperties = personProperties.putBuilderValue(key, propValue)
             return this
         }
 
@@ -105,10 +96,7 @@ public class PostHogFeatureFlagResultOptions private constructor(
          * @see <a href="https://posthog.com/docs/product-analytics/user-properties">Documentation: User Properties</a>
          */
         public fun personProperties(userProperties: Map<String, Any?>): Builder {
-            this.personProperties =
-                (this.personProperties ?: mutableMapOf()).apply {
-                    putAll(userProperties)
-                }
+            this.personProperties = this.personProperties.putBuilderValues(userProperties)
             return this
         }
 
@@ -125,10 +113,7 @@ public class PostHogFeatureFlagResultOptions private constructor(
             key: String,
             propValue: Any?,
         ): Builder {
-            groupProperties =
-                (groupProperties ?: mutableMapOf()).apply {
-                    getOrPut(group) { mutableMapOf() }[key] = propValue
-                }
+            groupProperties = groupProperties.putBuilderGroupProperty(group, key, propValue)
             return this
         }
 
@@ -139,12 +124,7 @@ public class PostHogFeatureFlagResultOptions private constructor(
          * @return This builder.
          */
         public fun groupProperties(groupProperties: Map<String, Map<String, Any?>>): Builder {
-            this.groupProperties =
-                (this.groupProperties ?: mutableMapOf()).apply {
-                    groupProperties.forEach { (group, properties) ->
-                        getOrPut(group) { mutableMapOf() }.putAll(properties)
-                    }
-                }
+            this.groupProperties = this.groupProperties.putBuilderGroupProperties(groupProperties)
             return this
         }
 

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -530,6 +530,15 @@ internal class FlagEvaluator(
         return part.toIntOrNull()
     }
 
+    @Throws(InconclusiveMatchException::class)
+    private fun parseFlagConditionSemver(propertyValue: String): SemverVersion {
+        return try {
+            parseSemver(propertyValue)
+        } catch (e: InconclusiveMatchException) {
+            throw InconclusiveMatchException("The flag condition value is not a valid semver: ${e.message}")
+        }
+    }
+
     /**
      * Compare two semver versions using the specified operator
      */
@@ -556,12 +565,7 @@ internal class FlagEvaluator(
             PropertyOperator.SEMVER_LT,
             PropertyOperator.SEMVER_LTE,
             -> {
-                val conditionVersion =
-                    try {
-                        parseSemver(propertyString)
-                    } catch (e: InconclusiveMatchException) {
-                        throw InconclusiveMatchException("The flag condition value is not a valid semver: ${e.message}")
-                    }
+                val conditionVersion = parseFlagConditionSemver(propertyString)
                 compareSemverVersions(overrideVersion, conditionVersion, propertyOperator)
             }
 
@@ -614,12 +618,7 @@ internal class FlagEvaluator(
      */
     @Throws(InconclusiveMatchException::class)
     private fun computeTildeBounds(propertyValue: String): Pair<SemverVersion, SemverVersion> {
-        val version =
-            try {
-                parseSemver(propertyValue)
-            } catch (e: InconclusiveMatchException) {
-                throw InconclusiveMatchException("The flag condition value is not a valid semver: ${e.message}")
-            }
+        val version = parseFlagConditionSemver(propertyValue)
         val lower = version
         val upper = SemverVersion(version.major, version.minor + 1, 0)
         return Pair(lower, upper)
@@ -634,12 +633,7 @@ internal class FlagEvaluator(
      */
     @Throws(InconclusiveMatchException::class)
     private fun computeCaretBounds(propertyValue: String): Pair<SemverVersion, SemverVersion> {
-        val version =
-            try {
-                parseSemver(propertyValue)
-            } catch (e: InconclusiveMatchException) {
-                throw InconclusiveMatchException("The flag condition value is not a valid semver: ${e.message}")
-            }
+        val version = parseFlagConditionSemver(propertyValue)
         val lower = version
         val upper =
             when {

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlagCache.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlagCache.kt
@@ -24,29 +24,16 @@ internal class PostHogFeatureFlagCache(
      * Get feature flags from cache if present and not expired
      */
     @Synchronized
-    fun get(key: FeatureFlagCacheKey): Map<String, FeatureFlag>? {
-        val entry = cache[key]
-        if (entry == null) {
-            return null
-        }
-
-        if (entry.isExpired()) {
-            cache.remove(key)
-            return null
-        }
-
-        return entry.flags
-    }
+    fun get(key: FeatureFlagCacheKey): Map<String, FeatureFlag>? = getValidEntry(key)?.flags
 
     /**
      * Get full cache entry (including requestId and evaluatedAt) if present and not expired
      */
     @Synchronized
-    fun getEntry(key: FeatureFlagCacheKey): FeatureFlagCacheEntry? {
-        val entry = cache[key]
-        if (entry == null) {
-            return null
-        }
+    fun getEntry(key: FeatureFlagCacheKey): FeatureFlagCacheEntry? = getValidEntry(key)
+
+    private fun getValidEntry(key: FeatureFlagCacheKey): FeatureFlagCacheEntry? {
+        val entry = cache[key] ?: return null
 
         if (entry.isExpired()) {
             cache.remove(key)

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -638,19 +638,7 @@ internal class PostHogFeatureFlags(
         groups: Map<String, String>?,
         personProperties: Map<String, Any?>?,
         groupProperties: Map<String, Map<String, Any?>>?,
-    ): String? {
-        if (distinctId == null) {
-            return null
-        }
-        val cacheKey =
-            FeatureFlagCacheKey(
-                distinctId = distinctId,
-                groups = groups,
-                personProperties = personProperties,
-                groupProperties = groupProperties,
-            )
-        return cache.getEntry(cacheKey)?.requestId
-    }
+    ): String? = getCacheEntry(distinctId, groups, personProperties, groupProperties)?.requestId
 
     /**
      * Get the evaluatedAt from the cache for the given distinctId and groups
@@ -660,7 +648,14 @@ internal class PostHogFeatureFlags(
         groups: Map<String, String>?,
         personProperties: Map<String, Any?>?,
         groupProperties: Map<String, Map<String, Any?>>?,
-    ): Long? {
+    ): Long? = getCacheEntry(distinctId, groups, personProperties, groupProperties)?.evaluatedAt
+
+    private fun getCacheEntry(
+        distinctId: String?,
+        groups: Map<String, String>?,
+        personProperties: Map<String, Any?>?,
+        groupProperties: Map<String, Map<String, Any?>>?,
+    ): FeatureFlagCacheEntry? {
         if (distinctId == null) {
             return null
         }
@@ -671,7 +666,7 @@ internal class PostHogFeatureFlags(
                 personProperties = personProperties,
                 groupProperties = groupProperties,
             )
-        return cache.getEntry(cacheKey)?.evaluatedAt
+        return cache.getEntry(cacheKey)
     }
 
     /**

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsOptionsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsOptionsTest.kt
@@ -1,0 +1,80 @@
+package com.posthog.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class PostHogEvaluateFlagsOptionsTest {
+    @Test
+    fun `builder creates instance with default values`() {
+        val options = PostHogEvaluateFlagsOptions.builder().build()
+
+        assertNull(options.groups)
+        assertNull(options.personProperties)
+        assertNull(options.groupProperties)
+        assertNull(options.flagKeys)
+        assertEquals(false, options.onlyEvaluateLocally)
+        assertEquals(false, options.disableGeoip)
+    }
+
+    @Test
+    fun `builder accumulates groups person properties and flag keys`() {
+        val options =
+            PostHogEvaluateFlagsOptions.builder()
+                .group("organization", "org_123")
+                .groups(mapOf("team" to "team_456"))
+                .personProperty("plan", "premium")
+                .personProperty("nullable", null)
+                .personProperties(mapOf("role" to "admin"))
+                .flagKeys(listOf("flag-a"))
+                .flagKeys(listOf("flag-b", "flag-c"))
+                .onlyEvaluateLocally(true)
+                .disableGeoip(true)
+                .build()
+
+        assertEquals(mapOf("organization" to "org_123", "team" to "team_456"), options.groups)
+        assertEquals(mapOf("plan" to "premium", "nullable" to null, "role" to "admin"), options.personProperties)
+        assertEquals(listOf("flag-a", "flag-b", "flag-c"), options.flagKeys)
+        assertEquals(true, options.onlyEvaluateLocally)
+        assertEquals(true, options.disableGeoip)
+    }
+
+    @Test
+    fun `groupProperty appends to existing group properties without mutating input maps`() {
+        val companyProperties = mapOf<String, Any?>("industry" to "tech")
+        val input = mapOf("company" to companyProperties)
+
+        val options =
+            PostHogEvaluateFlagsOptions.builder()
+                .groupProperties(input)
+                .groupProperty("company", "size", "large")
+                .groupProperty("project", "tier", 2)
+                .build()
+
+        assertEquals(
+            mapOf(
+                "company" to mapOf("industry" to "tech", "size" to "large"),
+                "project" to mapOf("tier" to 2),
+            ),
+            options.groupProperties,
+        )
+        assertEquals(mapOf("industry" to "tech"), companyProperties)
+    }
+
+    @Test
+    fun `later values replace earlier values for matching keys`() {
+        val options =
+            PostHogEvaluateFlagsOptions.builder()
+                .group("organization", "org_123")
+                .group("organization", "org_456")
+                .personProperty("plan", "free")
+                .personProperty("plan", "premium")
+                .groupProperty("company", "size", "small")
+                .groupProperty("company", "size", "large")
+                .build()
+
+        assertEquals(mapOf("organization" to "org_456"), options.groups)
+        assertEquals(mapOf("plan" to "premium"), options.personProperties)
+        assertEquals(mapOf("company" to mapOf("size" to "large")), options.groupProperties)
+    }
+}

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagCacheTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagCacheTest.kt
@@ -42,6 +42,34 @@ internal class PostHogFeatureFlagCacheTest {
     }
 
     @Test
+    fun `getEntry returns metadata for non-expired entry`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
+        val key = createTestKey()
+        val flags = createTestFlags()
+
+        cache.put(key, flags, requestId = "req-123", evaluatedAt = 1234L, error = "flag_missing")
+        val entry = cache.getEntry(key)
+
+        assertNotNull(entry)
+        assertEquals(flags, entry.flags)
+        assertEquals("req-123", entry.requestId)
+        assertEquals(1234L, entry.evaluatedAt)
+        assertEquals("flag_missing", entry.error)
+    }
+
+    @Test
+    fun `getEntry returns null and removes expired entries`() {
+        val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 1)
+        val key = createTestKey()
+
+        cache.put(key, createTestFlags(), requestId = "req-123")
+        Thread.sleep(10)
+
+        assertNull(cache.getEntry(key))
+        assertEquals(0, cache.size())
+    }
+
+    @Test
     fun `get returns null for non-existent key`() {
         val cache = PostHogFeatureFlagCache(maxSize = 10, maxAgeMs = 60000)
         val key = createTestKey()

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -65,15 +65,7 @@ public class PostHogApi(
                 config.serializer.serialize(batch, it.bufferedWriter())
             }
 
-        logRequestHeaders(request)
-
-        client.newCall(request).execute().use {
-            val response = logResponse(it)
-
-            if (!response.isSuccessful) {
-                throw PostHogApiError(response.code, response.message, response.body, parseRetryAfter(response))
-            }
-        }
+        executeNoBody(request)
     }
 
     @Throws(PostHogApiError::class, IOException::class)
@@ -91,15 +83,7 @@ public class PostHogApi(
                 config.serializer.serialize(events, it.bufferedWriter())
             }
 
-        logRequestHeaders(request)
-
-        client.newCall(request).execute().use {
-            val response = logResponse(it)
-
-            if (!response.isSuccessful) {
-                throw PostHogApiError(response.code, response.message, response.body, parseRetryAfter(response))
-            }
-        }
+        executeNoBody(request)
     }
 
     /**
@@ -130,6 +114,11 @@ public class PostHogApi(
                 config.serializer.serialize(payload, it.bufferedWriter())
             }
 
+        executeNoBody(request)
+    }
+
+    @Throws(PostHogApiError::class, IOException::class)
+    private fun executeNoBody(request: Request) {
         logRequestHeaders(request)
 
         client.newCall(request).execute().use {

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationDeserializers.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationDeserializers.kt
@@ -64,15 +64,7 @@ public class PropertyValueDeserializer : JsonDeserializer<PropertyValue> {
         // If first element has both "type" AND "values" fields (but no "key"), it's nested PropertyGroups
         return if (firstObject.has("key")) {
             // FlagProperties
-            val properties =
-                array.mapNotNull { element ->
-                    if (element.isJsonObject) {
-                        deserializeFlagProperty(element.asJsonObject)
-                    } else {
-                        null
-                    }
-                }
-            PropertyValue.FlagProperties(properties)
+            PropertyValue.FlagProperties(deserializeFlagProperties(array))
         } else if (firstObject.has("type") && firstObject.has("values")) {
             // Nested PropertyGroups
             val groups =
@@ -82,17 +74,18 @@ public class PropertyValueDeserializer : JsonDeserializer<PropertyValue> {
             PropertyValue.PropertyGroups(groups)
         } else {
             // Otherwise treat as FlagProperties
-            val properties =
-                array.mapNotNull { element ->
-                    if (element.isJsonObject) {
-                        deserializeFlagProperty(element.asJsonObject)
-                    } else {
-                        null
-                    }
-                }
-            PropertyValue.FlagProperties(properties)
+            PropertyValue.FlagProperties(deserializeFlagProperties(array))
         }
     }
+
+    private fun deserializeFlagProperties(array: com.google.gson.JsonArray): List<FlagProperty> =
+        array.mapNotNull { element ->
+            if (element.isJsonObject) {
+                deserializeFlagProperty(element.asJsonObject)
+            } else {
+                null
+            }
+        }
 
     private fun deserializeFlagProperty(jsonObject: com.google.gson.JsonObject): FlagProperty? {
         val key = jsonObject.get("key")?.asString ?: return null

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -22,6 +22,7 @@ public class ThrowableCoercer {
         return false
     }
 
+    @Suppress("DEPRECATION")
     public fun fromThrowableToPostHogProperties(
         throwable: Throwable,
         inAppIncludes: List<String> = listOf(),

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyAppearancePositionAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyAppearancePositionAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveyAppearancePosition
-import java.lang.reflect.Type
 
-internal class GsonSurveyAppearancePositionAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveyAppearancePosition>,
-    JsonDeserializer<SurveyAppearancePosition> {
-    override fun serialize(
-        src: SurveyAppearancePosition,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveyAppearancePosition? {
-        return try {
-            return SurveyAppearancePosition.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyAppearancePositionAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveyAppearancePosition>(
+        config,
+        { it.value },
+        { SurveyAppearancePosition.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyAppearanceWidgetTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyAppearanceWidgetTypeAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveyAppearanceWidgetType
-import java.lang.reflect.Type
 
-internal class GsonSurveyAppearanceWidgetTypeAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveyAppearanceWidgetType>,
-    JsonDeserializer<SurveyAppearanceWidgetType> {
-    override fun serialize(
-        src: SurveyAppearanceWidgetType,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveyAppearanceWidgetType? {
-        return try {
-            return SurveyAppearanceWidgetType.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyAppearanceWidgetTypeAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveyAppearanceWidgetType>(
+        config,
+        { it.value },
+        { SurveyAppearanceWidgetType.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyEnumAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyEnumAdapter.kt
@@ -1,0 +1,36 @@
+package com.posthog.internal.surveys
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import com.posthog.PostHogConfig
+import java.lang.reflect.Type
+
+internal abstract class GsonSurveyEnumAdapter<T>(
+    private val config: PostHogConfig,
+    private val value: (T) -> String,
+    private val fromValue: (String) -> T?,
+) : JsonSerializer<T>, JsonDeserializer<T> {
+    override fun serialize(
+        src: T,
+        typeOfSrc: Type,
+        context: JsonSerializationContext,
+    ): JsonElement {
+        return context.serialize(value(src))
+    }
+
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext,
+    ): T? {
+        return try {
+            fromValue(json.asString)
+        } catch (e: Throwable) {
+            config.logger.log("${json.asString} isn't a known type: $e.")
+            null
+        }
+    }
+}

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyMatchTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyMatchTypeAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveyMatchType
-import java.lang.reflect.Type
 
-internal class GsonSurveyMatchTypeAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveyMatchType>,
-    JsonDeserializer<SurveyMatchType> {
-    override fun serialize(
-        src: SurveyMatchType,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveyMatchType? {
-        return try {
-            return SurveyMatchType.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyMatchTypeAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveyMatchType>(
+        config,
+        { it.value },
+        { SurveyMatchType.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyQuestionTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyQuestionTypeAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveyQuestionType
-import java.lang.reflect.Type
 
-internal class GsonSurveyQuestionTypeAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveyQuestionType>,
-    JsonDeserializer<SurveyQuestionType> {
-    override fun serialize(
-        src: SurveyQuestionType,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveyQuestionType? {
-        return try {
-            return SurveyQuestionType.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyQuestionTypeAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveyQuestionType>(
+        config,
+        { it.value },
+        { SurveyQuestionType.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyRatingDisplayTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyRatingDisplayTypeAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveyRatingDisplayType
-import java.lang.reflect.Type
 
-internal class GsonSurveyRatingDisplayTypeAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveyRatingDisplayType>,
-    JsonDeserializer<SurveyRatingDisplayType> {
-    override fun serialize(
-        src: SurveyRatingDisplayType,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveyRatingDisplayType? {
-        return try {
-            return SurveyRatingDisplayType.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyRatingDisplayTypeAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveyRatingDisplayType>(
+        config,
+        { it.value },
+        { SurveyRatingDisplayType.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyScheduleAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyScheduleAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveySchedule
-import java.lang.reflect.Type
 
-internal class GsonSurveyScheduleAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveySchedule>,
-    JsonDeserializer<SurveySchedule> {
-    override fun serialize(
-        src: SurveySchedule,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveySchedule? {
-        return try {
-            return SurveySchedule.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyScheduleAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveySchedule>(
+        config,
+        { it.value },
+        { SurveySchedule.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyTypeAdapter.kt
@@ -1,35 +1,11 @@
 package com.posthog.internal.surveys
 
-import com.google.gson.JsonDeserializationContext
-import com.google.gson.JsonDeserializer
-import com.google.gson.JsonElement
-import com.google.gson.JsonSerializationContext
-import com.google.gson.JsonSerializer
 import com.posthog.PostHogConfig
 import com.posthog.surveys.SurveyType
-import java.lang.reflect.Type
 
-internal class GsonSurveyTypeAdapter(private val config: PostHogConfig) :
-    JsonSerializer<SurveyType>,
-    JsonDeserializer<SurveyType> {
-    override fun serialize(
-        src: SurveyType,
-        typeOfSrc: Type,
-        context: JsonSerializationContext,
-    ): JsonElement {
-        return context.serialize(src.value)
-    }
-
-    override fun deserialize(
-        json: JsonElement,
-        typeOfT: Type,
-        context: JsonDeserializationContext,
-    ): SurveyType? {
-        return try {
-            return SurveyType.fromValue(json.asString)
-        } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
-            null
-        }
-    }
-}
+internal class GsonSurveyTypeAdapter(config: PostHogConfig) :
+    GsonSurveyEnumAdapter<SurveyType>(
+        config,
+        { it.value },
+        { SurveyType.fromValue(it) },
+    )

--- a/posthog/src/main/java/com/posthog/surveys/SurveyEnums.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyEnums.kt
@@ -1,5 +1,11 @@
 package com.posthog.surveys
 
+private fun <T> enumFromValue(
+    value: String,
+    values: Array<T>,
+    enumValue: (T) -> String,
+): T? where T : Enum<T> = values.firstOrNull { enumValue(it) == value }
+
 public enum class SurveyType(public val value: String) {
     POPOVER("popover"),
     API("api"),
@@ -7,14 +13,7 @@ public enum class SurveyType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyType? {
-            return when (value) {
-                "popover" -> POPOVER
-                "api" -> API
-                "widget" -> WIDGET
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -27,16 +26,7 @@ public enum class SurveyQuestionType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyQuestionType? {
-            return when (value) {
-                "open" -> OPEN
-                "link" -> LINK
-                "rating" -> RATING
-                "multiple_choice" -> MULTIPLE_CHOICE
-                "single_choice" -> SINGLE_CHOICE
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyQuestionType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -46,13 +36,7 @@ public enum class SurveyTextContentType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyTextContentType? {
-            return when (value) {
-                "html" -> HTML
-                "text" -> TEXT
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyTextContentType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -68,19 +52,7 @@ public enum class SurveyMatchType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyMatchType? {
-            return when (value) {
-                "regex" -> REGEX
-                "not_regex" -> NOT_REGEX
-                "exact" -> EXACT
-                "is_not" -> IS_NOT
-                "icontains" -> I_CONTAINS
-                "not_icontains" -> NOT_I_CONTAINS
-                "gt" -> GT
-                "lt" -> LT
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyMatchType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -91,14 +63,7 @@ public enum class SurveyAppearancePosition(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyAppearancePosition? {
-            return when (value) {
-                "left" -> LEFT
-                "right" -> RIGHT
-                "center" -> CENTER
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyAppearancePosition? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -109,14 +74,7 @@ public enum class SurveyAppearanceWidgetType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyAppearanceWidgetType? {
-            return when (value) {
-                "button" -> BUTTON
-                "tab" -> TAB
-                "selector" -> SELECTOR
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyAppearanceWidgetType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -126,13 +84,7 @@ public enum class SurveyRatingDisplayType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyRatingDisplayType? {
-            return when (value) {
-                "number" -> NUMBER
-                "emoji" -> EMOJI
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyRatingDisplayType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -144,15 +96,7 @@ public enum class SurveyQuestionBranchingType(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveyQuestionBranchingType? {
-            return when (value) {
-                "next_question" -> NEXT_QUESTION
-                "end" -> END
-                "response_based" -> RESPONSE_BASED
-                "specific_question" -> SPECIFIC_QUESTION
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveyQuestionBranchingType? = enumFromValue(value, values()) { it.value }
     }
 }
 
@@ -163,13 +107,6 @@ public enum class SurveySchedule(public val value: String) {
     ;
 
     public companion object {
-        public fun fromValue(value: String): SurveySchedule? {
-            return when (value) {
-                "once" -> ONCE
-                "recurring" -> RECURRING
-                "always" -> ALWAYS
-                else -> null
-            }
-        }
+        public fun fromValue(value: String): SurveySchedule? = enumFromValue(value, values()) { it.value }
     }
 }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -2358,6 +2358,7 @@ internal class PostHogTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `captureException captures exception with correct properties`() {
         val http = mockHttp()
         val url = http.url("/")
@@ -2460,6 +2461,7 @@ internal class PostHogTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `captureException unwraps and captures exception with correct properties`() {
         val http = mockHttp()
         val url = http.url("/")

--- a/posthog/src/test/java/com/posthog/surveys/SurveyEnumsTest.kt
+++ b/posthog/src/test/java/com/posthog/surveys/SurveyEnumsTest.kt
@@ -1,0 +1,33 @@
+package com.posthog.surveys
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+internal class SurveyEnumsTest {
+    @Test
+    fun `fromValue resolves every survey enum value`() {
+        SurveyType.values().forEach { assertEquals(it, SurveyType.fromValue(it.value)) }
+        SurveyQuestionType.values().forEach { assertEquals(it, SurveyQuestionType.fromValue(it.value)) }
+        SurveyTextContentType.values().forEach { assertEquals(it, SurveyTextContentType.fromValue(it.value)) }
+        SurveyMatchType.values().forEach { assertEquals(it, SurveyMatchType.fromValue(it.value)) }
+        SurveyAppearancePosition.values().forEach { assertEquals(it, SurveyAppearancePosition.fromValue(it.value)) }
+        SurveyAppearanceWidgetType.values().forEach { assertEquals(it, SurveyAppearanceWidgetType.fromValue(it.value)) }
+        SurveyRatingDisplayType.values().forEach { assertEquals(it, SurveyRatingDisplayType.fromValue(it.value)) }
+        SurveyQuestionBranchingType.values().forEach { assertEquals(it, SurveyQuestionBranchingType.fromValue(it.value)) }
+        SurveySchedule.values().forEach { assertEquals(it, SurveySchedule.fromValue(it.value)) }
+    }
+
+    @Test
+    fun `fromValue returns null for unknown survey enum values`() {
+        assertNull(SurveyType.fromValue("unknown"))
+        assertNull(SurveyQuestionType.fromValue("unknown"))
+        assertNull(SurveyTextContentType.fromValue("unknown"))
+        assertNull(SurveyMatchType.fromValue("unknown"))
+        assertNull(SurveyAppearancePosition.fromValue("unknown"))
+        assertNull(SurveyAppearanceWidgetType.fromValue("unknown"))
+        assertNull(SurveyRatingDisplayType.fromValue("unknown"))
+        assertNull(SurveyQuestionBranchingType.fromValue("unknown"))
+        assertNull(SurveySchedule.fromValue("unknown"))
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

This is a refactoring PoC driven by the dry4kotlin duplicate-code report (`/Users/marandaneto/Github/dry4kotlin/posthog-android-dry4kotlin.json`).

The goal is to reduce duplicated implementation details while preserving the existing public APIs and SDK behavior.

Changes include:
- Extract shared builder mutation helpers for server-side Java-friendly options.
- Extract a shared Gson survey enum adapter while keeping existing adapter class names/constructors.
- Centralize repeated survey enum `fromValue` lookup logic.
- Reuse small internal helpers for Android WebP format selection, no-body API request execution, semver condition parsing, feature flag cache entry lookup, and local-evaluation flag-property deserialization.
- Add minimal deprecation suppressions for existing `Thread.id` usages required by `-Werror`.
- Add a changeset for `posthog`, `posthog-android`, and `posthog-server` because all three SDK packages were touched.
- Added focused regression tests for `PostHogEvaluateFlagsOptions`, survey enum `fromValue` lookups, and feature flag cache `getEntry`.


## :green_heart: How did you test it?

- `make checkFormat`
- `./gradlew :posthog:compileKotlin :posthog-android:compileDebugKotlin :posthog-server:compileKotlin`
- `./gradlew :posthog:apiCheck :posthog-android:apiCheck :posthog-server:apiCheck`
- `./gradlew :posthog:compileKotlin :posthog:compileTestKotlin` (after resolving conflicts)
- `./gradlew :posthog:test --tests "com.posthog.surveys.SurveyEnumsTest"`
- `./gradlew :posthog-server:test --tests "com.posthog.server.PostHogEvaluateFlagsOptionsTest" --tests "com.posthog.server.internal.PostHogFeatureFlagCacheTest"`
- `./gradlew :posthog-server:test --tests "com.posthog.server.PostHogCaptureOptionsTest" --tests "com.posthog.server.PostHogFeatureFlagOptionsTest" --tests "com.posthog.server.PostHogFeatureFlagResultOptionsTest" --tests "com.posthog.server.internal.FlagEvaluatorTest" --tests "com.posthog.server.internal.PostHogFeatureFlagCacheTest"`
- `./gradlew :posthog:test --tests "com.posthog.internal.PostHogApiTest" --tests "com.posthog.surveys.*" --tests "com.posthog.FeatureFlagResultTest"`

Note: `make compile` reaches the test phase but currently fails on existing Mockito inline mocking issues on Java 21 (`Mockito cannot mock this class`) in mock-heavy tests unrelated to this refactor.


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->


