### PR TITLE
fix: use uuid v7 for personless ids

### DIFF
--- a/.changeset/uuid-v7-personless-ids.md
+++ b/.changeset/uuid-v7-personless-ids.md
@@ -1,0 +1,7 @@
+---
+"posthog": patch
+"posthog-android": patch
+"posthog-server": patch
+---
+
+Generate UUID v7 values for SDK-created personless distinct IDs.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogRequestContext.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogRequestContext.kt
@@ -1,6 +1,6 @@
 package com.posthog.server
 
-import java.util.UUID
+import com.posthog.vendor.uuid.TimeBasedEpochGenerator
 
 /**
  * Request-scoped PostHog analytics context.
@@ -181,7 +181,7 @@ public class PostHogRequestContext private constructor() {
             val resolvedDistinctId = resolveDistinctId(distinctId)
             val isPersonless = resolvedDistinctId.isNullOrBlank()
             val mergedProperties = properties?.toMutableMap() ?: mutableMapOf()
-            val captureDistinctId = resolvedDistinctId ?: UUID.randomUUID().toString()
+            val captureDistinctId = resolvedDistinctId ?: TimeBasedEpochGenerator.generate().toString()
 
             if (isPersonless) {
                 mergedProperties.putIfAbsent(PROCESS_PERSON_PROFILE_PROPERTY, false)

--- a/posthog-server/src/test/java/com/posthog/server/PostHogRequestContextTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogRequestContextTest.kt
@@ -155,7 +155,8 @@ internal class PostHogRequestContextTest {
             val distinctId = batch.firstEvent?.get("distinct_id")?.asString
             assertNotNull(distinctId)
             assertNotEquals("header-user", distinctId)
-            assertTrue(runCatching { java.util.UUID.fromString(distinctId) }.isSuccess)
+            val parsedDistinctId = java.util.UUID.fromString(distinctId)
+            assertEquals(7, parsedDistinctId.version())
             val properties = batch.firstEventProperties()
             assertEquals(false, properties["\$process_person_profile"])
             assertFalse(properties.containsKey("\$session_id"))
@@ -176,7 +177,8 @@ internal class PostHogRequestContextTest {
             val batch = request.parseBatch()
             val distinctId = batch.firstEvent?.get("distinct_id")?.asString
             assertNotNull(distinctId)
-            assertTrue(runCatching { java.util.UUID.fromString(distinctId) }.isSuccess)
+            val parsedDistinctId = java.util.UUID.fromString(distinctId)
+            assertEquals(7, parsedDistinctId.version())
             val properties = batch.firstEventProperties()
             assertEquals(false, properties["\$process_person_profile"])
             assertEquals("present", properties["request"])

--- a/posthog/src/main/java/com/posthog/PostHogEvent.kt
+++ b/posthog/src/main/java/com/posthog/PostHogEvent.kt
@@ -16,7 +16,7 @@ import java.util.UUID
  * @property distinctId The distinct Id
  * @property properties All the event properties
  * @property timestamp The timestamp is automatically generated
- * @property uuid the UUID v4 is automatically generated and used for deduplication
+ * @property uuid the UUID v7 is automatically generated and used for deduplication
  */
 public data class PostHogEvent(
     val event: String,

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -13,8 +13,8 @@ import com.posthog.internal.PostHogPrintLogger
 import com.posthog.internal.PostHogQueueInterface
 import com.posthog.internal.PostHogThreadFactory
 import com.posthog.internal.errortracking.ThrowableCoercer
+import com.posthog.vendor.uuid.TimeBasedEpochGenerator
 import java.util.Date
-import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -599,7 +599,7 @@ public open class PostHogStateless protected constructor(
             var id = distinctId
             if (id.isNullOrBlank()) {
                 exceptionProperties.set("\$process_person_profile", false)
-                id = UUID.randomUUID().toString()
+                id = TimeBasedEpochGenerator.generate().toString()
             }
 
             captureStateless(PostHogEventName.EXCEPTION.event, distinctId = id, properties = exceptionProperties)

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import java.io.File
 import java.util.Date
+import java.util.UUID
 import java.util.concurrent.Executors
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -1349,7 +1350,7 @@ internal class PostHogStatelessTest {
     }
 
     @Test
-    fun `captureExceptionStateless without distinctId generates random UUID`() {
+    fun `captureExceptionStateless without distinctId generates UUID v7`() {
         val mockQueue = MockQueue()
         sut = createStatelessInstance()
         config = createConfig()
@@ -1365,6 +1366,7 @@ internal class PostHogStatelessTest {
         val event = mockQueue.events.first()
         assertTrue(event.distinctId.isNotBlank())
         assertTrue(event.distinctId.matches(("[0-9a-fA-F-]{36}".toRegex())))
+        assertEquals(7, UUID.fromString(event.distinctId).version())
         assertEquals(false, event.properties!!["\$process_person_profile"])
     }
 


### PR DESCRIPTION
## :bulb: Motivation and Context

SDK-generated IDs should use UUID v7 where possible for time-ordered identifiers. A couple of personless distinct ID fallback paths still used random UUID v4 generation, and the event UUID documentation still referred to v4 even though event UUIDs are already v7.

## :green_heart: How did you test it?

```bash
./gradlew :posthog:test --tests com.posthog.PostHogStatelessTest --tests com.posthog.vendor.uuid.UUIDTest :posthog-server:test --tests com.posthog.server.PostHogRequestContextTest
pnpm changeset status --since origin/main
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented the requested UUID v7 migration for the remaining runtime SDK-generated personless distinct IDs. Reused the existing `TimeBasedEpochGenerator.generate()` helper instead of adding a new dependency, and kept test-only arbitrary `UUID.randomUUID()` usages unchanged.
