### PR TITLE
fix: keep surveys loaded across identify/reset

### DIFF
--- a/.changeset/surveys-survive-reset.md
+++ b/.changeset/surveys-survive-reset.md
@@ -1,0 +1,6 @@
+---
+"posthog": patch
+"posthog-android": patch
+---
+
+Keep surveys loaded after an in-session `identify()`/`reset()` instead of clearing them until the next app restart.

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -20,6 +20,7 @@ import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
+import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.internal.PostHogPreferences.Companion.VERSION
 import com.posthog.internal.PostHogPrintLogger
 import com.posthog.internal.PostHogQueue
@@ -1506,9 +1507,9 @@ public class PostHog private constructor(
         // Preserve BUILD and VERSION to prevent over-sending "Application Installed" events
         // and under-sending "Application Updated" events. Preserve DEVICE_ID to maintain
         // stable feature flag bucketing across identity changes.
-        // Preserve SESSION_REPLAY, ERROR_TRACKING, and CAPTURE_PERFORMANCE (project-level config from
-        // /config, not user data) so each can re-arm after an identity change without an app restart.
-        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE)
+        // Preserve SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE, and SURVEYS (project-level config
+        // from /config, not user data) so each survives an identity change without an app restart.
+        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE, SURVEYS)
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)
         if (config?.reuseAnonymousId == true) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -1231,10 +1231,8 @@ public class PostHogRemoteConfig(
         }
 
         synchronized(remoteConfigLock) {
-            clearSurveys()
-            // Zero the in-memory flags but keep the cached config so a reload can re-arm them.
-            // Deliberately NOT clearErrorTracking()/clearCapturePerformance(): those also evict the
-            // cache. An explicit `false` from /config is the only path that evicts.
+            // Zero error tracking / capture performance in memory (cache kept so a reload re-arms them).
+            // Surveys are kept entirely — they don't depend on flags, so no re-arm is needed.
             autoCaptureExceptions = false
             captureNetworkTiming = false
         }
@@ -1243,7 +1241,7 @@ public class PostHogRemoteConfig(
         resetPersonPropertiesForFlags()
         resetGroupPropertiesForFlags()
 
-        // SESSION_REPLAY, ERROR_TRACKING, and CAPTURE_PERFORMANCE are intentionally kept (project-level,
-        // not user data) so a reload can re-arm each without an app restart.
+        // SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE, and SURVEYS are intentionally kept
+        // (project-level, not user data) so each survives a reset without an app restart.
     }
 }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -9,6 +9,7 @@ import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.GROUP_PROPERTIES_FOR_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROPERTIES_FOR_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
+import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.internal.PostHogPrintLogger
 import com.posthog.internal.PostHogSendCachedEventsIntegration
 import com.posthog.internal.PostHogSerializer
