### PR TITLE
chore: deprecate getFeatureFlagPayload in favor of getFeatureFlagResult

### DIFF
--- a/.changeset/deprecate-getfeatureflagpayload.md
+++ b/.changeset/deprecate-getfeatureflagpayload.md
@@ -1,0 +1,6 @@
+---
+"posthog": patch
+"posthog-android": patch
+---
+
+Deprecate `getFeatureFlagPayload` in favor of `getFeatureFlagResult`, which returns the flag value and payload from a single evaluation. `getFeatureFlagPayload` continues to work.

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1435,6 +1435,7 @@ public class PostHog private constructor(
         return results
     }
 
+    @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
     public override fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,
@@ -1877,6 +1878,8 @@ public class PostHog private constructor(
             return shared.getAllFeatureFlags()
         }
 
+        @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
+        @Suppress("DEPRECATION")
         public override fun getFeatureFlagPayload(
             key: String,
             defaultValue: Any?,

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1436,7 +1436,7 @@ public class PostHog private constructor(
     }
 
     @Deprecated(
-        message = "Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation. Note: getFeatureFlagResult sends the \$feature_flag_called event by default, while getFeatureFlagPayload does not.",
+        message = "Use getFeatureFlagResult() instead; note it sends the \$feature_flag_called event by default.",
         replaceWith = ReplaceWith("getFeatureFlagResult(key)?.payload"),
     )
     public override fun getFeatureFlagPayload(
@@ -1882,7 +1882,7 @@ public class PostHog private constructor(
         }
 
         @Deprecated(
-            message = "Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation. Note: getFeatureFlagResult sends the \$feature_flag_called event by default, while getFeatureFlagPayload does not.",
+            message = "Use getFeatureFlagResult() instead; note it sends the \$feature_flag_called event by default.",
             replaceWith = ReplaceWith("getFeatureFlagResult(key)?.payload"),
         )
         @Suppress("DEPRECATION")

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1435,7 +1435,10 @@ public class PostHog private constructor(
         return results
     }
 
-    @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
+    @Deprecated(
+        message = "Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation. Note: getFeatureFlagResult sends the \$feature_flag_called event by default, while getFeatureFlagPayload does not.",
+        replaceWith = ReplaceWith("getFeatureFlagResult(key)?.payload"),
+    )
     public override fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,
@@ -1878,7 +1881,10 @@ public class PostHog private constructor(
             return shared.getAllFeatureFlags()
         }
 
-        @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
+        @Deprecated(
+            message = "Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation. Note: getFeatureFlagResult sends the \$feature_flag_called event by default, while getFeatureFlagPayload does not.",
+            replaceWith = ReplaceWith("getFeatureFlagResult(key)?.payload"),
+        )
         @Suppress("DEPRECATION")
         public override fun getFeatureFlagPayload(
             key: String,

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -144,7 +144,10 @@ public interface PostHogInterface : PostHogCoreInterface {
      * @param defaultValue the default value if not found
      * @return The feature flag payload, or [defaultValue] if not found.
      */
-    @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
+    @Deprecated(
+        message = "Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation. Note: getFeatureFlagResult sends the \$feature_flag_called event by default, while getFeatureFlagPayload does not.",
+        replaceWith = ReplaceWith("getFeatureFlagResult(key)?.payload"),
+    )
     public fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any? = null,

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -145,7 +145,7 @@ public interface PostHogInterface : PostHogCoreInterface {
      * @return The feature flag payload, or [defaultValue] if not found.
      */
     @Deprecated(
-        message = "Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation. Note: getFeatureFlagResult sends the \$feature_flag_called event by default, while getFeatureFlagPayload does not.",
+        message = "Use getFeatureFlagResult() instead; note it sends the \$feature_flag_called event by default.",
         replaceWith = ReplaceWith("getFeatureFlagResult(key)?.payload"),
     )
     public fun getFeatureFlagPayload(

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -144,6 +144,7 @@ public interface PostHogInterface : PostHogCoreInterface {
      * @param defaultValue the default value if not found
      * @return The feature flag payload, or [defaultValue] if not found.
      */
+    @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
     public fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any? = null,

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -529,6 +529,7 @@ internal class PostHogTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `getFeatureFlagPayload returns the value after reloaded`() {
         val http =
             mockHttp(

--- a/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
+++ b/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
@@ -83,6 +83,7 @@ public class PostHogFake : PostHogInterface {
         return null
     }
 
+    @Deprecated("Use getFeatureFlagResult() instead, which returns the flag value and payload from a single evaluation")
     override fun getFeatureFlagPayload(
         key: String,
         defaultValue: Any?,


### PR DESCRIPTION
## :bulb: Motivation and Context

`getFeatureFlagPayload` is being deprecated in favor of `getFeatureFlagResult` across PostHog's client SDKs (iOS already did this; posthog-js core + RN in a companion PR). `getFeatureFlagResult` returns the flag value and payload from a single evaluation, with proper `$feature_flag_called` tracking. This brings Android in line.

## :green_heart: How did you test it?

Annotation-only change (no behavior change) — `getFeatureFlagPayload` still works. Relying on CI for build + API checks.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed. (docs updated in a separate posthog.com PR)
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

Human-driven (agent-assisted).
