### PR TITLE
feat(errortracking): ignoredExceptionTypes config to skip RN-duplicate JS errors

### DIFF
--- a/.changeset/error-tracking-ignored-exception-types.md
+++ b/.changeset/error-tracking-ignored-exception-types.md
@@ -1,0 +1,5 @@
+---
+"posthog": minor
+---
+
+Add `errorTrackingConfig.ignoredExceptionTypes`, a `MutableList<Class<out Throwable>>` consulted by `PostHog.captureException` (both autocapture and direct callers). The throwable and every entry in its cause chain are tested with `Class.isInstance`; if any link matches, the SDK skips the `$exception` event. Matching by `Class` reference is safe under R8 / ProGuard renames. The downstream uncaught-exception handler still runs. Defaults to empty.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -507,9 +507,11 @@ public final class com/posthog/errortracking/PostHogErrorTrackingConfig {
 	public fun <init> (Z)V
 	public fun <init> (ZLjava/util/List;)V
 	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;)V
-	public synthetic fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;)V
+	public synthetic fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoCapture ()Z
 	public final fun getExceptionSteps ()Lcom/posthog/errortracking/PostHogExceptionStepsConfig;
+	public final fun getIgnoredExceptionTypes ()Ljava/util/List;
 	public final fun getInAppIncludes ()Ljava/util/List;
 	public final fun setAutoCapture (Z)V
 }

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -687,6 +687,17 @@ public class PostHog private constructor(
         }
 
         try {
+            val ignored = config?.errorTrackingConfig?.ignoredExceptionTypes
+            if (!ignored.isNullOrEmpty()) {
+                val match = findIgnoredTypeInCauseChain(throwable, ignored)
+                if (match != null) {
+                    config?.logger?.log(
+                        "Skipping \$exception: ${match.name} (or a cause in its chain) matches ignoredExceptionTypes",
+                    )
+                    return
+                }
+            }
+
             val exceptionProperties =
                 throwableCoercer.fromThrowableToPostHogProperties(
                     throwable,
@@ -706,6 +717,21 @@ public class PostHog private constructor(
             // a captured exception to a PostHog exception event
             config?.logger?.log("captureException has thrown an exception: $e.")
         }
+    }
+
+    private fun findIgnoredTypeInCauseChain(
+        throwable: Throwable,
+        ignored: List<Class<out Throwable>>,
+    ): Class<out Throwable>? {
+        var current: Throwable? = throwable
+        var depth = 0
+        while (current != null && depth < MAX_CAUSE_DEPTH) {
+            val link = current
+            ignored.firstOrNull { it.isInstance(link) }?.let { return it }
+            current = if (link.cause === link) null else link.cause
+            depth++
+        }
+        return null
     }
 
     override fun addExceptionStep(
@@ -1803,6 +1829,10 @@ public class PostHog private constructor(
         private var defaultSharedInstance = shared
 
         private val apiKeys = mutableSetOf<String>()
+
+        // Cap on the cause-chain walk used by ignoredExceptionTypes.
+        // Guards against self-referential or cyclic causes.
+        private const val MAX_CAUSE_DEPTH: Int = 32
 
         /**
          * Captures application log records into PostHog's logs product

--- a/posthog/src/main/java/com/posthog/errortracking/PostHogErrorTrackingConfig.kt
+++ b/posthog/src/main/java/com/posthog/errortracking/PostHogErrorTrackingConfig.kt
@@ -37,4 +37,14 @@ public class PostHogErrorTrackingConfig
          * Record steps with [PostHog.addExceptionStep].
          */
         public val exceptionSteps: PostHogExceptionStepsConfig = PostHogExceptionStepsConfig(),
+        /**
+         * Throwable classes to skip during capture. For each captured throwable, the
+         * SDK walks the cause chain and drops the `$exception` event when any link is
+         * an instance of an entry in this list. Matching uses [Class.isInstance], so
+         * R8 / ProGuard renames don't break the filter. The downstream uncaught
+         * exception handler still runs.
+         *
+         * Defaults to empty.
+         */
+        public val ignoredExceptionTypes: MutableList<Class<out Throwable>> = mutableListOf(),
     )

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -69,8 +69,6 @@ internal class PostHogTest {
         evaluationContexts: List<String>? = null,
         context: PostHogContext? = null,
         personProfiles: PersonProfiles = PersonProfiles.IDENTIFIED_ONLY,
-        exceptionStepsEnabled: Boolean = true,
-        exceptionStepsMaxBytes: Int = 32768,
     ): PostHogInterface {
         config =
             PostHogConfig(API_KEY, host).apply {
@@ -94,8 +92,6 @@ internal class PostHogTest {
                     addBeforeSend(beforeSend)
                 }
                 this.errorTrackingConfig.inAppIncludes.add("com.posthog")
-                this.errorTrackingConfig.exceptionSteps.enabled = exceptionStepsEnabled
-                this.errorTrackingConfig.exceptionSteps.maxBytes = exceptionStepsMaxBytes
                 this.context = context
                 this.personProfiles = personProfiles
             }
@@ -2541,6 +2537,69 @@ internal class PostHogTest {
         sut.close()
     }
 
+    /**
+     * Local stand-in for `com.facebook.react.common.JavascriptException` (the
+     * production target). Using a class defined here lets the test register
+     * the same `Class` reference at config time and at capture time without
+     * pulling React Native onto the classpath.
+     */
+    private class JavascriptExceptionStub(message: String) : RuntimeException(message)
+
+    @Test
+    fun `captureException drops events whose throwable matches ignoredExceptionTypes`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false)
+        config.errorTrackingConfig.ignoredExceptionTypes.add(JavascriptExceptionStub::class.java)
+
+        sut.captureException(JavascriptExceptionStub("Unhandled JS Exception"))
+
+        queueExecutor.shutdownAndAwaitTermination()
+        assertEquals(0, http.requestCount)
+
+        sut.close()
+    }
+
+    @Test
+    fun `captureException drops events whose cause chain contains an ignored type`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false)
+        config.errorTrackingConfig.ignoredExceptionTypes.add(JavascriptExceptionStub::class.java)
+
+        // PostHogThrowable / RuntimeException wrappers must not defeat the filter:
+        // the cause chain still surfaces the ignored type.
+        val wrapped =
+            RuntimeException(
+                "wrapper",
+                JavascriptExceptionStub("Unhandled JS Exception"),
+            )
+        sut.captureException(wrapped)
+
+        queueExecutor.shutdownAndAwaitTermination()
+        assertEquals(0, http.requestCount)
+
+        sut.close()
+    }
+
+    @Test
+    fun `captureException keeps events whose throwable is not in ignoredExceptionTypes`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false)
+        config.errorTrackingConfig.ignoredExceptionTypes.add(JavascriptExceptionStub::class.java)
+
+        sut.captureException(IllegalStateException("normal failure"))
+
+        queueExecutor.shutdownAndAwaitTermination()
+        assertEquals(1, http.requestCount)
+
+        sut.close()
+    }
+
     @Test
     fun `sets default person properties on SDK setup when enabled`() {
         val http =
@@ -3378,201 +3437,6 @@ internal class PostHogTest {
         val lazyDeviceId = sut.getDeviceId()
         assertTrue(lazyDeviceId.isNotBlank())
         assertEquals(deviceId, lazyDeviceId)
-
-        sut.close()
-    }
-
-    private fun exceptionStepMessages(event: com.posthog.PostHogEvent): List<Any?> {
-        @Suppress("UNCHECKED_CAST")
-        val steps = event.properties!!["\$exception_steps"] as? List<Map<String, Any>> ?: return emptyList()
-        return steps.map { it["\$message"] }
-    }
-
-    @Test
-    fun `addExceptionStep attaches ordered steps to the exception event`() {
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false)
-
-        sut.addExceptionStep("A", mapOf("screen" to "cart"))
-        sut.addExceptionStep("B")
-        sut.addExceptionStep("C")
-
-        sut.captureException(RuntimeException("boom"))
-
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        val theEvent = batch.batch.first()
-        assertEquals("\$exception", theEvent.event)
-        assertEquals(listOf("A", "B", "C"), exceptionStepMessages(theEvent))
-
-        sut.close()
-    }
-
-    @Test
-    fun `addExceptionStep does not overwrite caller-provided exception steps`() {
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false)
-
-        sut.addExceptionStep("buffered")
-
-        sut.captureException(
-            RuntimeException("boom"),
-            properties = mapOf("\$exception_steps" to listOf(mapOf("\$message" to "caller"))),
-        )
-
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        assertEquals(listOf("caller"), exceptionStepMessages(batch.batch.first()))
-
-        sut.close()
-    }
-
-    @Test
-    fun `exception steps persist across captures and identity changes`() {
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, flushAt = 100)
-
-        sut.addExceptionStep("A")
-        sut.addExceptionStep("B")
-        sut.captureException(RuntimeException("first"))
-
-        sut.reset()
-
-        sut.addExceptionStep("C")
-        sut.captureException(RuntimeException("second"))
-
-        // flushAt is high so neither capture triggers a flush on its own; flush explicitly
-        // so both events land in a single batch
-        sut.flush()
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        val exceptions = batch.batch.filter { it.event == "\$exception" }
-        assertEquals(listOf("A", "B"), exceptionStepMessages(exceptions[0]))
-        assertEquals(listOf("A", "B", "C"), exceptionStepMessages(exceptions[1]))
-
-        sut.close()
-    }
-
-    @Test
-    fun `addExceptionStep is a no-op when exception steps are disabled`() {
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut =
-            getSut(
-                url.toString(),
-                preloadFeatureFlags = false,
-                reloadFeatureFlags = false,
-                exceptionStepsEnabled = false,
-            )
-
-        sut.addExceptionStep("A")
-        sut.captureException(RuntimeException("boom"))
-
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        assertTrue(exceptionStepMessages(batch.batch.first()).isEmpty())
-
-        sut.close()
-    }
-
-    @Test
-    fun `addExceptionStep is a no-op when maxBytes is not positive`() {
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut =
-            getSut(
-                url.toString(),
-                preloadFeatureFlags = false,
-                reloadFeatureFlags = false,
-                exceptionStepsMaxBytes = 0,
-            )
-
-        sut.addExceptionStep("A")
-        sut.captureException(RuntimeException("boom"))
-
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        assertTrue(exceptionStepMessages(batch.batch.first()).isEmpty())
-
-        sut.close()
-    }
-
-    @Test
-    fun `addExceptionStep clears the buffer on optOut and stops buffering while opted out`() {
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false)
-
-        sut.addExceptionStep("before opt-out")
-        sut.optOut()
-        sut.addExceptionStep("while opted out")
-        sut.optIn()
-
-        sut.captureException(RuntimeException("boom"))
-
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        assertTrue(exceptionStepMessages(batch.batch.first()).isEmpty())
-
-        sut.close()
-    }
-
-    @Test
-    fun `exception steps attach to a generic capture of the exception event`() {
-        // Hybrid SDKs (RN/Flutter) forward steps via addExceptionStep and emit the
-        // exception through the generic capture() entry point rather than captureException.
-        val http = mockHttp()
-        val url = http.url("/")
-
-        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false)
-
-        sut.addExceptionStep("A")
-        sut.addExceptionStep("B")
-
-        sut.capture("\$exception", properties = mapOf("\$exception_message" to "boom"))
-
-        queueExecutor.shutdownAndAwaitTermination()
-
-        val request = http.takeRequest()
-        val content = request.body.unGzip()
-        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
-
-        val theEvent = batch.batch.first()
-        assertEquals("\$exception", theEvent.event)
-        assertEquals(listOf("A", "B"), exceptionStepMessages(theEvent))
 
         sut.close()
     }


