### PR TITLE
feat: expose getAnonymousId() on PostHogInterface

### DIFF
--- a/.changeset/expose-get-anonymous-id.md
+++ b/.changeset/expose-get-anonymous-id.md
@@ -1,0 +1,6 @@
+---
+"posthog": minor
+"posthog-android": minor
+---
+
+Expose `getAnonymousId()` on `PostHogInterface`. Returns the anonymous ID generated before any `identify()` call — unlike `distinctId()`, this does not change after identification. iOS SDK already had this; Android was the only platform missing it.

--- a/.changeset/expose-get-anonymous-id.md
+++ b/.changeset/expose-get-anonymous-id.md
@@ -3,4 +3,4 @@
 "posthog-android": minor
 ---
 
-Expose `getAnonymousId()` on `PostHogInterface`. Returns the anonymous ID generated before any `identify()` call — unlike `distinctId()`, this does not change after identification. iOS SDK already had this; Android was the only platform missing it.
+Expose `getAnonymousId()` on `PostHogInterface`. Returns the anonymous ID generated before any `identify()` call — unlike `distinctId()`, this does not change after identification.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.m2/repository/org/robolectric
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -34,6 +34,7 @@ public final class com/posthog/PostHog : com/posthog/PostHogStateless, com/posth
 	public fun endSession ()V
 	public fun flush ()V
 	public fun getAllFeatureFlags ()Ljava/util/List;
+	public fun getAnonymousId ()Ljava/lang/String;
 	public fun getConfig ()Lcom/posthog/PostHogConfig;
 	public fun getDeviceId ()Ljava/lang/String;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;
@@ -78,6 +79,7 @@ public final class com/posthog/PostHog$Companion : com/posthog/PostHogInterface 
 	public fun endSession ()V
 	public fun flush ()V
 	public fun getAllFeatureFlags ()Ljava/util/List;
+	public fun getAnonymousId ()Ljava/lang/String;
 	public fun getConfig ()Lcom/posthog/PostHogConfig;
 	public fun getDeviceId ()Ljava/lang/String;
 	public fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;
@@ -330,6 +332,7 @@ public abstract interface class com/posthog/PostHogInterface : com/posthog/PostH
 	public abstract fun distinctId ()Ljava/lang/String;
 	public abstract fun endSession ()V
 	public abstract fun getAllFeatureFlags ()Ljava/util/List;
+	public abstract fun getAnonymousId ()Ljava/lang/String;
 	public abstract fun getConfig ()Lcom/posthog/PostHogConfig;
 	public abstract fun getDeviceId ()Ljava/lang/String;
 	public abstract fun getFeatureFlag (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -383,6 +383,7 @@ public class PostHog private constructor(
         }
     }
 
+    @get:JvmName("getAnonymousIdInternal")
     private var anonymousId: String
         get() {
             var anonymousId: String?

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1591,6 +1591,13 @@ public class PostHog private constructor(
         return distinctId
     }
 
+    override fun getAnonymousId(): String {
+        if (!isEnabled()) {
+            return ""
+        }
+        return anonymousId
+    }
+
     override fun getDeviceId(): String {
         if (!isEnabled()) {
             return ""
@@ -1992,6 +1999,8 @@ public class PostHog private constructor(
         }
 
         override fun distinctId(): String = shared.distinctId()
+
+        override fun getAnonymousId(): String = shared.getAnonymousId()
 
         override fun getDeviceId(): String = shared.getDeviceId()
 

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -230,6 +230,17 @@ public interface PostHogInterface : PostHogCoreInterface {
     public fun distinctId(): String
 
     /**
+     * Returns the anonymous ID generated for this device before any [identify] call.
+     *
+     * Unlike [distinctId], this value does not change after [identify] — it always reflects
+     * the pre-identification anonymous identifier. Useful for linking anonymous sessions to
+     * identified users in downstream systems.
+     *
+     * @return The anonymous ID, or an empty string if not yet initialized.
+     */
+    public fun getAnonymousId(): String
+
+    /**
      * Returns the stable device identifier used for device-level feature flag bucketing.
      * This ID persists across [identify] and [reset] calls, only changing on a fresh
      * app install, manual cache clearing, or OS-initiated storage cleanup.

--- a/posthog/src/main/java/com/posthog/PostHogInterface.kt
+++ b/posthog/src/main/java/com/posthog/PostHogInterface.kt
@@ -236,7 +236,7 @@ public interface PostHogInterface : PostHogCoreInterface {
      * the pre-identification anonymous identifier. Useful for linking anonymous sessions to
      * identified users in downstream systems.
      *
-     * @return The anonymous ID, or an empty string if not yet initialized.
+     * @return The anonymous ID, or an empty string if the SDK is not enabled.
      */
     public fun getAnonymousId(): String
 

--- a/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
+++ b/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
@@ -189,6 +189,10 @@ public class PostHogFake : PostHogInterface {
         return ""
     }
 
+    override fun getAnonymousId(): String {
+        return ""
+    }
+
     override fun getDeviceId(): String {
         return ""
     }


### PR DESCRIPTION
## Summary

- Adds `getAnonymousId(): String` to `PostHogInterface`
- Implements it in `PostHog.kt` (reads the existing `anonymousId` field backed by SharedPreferences)
- Adds the delegation stub in the inner `NoOpPostHog` companion

The anonymous ID was already stored and managed internally — this just surfaces it through the public API.

## Motivation

iOS SDK already exposes `getAnonymousId()` publicly. Android was the only platform missing it, which blocked the [posthog-kmp](https://github.com/PostHog/posthog-kmp) KMP wrapper from implementing `getAnonymousId()` correctly. Without this, the KMP wrapper falls back to returning `distinctId()`, which is wrong for identified users.

Spotted in review: PostHog/posthog-kmp#1

## Test plan

- [ ] `getAnonymousId()` returns the anonymous ID before `identify()` is called
- [ ] `getAnonymousId()` still returns the original anonymous ID after `identify()` (does not change to the identified distinct ID)
- [ ] `getAnonymousId()` returns `""` when SDK is not enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)