@@ -58,6 +59,7 @@ internal class PostHogTest {
         reuseAnonymousId: Boolean = false,
         integration: PostHogIntegration? = null,
         remoteConfig: Boolean = false,
+        surveys: Boolean = false,
         cachePreferences: PostHogMemoryPreferences = PostHogMemoryPreferences(),
         propertiesSanitizer: PostHogPropertiesSanitizer? = null,
         beforeSend: PostHogBeforeSend? = null,
@@ -82,6 +84,7 @@ internal class PostHogTest {
                 this.propertiesSanitizer = propertiesSanitizer
                 this.evaluationContexts = evaluationContexts
                 this.remoteConfig = remoteConfig
+                this.surveys = surveys
                 if (beforeSend != null) {
                     addBeforeSend(beforeSend)
                 }
@@ -3254,12 +3257,17 @@ internal class PostHogTest {
         cachePreferences.setValue(SESSION_REPLAY, mapOf("endpoint" to "/b/"))
         cachePreferences.setValue(ERROR_TRACKING, mapOf("autocaptureExceptions" to true))
         cachePreferences.setValue(CAPTURE_PERFORMANCE, mapOf("network_timing" to true))
+        cachePreferences.setValue(
+            SURVEYS,
+            listOf(mapOf("id" to "s1", "name" to "Test Survey", "type" to "popover", "questions" to emptyList<Any>())),
+        )
 
         val sut =
             getSut(
                 url.toString(),
                 preloadFeatureFlags = false,
                 reloadFeatureFlags = false,
+                surveys = true,
                 cachePreferences = cachePreferences,
             )
 
@@ -3270,6 +3278,7 @@ internal class PostHogTest {
         assertNotNull(cachePreferences.getValue(SESSION_REPLAY))
         assertNotNull(cachePreferences.getValue(ERROR_TRACKING))
         assertNotNull(cachePreferences.getValue(CAPTURE_PERFORMANCE))
+        assertNotNull(cachePreferences.getValue(SURVEYS))
 
         sut.close()
     }

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -6,6 +6,7 @@ import com.posthog.PostHogOnFeatureFlags
 import com.posthog.internal.PostHogPreferences.Companion.CAPTURE_PERFORMANCE
 import com.posthog.internal.PostHogPreferences.Companion.ERROR_TRACKING
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
+import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.mockHttp
 import com.posthog.shutdownAndAwaitTermination
 import okhttp3.mockwebserver.MockResponse
@@ -17,6 +18,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -32,10 +34,12 @@ internal class PostHogRemoteConfigTest {
     private fun getSut(
         host: String,
         networkStatus: PostHogNetworkStatus? = null,
+        surveys: Boolean = false,
     ): PostHogRemoteConfig {
         config =
             PostHogConfig(API_KEY, host).apply {
                 this.networkStatus = networkStatus
+                this.surveys = surveys
                 cachePreferences = preferences
             }
         val api = PostHogApi(config!!)
@@ -1338,6 +1342,47 @@ internal class PostHogRemoteConfigTest {
         assertFalse(sut.isCaptureNetworkTimingEnabled())
 
         sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `surveys survive reset and stay in memory and cache`() {
+        preferences.setValue(
+            SURVEYS,
+            listOf(
+                mapOf(
+                    "id" to "s1",
+                    "name" to "Test Survey",
+                    "type" to "popover",
+                    "questions" to emptyList<Any>(),
+                ),
+            ),
+        )
+
+        val sut = getSut(host = "https://localhost", surveys = true)
+        assertEquals("s1", sut.getSurveys()?.single()?.id)
+
+        sut.clear()
+        assertEquals("s1", sut.getSurveys()?.single()?.id)
+        assertNotNull(preferences.getValue(SURVEYS))
+    }
+
+    @Test
+    fun `surveys loaded from remote config survive reset`() {
+        val file = File("src/test/resources/json/basic-remote-config-with-surveys.json")
+        val http = mockHttp(response = MockResponse().setBody(file.readText()))
+        val sut = getSut(host = http.url("/").toString(), surveys = true)
+
+        sut.loadRemoteConfig("my_identify", anonymousId = "anonId", emptyMap())
+        executor.shutdownAndAwaitTermination()
+
+        assertEquals("s1", sut.getSurveys()?.single()?.id)
+        assertNotNull(preferences.getValue(SURVEYS))
+
+        sut.clear()
+        assertEquals("s1", sut.getSurveys()?.single()?.id)
+        assertNotNull(preferences.getValue(SURVEYS))
+
         http.shutdown()
     }
 

--- a/posthog/src/test/resources/json/basic-remote-config-with-surveys.json
+++ b/posthog/src/test/resources/json/basic-remote-config-with-surveys.json
@@ -1,0 +1,22 @@
+{
+  "token": "phc_QFbR1y41s5sxnNTZoyKG2NJo2RlsCIWkUfdpawgb40D",
+  "supportedCompression": [
+    "gzip",
+    "gzip-js"
+  ],
+  "hasFeatureFlags": false,
+  "analytics": {
+    "endpoint": "/i/v0/e/"
+  },
+  "heatmaps": false,
+  "surveys": [
+    {
+      "id": "s1",
+      "name": "Test Survey",
+      "type": "popover",
+      "questions": []
+    }
+  ],
+  "defaultIdentifiedOnly": true,
+  "siteApps": []
+}


### PR DESCRIPTION
## 💡 Motivation and Context

Follow-up to #547. That PR made session replay, error tracking, and capture performance survive an in-session `identify()`/`reset()`; surveys were left as the follow-up.

Before this change, a `reset()` (or `identify()`) wiped surveys:
- `PostHog.reset()` didn't preserve the `SURVEYS` preference, and
- `PostHogRemoteConfig.clear()` called `clearSurveys()`, which evicted the cache **and** zeroed the in-memory list.

Since the survey catalog is only fetched at startup via `/config` (the `/flags` reload path deliberately skips it), surveys then disappeared until the next app restart.

Surveys are project-level config that **doesn't depend on feature flags** — per-user targeting (`linked_flag_key`/`targeting_flag_key`) is evaluated at display time against the current user's flags, which are reloaded on reset. So unlike the flag-derived settings, surveys don't need the zero-and-re-arm machinery; they just need to be **preserved**. This matches the iOS SDK, which keeps the cached remote config (including surveys) across `reset()`.

Changes:
- `PostHog.reset()`: add `SURVEYS` to the `except` preserve list.
- `PostHogRemoteConfig.clear()`: stop calling `clearSurveys()`, so the in-memory list and cache survive reset.

## 💚 How did you test it?

- New unit test: surveys preloaded from cache survive `clear()` (in-memory + cache).
- New unit test: surveys loaded via the live `/config` path (`loadRemoteConfig`) survive `clear()` — models the real in-session load → reset scenario.
- Extended `PostHogTest`'s `project-level remote config is preserved across reset` to assert the `SURVEYS` pref survives a real `identify()`/`reset()`.
- `./gradlew :posthog:test` (PostHogRemoteConfigTest + PostHogTest) and `spotlessCheck` pass.

## 📝 Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