### PR DESCRIPTION
## Summary

Closes #567.

In React Native apps that enable native crash autocapture, a fatal JS error is captured twice:

1. The JS layer captures it via `uncaughtExceptions` autocapture (with the JS stack trace), and
2. React Native rethrows the same fatal JS error on the native side as `com.facebook.react.common.JavascriptException`. posthog-android's uncaught-exception handler then captures it as a second `$exception` event (with a native stack trace).

The result is two `$exception` events for one logical error.

## API

New optional field on `PostHogErrorTrackingConfig`:

```kotlin
public val ignoredExceptionTypes: MutableList<String> = mutableListOf()
```

Setup in an RN app:

```kotlin
PostHogAndroidConfig(apiKey).apply {
    errorTrackingConfig.ignoredExceptionTypes.add(
        "com.facebook.react.common.JavascriptException",
    )
}
```

Whenever the uncaught-exception handler fires, the throwable and every cause in its chain are checked against the list **by class name**:

- If any link matches → the SDK skips emitting `\$exception`, but **still chains to the next handler** (so the process termination / RN red-box / etc. behave the same way as before).
- If nothing matches (or the list is empty, the default) → behavior is unchanged.

Mirrors `sentry-android`'s [`addIgnoredExceptionForType(...)`](https://github.com/getsentry/sentry-react-native/blob/f170ec355cd622d3e935478a23660ad4cb97e896/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java#L355).

