### PR TITLE
chore: gate release publishing behind environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,15 @@ jobs:
         environment: 'Release'
         permissions:
             contents: write
+            actions: write
         outputs:
             committed: ${{ steps.commit-version-bump.outputs.commit-hash != '' }}
+            packages-released: ${{ steps.publish-packages.outputs.packages-released }}
+        env:
+            SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+            SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         steps:
             - name: Notify Slack - Approved
               continue-on-error: true
@@ -132,6 +139,116 @@ jobs:
                 branch: main
               env:
                 GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
+            - name: Sync checkout to release commit
+              if: steps.commit-version-bump.outputs.commit-hash != ''
+              env:
+                  COMMIT_HASH: ${{ steps.commit-version-bump.outputs.commit-hash }}
+              run: |
+                  git fetch origin main
+                  git reset --hard "$COMMIT_HASH"
+
+            - name: 'Set up Java 17'
+              if: steps.commit-version-bump.outputs.commit-hash != ''
+              uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+              with:
+                  java-version: '17'
+                  distribution: 'temurin'
+
+            - name: Setup environment for publishing
+              if: steps.commit-version-bump.outputs.commit-hash != ''
+              uses: ./.github/actions/setup
+              with:
+                  install: false
+
+            - name: Publish packages
+              id: publish-packages
+              if: steps.commit-version-bump.outputs.commit-hash != ''
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+
+                  packages_released=false
+
+                  release_package() {
+                    local package_name="$1"
+                    local tag_prefix="$2"
+                    local make_dry_target="$3"
+                    local make_release_target="$4"
+                    local changelog_file="$5"
+
+                    local current_version
+                    local release_tag
+
+                    current_version=$(node -p "require('./${package_name}/package.json').version")
+                    if [ -z "$current_version" ]; then
+                      echo "Could not determine current version for $package_name"
+                      return 0
+                    fi
+
+                    release_tag="${tag_prefix}-v${current_version}"
+
+                    if git rev-parse "$release_tag" >/dev/null 2>&1; then
+                      echo "Tag $release_tag already exists - no new version to release"
+                      return 0
+                    fi
+
+                    echo "Tag $release_tag does not exist - new version detected: $current_version"
+
+                    make "$make_dry_target"
+                    make "$make_release_target"
+
+                    git tag -a "$release_tag" -m "$package_name $current_version"
+                    git push origin "$release_tag"
+
+                    # Read the latest changelog entry, skipping "## Next" and the version header line
+                    # e.g. given: ## Next\n\n# 3.32.1 - 2026-02-19\n\n- no user facing changes\n\n## 3.31.0 ...
+                    # it extracts: - no user facing changes
+                    LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '
+                      /^## Next/ { next }
+                      /^#+ [0-9]/ { if (found_version) exit; found_version=1; next }
+                      found_version && /^## / { exit }
+                      found_version { print }
+                      END { if (!found_version) print defText }
+                    ' "$changelog_file" | sed '/[^[:space:]]/,$!d' | tac | sed '/[^[:space:]]/,$!d' | tac)
+
+                    gh api \
+                      --method POST \
+                      -H "Accept: application/vnd.github+json" \
+                      -H "X-GitHub-Api-Version: 2022-11-28" \
+                      /repos/${{ github.repository }}/releases \
+                      -f tag_name="$release_tag" \
+                      -f target_commitish='main' \
+                      -f name="$release_tag" \
+                      -f body="$LAST_CHANGELOG_ENTRY" \
+                      -F draft=false \
+                      -F prerelease=false \
+                      -F generate_release_notes=false
+
+                    packages_released=true
+                  }
+
+                  # Order matters: posthog (core) must be released before dependents.
+                  release_package "posthog" "core" "dryReleaseCore" "releaseCore" "posthog/CHANGELOG.md"
+                  release_package "posthog-android" "android" "dryReleaseAndroid" "releaseAndroid" "posthog-android/CHANGELOG.md"
+                  release_package "posthog-server" "server" "dryReleaseServer" "releaseServer" "posthog-server/CHANGELOG.md"
+                  release_package "posthog-android-gradle-plugin" "androidPlugin" "dryReleaseAndroidPlugin" "releaseAndroidPlugin" "posthog-android-gradle-plugin/CHANGELOG.md"
+
+                  echo "packages-released=$packages_released" >> "$GITHUB_OUTPUT"
+
+            - name: Send failure event to PostHog
+              if: ${{ failure() }}
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
+                  event: 'posthog-android-github-release-workflow-failure'
+                  properties: >-
+                      {
+                        "commitSha": "${{ github.sha }}",
+                        "jobStatus": "${{ job.status }}",
+                        "ref": "${{ github.ref }}"
+                      }
+
             - name: Notify Slack - Failed
               continue-on-error: true
               if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
