### PR TITLE
chore: remove sample network state permission

### DIFF
--- a/posthog-samples/posthog-android-sample/src/main/AndroidManifest.xml
+++ b/posthog-samples/posthog-android-sample/src/main/AndroidManifest.xml
@@ -2,9 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <!--    optional permission-->
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"


### PR DESCRIPTION
## :bulb: Motivation and Context

The Android sample app no longer needs to request `ACCESS_NETWORK_STATE`, so this removes the optional permission from the sample manifest.

## :green_heart: How did you test it?

Not run; manifest-only sample cleanup.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->