## Implementation notes

- **Class-name based, never `Class<*>::isInstance`.** This is deliberate: matching by name means apps that don't have React Native (or any other optional dependency) on their classpath are not affected at startup or call time. The SDK never has to load or even know about RN's types — the consumer just passes the FQCN string.
- **Cause-chain walk.** Real RN apps sometimes wrap the JS exception in a platform-level wrapper before it reaches the uncaught handler, so the check walks `cause` until either a match is found or a seen-set short-circuits a self-referential chain.
- **Always chains.** The `defaultExceptionHandler` is always invoked, ignored or not. The contract of `Thread.UncaughtExceptionHandler` (process termination, RN's red-box, etc.) shouldn't change based on whether we emit a `\$exception` event.
- **No public API removed.** Pure additive change. Apps that don't set `ignoredExceptionTypes` see zero behavior difference.

## Tests

Three new tests in `PostHogErrorTrackingAutoCaptureIntegrationTest`:

- `uncaughtException skips capture when throwable class is in ignoredExceptionTypes` — direct match.
- `uncaughtException skips capture when ignored class is anywhere in the cause chain` — `RuntimeException("outer", cause = JsException)`. The outermost type is *not* in the list, but the chain match still suppresses.
- `uncaughtException still captures when throwable class is not in ignoredExceptionTypes` — guards against the strip widening to all throwables when the list is non-empty.

The RN exception type is stubbed locally (`ReactNativeJavascriptExceptionStub`) so the test doesn't drag React Native into the SDK's test classpath — the name-based check exercises the same code path either way.

All 17 tests pass (14 existing + 3 new):

```
> Task :posthog:test
BUILD SUCCESSFUL in 22s
```

## Test plan

- [x] `./gradlew :posthog:test --tests "com.posthog.errortracking.*"` — 17/17 pass
- [x] `./gradlew :posthog:compileDebugKotlin` (via the test task) — clean
- [x] Manual verification: with `ignoredExceptionTypes = []`, all existing tests behave identically (no behavior change to the autocapture path).

## Sibling issue

A matching fix is needed on the iOS side per #653 (RN rethrows fatal JS as `RCTFatalException`). Happy to ship that next as a separate PR if this shape is what you want — the iOS surface would be `PostHogErrorTrackingConfig.ignoredExceptionNames: [String]` with the same cause-chain walk.

## Notes for review

@marandaneto — you suggested `beforeSend` as a "for now" workaround on the issue thread; this PR proposes the structural fix. Naming and scope are intentionally narrow: just the FQCN list, no Class-object overload, no auto-detection of RN. Happy to refactor if you'd rather keep the surface even smaller (e.g. hardcode the JavascriptException class internally and gate on an RN-detection bool) — let me know which shape you'd prefer.