### PR TITLE
feat: add public captureLog API with W3C trace correlation

### DIFF
--- a/.changeset/log-capture-trace-correlation.md
+++ b/.changeset/log-capture-trace-correlation.md
@@ -1,0 +1,6 @@
+---
+"posthog": minor
+"posthog-android": minor
+---
+
+Add a public `captureLog()` API for capturing logs with optional W3C trace correlation (`traceId`/`spanId`/`traceFlags`), matching iOS, web, and React Native. The `logger` facade is unchanged.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -28,6 +28,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogStateless, com/posth
 	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)V
 	public fun captureFeatureInteraction (Ljava/lang/String;Ljava/lang/String;)V
 	public fun captureFeatureView (Ljava/lang/String;Ljava/lang/String;)V
+	public fun captureLog (Ljava/lang/String;Lcom/posthog/logs/PostHogLogSeverity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
 	public fun close ()V
 	public fun distinctId ()Ljava/lang/String;
 	public fun endSession ()V
@@ -70,6 +71,7 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)V
 	public fun captureFeatureInteraction (Ljava/lang/String;Ljava/lang/String;)V
 	public fun captureFeatureView (Ljava/lang/String;Ljava/lang/String;)V
+	public fun captureLog (Ljava/lang/String;Lcom/posthog/logs/PostHogLogSeverity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
 	public fun close ()V
 	public fun debug (Z)V
 	public fun distinctId ()Ljava/lang/String;
@@ -324,6 +326,7 @@ public abstract interface class com/posthog/PostHogInterface : com/posthog/PostH
 	public abstract fun captureException (Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun captureFeatureInteraction (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun captureFeatureView (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun captureLog (Ljava/lang/String;Lcom/posthog/logs/PostHogLogSeverity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
 	public abstract fun distinctId ()Ljava/lang/String;
 	public abstract fun endSession ()V
 	public abstract fun getAllFeatureFlags ()Ljava/util/List;
@@ -358,6 +361,7 @@ public final class com/posthog/PostHogInterface$DefaultImpls {
 	public static synthetic fun captureException$default (Lcom/posthog/PostHogInterface;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun captureFeatureInteraction$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun captureFeatureView$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun captureLog$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Lcom/posthog/logs/PostHogLogSeverity;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
 	public static synthetic fun getFeatureFlag$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getFeatureFlagPayload$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getFeatureFlagResult$default (Lcom/posthog/PostHogInterface;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/posthog/FeatureFlagResult;

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -92,7 +92,10 @@ public class PostHog private constructor(
      *
      * Not to be confused with the internal `config.logger` debug sink.
      */
-    public override val logger: PostHogLogger = PostHogLogger(::captureLog)
+    public override val logger: PostHogLogger =
+        PostHogLogger { message, severity, attributes ->
+            captureLogInternal(message, severity, attributes, traceId = null, spanId = null, traceFlags = null)
+        }
 
     @Volatile
     private var lastScreenName: String? = null
@@ -668,18 +671,32 @@ public class PostHog private constructor(
         }
     }
 
-    /**
-     * Internal entry point invoked by [PostHogLogger]. Builds a record from
-     * the call-site arguments + capture-time context (distinctId, sessionId,
-     * screenName, app state, active feature flag keys), runs the `beforeSend`
-     * chain, and enqueues to the logs queue.
-     *
-     * No-ops when the SDK is disabled or opted-out.
-     */
-    internal fun captureLog(
+    public override fun captureLog(
         message: String,
         severity: PostHogLogSeverity,
         attributes: Map<String, Any>?,
+        traceId: String?,
+        spanId: String?,
+        traceFlags: Int?,
+    ) {
+        captureLogInternal(message, severity, attributes, traceId, spanId, traceFlags)
+    }
+
+    /**
+     * Shared implementation behind [captureLog] and the [logger] facade.
+     * Builds a record from the call-site arguments + capture-time context
+     * (distinctId, sessionId, screenName, app state, active feature flag
+     * keys), runs the `beforeSend` chain, and enqueues to the logs queue.
+     *
+     * No-ops when the SDK is disabled or opted-out.
+     */
+    private fun captureLogInternal(
+        message: String,
+        severity: PostHogLogSeverity,
+        attributes: Map<String, Any>?,
+        traceId: String?,
+        spanId: String?,
+        traceFlags: Int?,
     ) {
         try {
             if (!isEnabled()) return
@@ -699,6 +716,9 @@ public class PostHog private constructor(
                     // nested maps/lists inside it); the serializer reads it
                     // later on the logs executor thread.
                     attributes = attributes?.let { deepCopyAttributes(it) } ?: emptyMap(),
+                    traceId = traceId,
+                    spanId = spanId,
+                    traceFlags = traceFlags,
                     distinctId = distinctId.takeIf { it.isNotBlank() },
                     sessionId = PostHogSessionManager.getActiveSessionId()?.toString(),
                     screenName = lastScreenName,
@@ -1725,6 +1745,17 @@ public class PostHog private constructor(
          */
         public override val logger: PostHogLogger
             get() = shared.logger
+
+        public override fun captureLog(
+            message: String,
+            severity: PostHogLogSeverity,
+            attributes: Map<String, Any>?,
+            traceId: String?,
+            spanId: String?,
+            traceFlags: Int?,
+        ) {
+            shared.captureLog(message, severity, attributes, traceId, spanId, traceFlags)
+        }
 
         @PostHogVisibleForTesting
         public fun overrideSharedInstance(postHog: PostHogInterface) {

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -1,5 +1,6 @@
 package com.posthog
 
+import com.posthog.logs.PostHogLogSeverity
 import com.posthog.logs.PostHogLogger
 import java.util.Date
 import java.util.UUID
@@ -24,6 +25,46 @@ public interface PostHogInterface : PostHogCoreInterface {
      * Not to be confused with the internal `config.logger` debug sink.
      */
     public val logger: PostHogLogger
+
+    /**
+     * Captures a single log record into PostHog's logs product, with optional
+     * W3C distributed-tracing correlation.
+     *
+     * Prefer the [logger] facade ([logger].info, .error, …) for everyday
+     * logging. Reach for this entry point when you need to correlate a log
+     * with a distributed trace by attaching [traceId] / [spanId] / [traceFlags].
+     *
+     * ```kotlin
+     * posthog.captureLog(
+     *     "payment failed",
+     *     severity = PostHogLogSeverity.ERROR,
+     *     attributes = mapOf("code" to "PAY_3001"),
+     *     traceId = "4bf92f3577b34da6a3ce929d0e0e4736",
+     *     spanId = "00f067aa0ba902b7",
+     *     traceFlags = 0x01,
+     * )
+     * ```
+     *
+     * @param message the log message body; blank messages are dropped
+     * @param severity the log severity, defaults to [PostHogLogSeverity.INFO]
+     * @param attributes optional structured attributes; values must be
+     *   JSON-serializable (`String`, `Number`, `Boolean`, `Date`, lists or
+     *   maps of the same)
+     * @param traceId optional 32-character lowercase hex W3C trace id. The
+     *   ingestion service zeroes ids that are not exactly 16 bytes.
+     * @param spanId optional 16-character lowercase hex W3C span id. The
+     *   ingestion service zeroes ids that are not exactly 8 bytes.
+     * @param traceFlags optional W3C trace flags bitfield (bit 0 is the
+     *   `sampled` flag); emitted on the wire as `flags`.
+     */
+    public fun captureLog(
+        message: String,
+        severity: PostHogLogSeverity = PostHogLogSeverity.INFO,
+        attributes: Map<String, Any>? = null,
+        traceId: String? = null,
+        spanId: String? = null,
+        traceFlags: Int? = null,
+    )
 
     /**
      * Captures events

--- a/posthog/src/test/java/com/posthog/logs/PostHogLogRecordTest.kt
+++ b/posthog/src/test/java/com/posthog/logs/PostHogLogRecordTest.kt
@@ -105,6 +105,28 @@ internal class PostHogLogRecordTest {
     }
 
     @Test
+    fun `storage round-trip through serializer preserves traceFlags zero`() {
+        // The null-vs-zero boundary: 0x00 is a valid trace-flags value (sampled
+        // = false) and must survive persist->reload as 0, not collapse to null.
+        // Goes through the real codec to catch a JSON Number (Double/Long) that
+        // `fromStorageMap` must coerce back to Int 0.
+        val config = PostHogConfig(API_KEY)
+        val original = PostHogLogRecord(body = "zero", traceFlags = 0)
+        // The key must be present after toStorageMap — a `?.let` that ever became
+        // a falsy check (`takeIf { it != 0 }`) would silently drop it here.
+        assertTrue(original.toStorageMap().containsKey("traceFlags"))
+
+        val buf = ByteArrayOutputStream()
+        config.serializer.serialize(original.toStorageMap(), buf.writer().buffered())
+        val map: Map<String, Any> =
+            config.serializer.deserialize(
+                ByteArrayInputStream(buf.toByteArray()).reader().buffered(),
+            )!!
+        val restored = PostHogLogRecord.fromStorageMap(map)!!
+        assertEquals(0, restored.traceFlags)
+    }
+
+    @Test
     fun `storage map omits null optionals`() {
         val record = PostHogLogRecord(body = "minimal")
         val map = record.toStorageMap()

--- a/posthog/src/test/java/com/posthog/logs/PostHogLogsCaptureTest.kt
+++ b/posthog/src/test/java/com/posthog/logs/PostHogLogsCaptureTest.kt
@@ -88,6 +88,76 @@ internal class PostHogLogsCaptureTest {
     }
 
     @Test
+    fun `captureLog emits traceId spanId and flags on the wire`() {
+        val http = mockHttp()
+        val sut = getSut(http)
+
+        sut.captureLog(
+            "traced log",
+            severity = PostHogLogSeverity.ERROR,
+            attributes = mapOf("code" to "PAY_3001"),
+            traceId = "4bf92f3577b34da6a3ce929d0e0e4736",
+            spanId = "00f067aa0ba902b7",
+            traceFlags = 1,
+        )
+
+        logsExecutor.shutdown()
+        logsExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS)
+
+        val unzipped = http.takeRequest().body.unGzip()
+        // trace_flags is renamed to `flags` on the OTLP wire.
+        assertTrue(unzipped.contains("\"traceId\":\"4bf92f3577b34da6a3ce929d0e0e4736\""), unzipped)
+        assertTrue(unzipped.contains("\"spanId\":\"00f067aa0ba902b7\""), unzipped)
+        assertTrue(unzipped.contains("\"flags\":1"), unzipped)
+        // error → severityNumber 17
+        assertTrue(unzipped.contains("\"severityNumber\":17"), unzipped)
+
+        sut.close()
+        http.shutdown()
+    }
+
+    @Test
+    fun `captureLog with explicit traceFlags zero still emits flags 0`() {
+        val http = mockHttp()
+        val sut = getSut(http)
+
+        // 0x00 is a valid W3C trace-flags value (sampled = false). It must be
+        // emitted, not treated as "absent" — guards the null-vs-zero trap on
+        // the three `traceFlags?.let` sites.
+        sut.captureLog("zero flags", traceFlags = 0)
+
+        logsExecutor.shutdown()
+        logsExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS)
+
+        val unzipped = http.takeRequest().body.unGzip()
+        assertTrue(unzipped.contains("\"flags\":0"), unzipped)
+
+        sut.close()
+        http.shutdown()
+    }
+
+    @Test
+    fun `captureLog without trace fields omits traceId spanId and flags`() {
+        val http = mockHttp()
+        val sut = getSut(http)
+
+        sut.captureLog("plain log")
+
+        logsExecutor.shutdown()
+        logsExecutor.awaitTermination(2, java.util.concurrent.TimeUnit.SECONDS)
+
+        val unzipped = http.takeRequest().body.unGzip()
+        assertEquals(false, unzipped.contains("\"traceId\""), unzipped)
+        assertEquals(false, unzipped.contains("\"spanId\""), unzipped)
+        assertEquals(false, unzipped.contains("\"flags\""), unzipped)
+        // missing level defaults to info → severityNumber 9
+        assertTrue(unzipped.contains("\"severityNumber\":9"), unzipped)
+
+        sut.close()
+        http.shutdown()
+    }
+
+    @Test
     fun `logger info with blank message is a no-op`() {
         val http = mockHttp()
         val sut = getSut(http)

--- a/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
+++ b/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
@@ -1,6 +1,7 @@
 package com.posthog
 
 import com.posthog.internal.PostHogSessionManager
+import com.posthog.logs.PostHogLogSeverity
 import com.posthog.logs.PostHogLogger
 import java.util.Date
 import java.util.UUID
@@ -38,6 +39,16 @@ public class PostHogFake : PostHogInterface {
         this.event = event
         this.properties = properties
         captures++
+    }
+
+    override fun captureLog(
+        message: String,
+        severity: PostHogLogSeverity,
+        attributes: Map<String, Any>?,
+        traceId: String?,
+        spanId: String?,
+        traceFlags: Int?,
+    ) {
     }
 
     override fun captureException(


### PR DESCRIPTION
## :bulb: Motivation and Context

Android was the only PostHog SDK without a public `captureLog()` entry point that accepts W3C distributed-tracing fields. iOS, web, and React Native all let you attach `trace_id` / `span_id` / `trace_flags` to a log; on Android you could only set them by mutating the record inside a `beforeSend` hook — not a real API. The logs spec requires this entry point.

The record model (`PostHogLogRecord`) and OTLP serializer already carried the three fields and shipped them on the wire (as `traceId` / `spanId` / `flags`). The only gap was a public input path, so this is a thin wiring change rather than new plumbing.

## :green_heart: How did you test it?

- Added unit tests in `PostHogLogsCaptureTest`: trace fields land on the OTLP wire; omitted when absent (level defaults to `info`); explicit `traceFlags = 0` still emits `"flags":0` (the W3C sampled-false case, guarding the null-vs-zero trap).
- Full suite green: `PostHogLogsCaptureTest` 11/11, plus `PostHogLogRecordTest` / `PostHogLogsOTLPTest`.
- `apiCheck` green across modules after regenerating `posthog.api` (purely additive).

**Note for reviewers:** this adds a new `public abstract fun captureLog` to `PostHogInterface`. It's additive for callers and the regenerated `posthog.api` is additive-only; consistent with how `captureException` (#300) and `captureFeatureView`/`captureFeatureInteraction` (#416) were added. The `logger` facade signature/behavior is unchanged.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
