### PR TITLE
chore: run required checks on docs-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Skip expensive CI for markdown-only PR
+      - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
+        run: echo "Only Markdown files changed; no additional work is required for this check."
       - name: Git checkout
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,27 +7,66 @@ on:
 
 permissions:
   contents: read
-
+  pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  detect-markdown-only:
+    name: Detect markdown-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      markdown_only: ${{ steps.detect.outputs.markdown_only }}
+    steps:
+      - name: Detect markdown-only PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
+
+          if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
+            markdown_only=false
+          elif grep -qvE '\.md$' "$RUNNER_TEMP/changed-files.txt"; then
+            markdown_only=false
+          else
+            markdown_only=true
+          fi
+
+          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
+          echo "markdown_only=$markdown_only"
+
   build:
+    needs: detect-markdown-only
     name: Build Job
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip expensive CI for markdown-only PR
+        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
       - name: Git checkout
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: 'Set up Java 17'
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache Gradle packages
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -38,7 +77,9 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Make compile
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: make compile
 
       - name: Make stop
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: make stop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,43 +7,15 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   detect-markdown-only:
-    name: Detect markdown-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      markdown_only: ${{ steps.detect.outputs.markdown_only }}
-    steps:
-      - name: Detect markdown-only PR
-        id: detect
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
-
-          if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
-            markdown_only=false
-          elif grep -qvE '\.md$' "$RUNNER_TEMP/changed-files.txt"; then
-            markdown_only=false
-          else
-            markdown_only=true
-          fi
-
-          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
-          echo "markdown_only=$markdown_only"
+    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
+    permissions:
+      pull-requests: read
 
   build:
     needs: detect-markdown-only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - "**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -17,9 +17,9 @@ jobs:
     needs: detect-markdown-only
     runs-on: ubuntu-latest
     steps:
-      - name: Skip expensive CI for markdown-only PR
+      - name: Complete markdown-only PR check
         if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
+        run: echo "Only Markdown files changed; no additional work is required for this check."
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
       - uses: gradle/actions/wrapper-validation@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,39 +7,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 jobs:
   detect-markdown-only:
-    name: Detect markdown-only changes
-    runs-on: ubuntu-latest
-    outputs:
-      markdown_only: ${{ steps.detect.outputs.markdown_only }}
-    steps:
-      - name: Detect markdown-only PR
-        id: detect
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
-
-          if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
-            markdown_only=false
-          elif grep -qvE '\.md$' "$RUNNER_TEMP/changed-files.txt"; then
-            markdown_only=false
-          else
-            markdown_only=true
-          fi
-
-          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
-          echo "markdown_only=$markdown_only"
+    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
+    permissions:
+      pull-requests: read
 
   validation:
     needs: detect-markdown-only

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,10 +7,48 @@ on:
 
 permissions:
   contents: read
-
+  pull-requests: read
 jobs:
+  detect-markdown-only:
+    name: Detect markdown-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      markdown_only: ${{ steps.detect.outputs.markdown_only }}
+    steps:
+      - name: Detect markdown-only PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh api --paginate "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --jq '.[].filename' > "$RUNNER_TEMP/changed-files.txt"
+
+          if [ ! -s "$RUNNER_TEMP/changed-files.txt" ]; then
+            markdown_only=false
+          elif grep -qvE '\.md$' "$RUNNER_TEMP/changed-files.txt"; then
+            markdown_only=false
+          else
+            markdown_only=true
+          fi
+
+          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
+          echo "markdown_only=$markdown_only"
+
   validation:
+    needs: detect-markdown-only
     runs-on: ubuntu-latest
     steps:
+      - name: Skip expensive CI for markdown-only PR
+        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed; marking this check successful without running expensive CI."
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
       - uses: gradle/actions/wrapper-validation@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - "**/*.md"
 
 permissions:
   contents: read

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,23 +4,15 @@ on:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - "**/*.md"
 
 permissions:
   contents: read
-jobs:
-  detect-markdown-only:
-    uses: PostHog/.github/.github/workflows/detect-markdown-only.yml@ec25337d9fae0100622cbfea1bd5bd88284ac10b
-    permissions:
-      pull-requests: read
 
+jobs:
   validation:
-    needs: detect-markdown-only
     runs-on: ubuntu-latest
     steps:
-      - name: Complete markdown-only PR check
-        if: needs.detect-markdown-only.outputs.markdown_only == 'true'
-        run: echo "Only Markdown files changed; no additional work is required for this check."
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
       - uses: gradle/actions/wrapper-validation@5e2ebd065dc2488b7a6ad670704656cbbe1e8f60 # v6.1.1
-        if: needs.detect-markdown-only.outputs.markdown_only != 'true'


### PR DESCRIPTION
## Problem

Required checks can remain permanently pending on docs-only PRs when the workflow that reports the required check is skipped by a PR path filter.

## Changes

- Keep required-check workflows running for PRs so required status contexts are always reported.
- Reuse the shared markdown-only detector from `PostHog/.github` pinned to `ec25337d9fae0100622cbfea1bd5bd88284ac10b`.
- Scope `pull-requests: read` to only the detector job.
- For PRs where every changed file ends in `.md`, each required job runs a neutral completion step and bypasses the build/test/lint work.
- For any PR with non-`.md` changes, the normal CI steps still run.

## How did you test this code?

- Reviewed the workflow diff.
- Ran `git diff --check`.
- Parsed the edited workflow YAML locally.
- Verified the copied detector implementation was removed and the shared workflow reference is pinned to the merged `.github` commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to apply this workflow change after markdown-only AI policy PRs exposed required checks that did not report. One subagent inspected each affected repo before implementation so the required job names and workflow structure stayed repo-specific. The common detector was then factored into `PostHog/.github` and referenced from this repo after that shared workflow merged.