@@ -140,7 +257,7 @@ jobs:
                   slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
                   slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
                   thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to bump versions for `posthog-android`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
+                  message: '❌ Failed to release `posthog-android`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
                   emoji_reaction: 'x'
 
     notify-rejected:
@@ -183,174 +300,11 @@ jobs:
                   message: '${{ steps.check-rejection.outputs.message }}'
                   emoji_reaction: 'no_entry_sign'
 
-    publish:
-        name: Publish packages
-        needs: [version-bump, notify-approval-needed]
-        runs-on: ubuntu-latest
-        if: always() && needs.version-bump.outputs.committed == 'true'
-        permissions:
-            contents: write
-            actions: write
-        env:
-            SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-            SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-            GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        strategy:
-            # If any package fails to publish, stop immediately — don't publish dependents against a broken/missing dependency
-            fail-fast: true
-            # Order matters: posthog (core) must be released before posthog-android and posthog-server
-            # since they are transitive dependencies. We use max-parallel: 1 to enforce sequential execution.
-            max-parallel: 1
-            matrix:
-                package:
-                    - name: posthog
-                      tag_prefix: core
-                      make_dry_target: dryReleaseCore
-                      make_release_target: releaseCore
-                      changelog: posthog/CHANGELOG.md
-                    - name: posthog-android
-                      tag_prefix: android
-                      make_dry_target: dryReleaseAndroid
-                      make_release_target: releaseAndroid
-                      changelog: posthog-android/CHANGELOG.md
-                    - name: posthog-server
-                      tag_prefix: server
-                      make_dry_target: dryReleaseServer
-                      make_release_target: releaseServer
-                      changelog: posthog-server/CHANGELOG.md
-                    - name: posthog-android-gradle-plugin
-                      tag_prefix: androidPlugin
-                      make_dry_target: dryReleaseAndroidPlugin
-                      make_release_target: releaseAndroidPlugin
-                      changelog: posthog-android-gradle-plugin/CHANGELOG.md
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  ref: main
-                  fetch-depth: 0
-
-            - name: Configure Git
-              run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-
-            - name: 'Set up Java 17'
-              uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-              with:
-                  java-version: '17'
-                  distribution: 'temurin'
-
-            - name: Setup environment
-              uses: ./.github/actions/setup
-              with:
-                  install: false
-
-            - name: Detect version change for ${{ matrix.package.name }}
-              id: detect-version
-              run: |
-                  # Get the current version from the package's package.json (source of truth for changesets)
-                  CURRENT_VERSION=$(node -p "require('./${{ matrix.package.name }}/package.json').version")
-                  if [ -z "$CURRENT_VERSION" ]; then
-                    echo "Could not determine current version for ${{ matrix.package.name }}"
-                    echo "has-new-version=false" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
-
-                  TAG="${{ matrix.package.tag_prefix }}-v${CURRENT_VERSION}"
-
-                  # Check if this tag already exists
-                  if git rev-parse "$TAG" >/dev/null 2>&1; then
-                    echo "Tag $TAG already exists - no new version to release"
-                    echo "has-new-version=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "Tag $TAG does not exist - new version detected: $CURRENT_VERSION"
-                    echo "has-new-version=true" >> "$GITHUB_OUTPUT"
-                    echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-                    echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-                  fi
-
-            - name: Dry release ${{ matrix.package.name }}
-              if: steps.detect-version.outputs.has-new-version == 'true'
-              run: make ${{ matrix.package.make_dry_target }}
-
-            - name: Release ${{ matrix.package.name }}
-              if: steps.detect-version.outputs.has-new-version == 'true'
-              run: make ${{ matrix.package.make_release_target }}
-
-            - name: Tag and push ${{ matrix.package.name }}
-              if: steps.detect-version.outputs.has-new-version == 'true'
-              env:
-                  RELEASE_TAG: ${{ steps.detect-version.outputs.tag }}
-                  RELEASE_VERSION: ${{ steps.detect-version.outputs.version }}
-                  PACKAGE_NAME: ${{ matrix.package.name }}
-              run: |
-                  git tag -a "$RELEASE_TAG" -m "$PACKAGE_NAME $RELEASE_VERSION"
-                  git push origin "$RELEASE_TAG"
-
-            - name: Create GitHub release for ${{ matrix.package.name }}
-              if: steps.detect-version.outputs.has-new-version == 'true'
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  RELEASE_TAG: ${{ steps.detect-version.outputs.tag }}
-                  CHANGELOG_FILE: ${{ matrix.package.changelog }}
-              run: |
-                  # Read the latest changelog entry, skipping "## Next" and the version header line
-                  # e.g. given: ## Next\n\n# 3.32.1 - 2026-02-19\n\n- no user facing changes\n\n## 3.31.0 ...
-                  # it extracts: - no user facing changes
-                  LAST_CHANGELOG_ENTRY=$(awk -v defText="see CHANGELOG.md" '
-                    /^## Next/ { next }
-                    /^#+ [0-9]/ { if (found_version) exit; found_version=1; next }
-                    found_version && /^## / { exit }
-                    found_version { print }
-                    END { if (!found_version) print defText }
-                  ' "$CHANGELOG_FILE" | sed '/[^[:space:]]/,$!d' | tac | sed '/[^[:space:]]/,$!d' | tac)
-                  gh api \
-                    --method POST \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    /repos/${{ github.repository }}/releases \
-                    -f tag_name="$RELEASE_TAG" \
-                    -f target_commitish='main' \
-                    -f name="$RELEASE_TAG" \
-                    -f body="$LAST_CHANGELOG_ENTRY" \
-                    -F draft=false \
-                    -F prerelease=false \
-                    -F generate_release_notes=false
-
-            - name: Send failure event to PostHog
-              if: ${{ failure() }}
-              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
-              with:
-                  posthog-token: '${{ secrets.POSTHOG_PROJECT_API_KEY }}'
-                  event: 'posthog-android-github-release-workflow-failure'
-                  properties: >-
-                      {
-                        "commitSha": "${{ github.sha }}",
-                        "jobStatus": "${{ job.status }}",
-                        "ref": "${{ github.ref }}",
-                        "packageName": "${{ matrix.package.name }}",
-                        "packageVersion": "${{ steps.detect-version.outputs.version }}"
-                      }
-
-            - name: Notify Slack - Failed
-              continue-on-error: true
-              if: ${{ failure() && needs.notify-approval-needed.outputs.slack_ts != '' }}
-              uses: PostHog/.github/.github/actions/slack-thread-reply@5fc4680761e8ac29a61b212756230eba0e276d8c
-              with:
-                  slack_bot_token: ${{ secrets.SLACK_CLIENT_LIBRARIES_BOT_TOKEN }}
-                  slack_channel_id: ${{ vars.SLACK_APPROVALS_CLIENT_LIBRARIES_CHANNEL_ID }}
-                  thread_ts: ${{ needs.notify-approval-needed.outputs.slack_ts }}
-                  message: '❌ Failed to release `${{ matrix.package.name }}@${{ steps.detect-version.outputs.version }}`! <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>'
-                  emoji_reaction: 'x'
-
     notify-released:
         name: Notify Slack - Released
-        needs: [notify-approval-needed, publish]
+        needs: [notify-approval-needed, version-bump]
         runs-on: ubuntu-latest
-        if: always() && needs.publish.result == 'success' && needs.notify-approval-needed.outputs.slack_ts != ''
+        if: always() && needs.version-bump.result == 'success' && needs.version-bump.outputs.packages-released == 'true' && needs.notify-approval-needed.outputs.slack_ts != ''
         steps:
             - name: Checkout repository
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## :bulb: Motivation and Context

Release workflows should not rely on `needs:` as the only connection between an approved environment-gated job and the jobs that publish packages, push release tags, or create GitHub releases. A modified workflow could otherwise remove that dependency and run trusted release steps without the intended approval gate.

This PR keeps release side effects behind the protected release environment.

## :green_heart: How did you test it?

- Parsed the changed workflow YAML with Python/PyYAML.
- Ran `git diff --check`.
- Confirmed the branch contains the latest `origin/main` before opening this draft PR.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file
