### PR TITLE
fix: skip session replay event-trigger gating when running under React Native

### DIFF
--- a/.changeset/rn-skip-event-trigger-gating.md
+++ b/.changeset/rn-skip-event-trigger-gating.md
@@ -1,0 +1,6 @@
+---
+"posthog": patch
+"posthog-android": patch
+---
+
+Session replay: skip native event-trigger gating when running under React Native (`sdkName == "posthog-react-native"`). `PostHogRemoteConfig.getEventTriggers()` returns null for RN, so the native recorder no longer self-gates and `startSessionReplay` records as instructed. React Native evaluates `sessionRecording.eventTriggers` in its JS layer and drives recording explicitly; the native gate could never be satisfied because JS-captured events never reach the native capture pipeline, so event-triggered replay never recorded on RN. The linked-flag and sampling gates are unchanged, and non-RN behavior is unaffected.

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -1059,8 +1059,15 @@ public class PostHogRemoteConfig(
     /**
      * Returns the current event triggers for session recording, or null if not configured.
      * When event triggers are configured, session recording only starts after one of these events is captured.
+     *
+     * React Native evaluates event triggers in its JS layer; RN-captured events never reach the
+     * native capture() pipeline, so the native gate can't be satisfied. Returns null for RN — the
+     * JS layer owns them (linkedFlag and sampling gates still apply).
      */
-    public fun getEventTriggers(): Set<String>? = sessionRecordingEventTriggers
+    public fun getEventTriggers(): Set<String>? {
+        if (PostHogSessionManager.isReactNative) return null
+        return sessionRecordingEventTriggers
+    }
 
     /**
      * Returns the current minimum recording duration in milliseconds, or null if not set.

--- a/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogRemoteConfigTest.kt
@@ -49,6 +49,9 @@ internal class PostHogRemoteConfigTest {
     @BeforeTest
     fun `set up`() {
         preferences.clear()
+        // isReactNative is a process-global flag on the PostHogSessionManager singleton; reset it so a
+        // test in another suite that sets it true can't leak into these (e.g. flip getEventTriggers to null).
+        PostHogSessionManager.isReactNative = false
     }
 
     @Test
@@ -1991,6 +1994,33 @@ internal class PostHogRemoteConfigTest {
 
         val sut = getSut(host = url.toString())
 
+        assertEquals(triggers.toSet(), sut.getEventTriggers())
+
+        sut.clear()
+        http.shutdown()
+    }
+
+    @Test
+    fun `getEventTriggers returns null for react native even when configured`() {
+        val triggers = listOf("checkout_started", "payment_completed")
+        preferences.setValue(SESSION_REPLAY, mapOf("eventTriggers" to triggers))
+
+        val http =
+            mockHttp(
+                response =
+                    MockResponse()
+                        .setBody(responseFlagsApi),
+            )
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        // React Native evaluates event triggers in its JS layer, so the native gate opts out.
+        PostHogSessionManager.isReactNative = true
+        assertNull(sut.getEventTriggers())
+
+        // Non-RN still receives the configured set.
+        PostHogSessionManager.isReactNative = false
         assertEquals(triggers.toSet(), sut.getEventTriggers())
 
         sut.clear()


### PR DESCRIPTION
## :bulb: Motivation and Context

**This is groundwork, not a feature.** It *enables* React Native session-replay event triggers but does not implement them. The RN feature lives entirely in the JS layer — [PostHog/posthog-js#3932](https://github.com/PostHog/posthog-js/pull/3932), shipped to apps via `@posthog/react-native-plugin` — where event triggers are evaluated and recording is started/stopped explicitly. On its own, this PR adds **no behavior change for native Android consumers**; it only takes effect when the SDK is run under React Native.

Why it's required for the RN feature to work: posthog-android fetches its own remote config (`GET /array/{key}/config`) and applies its **own** session-replay event-trigger gate in `PostHogReplayIntegration.start()` via `shouldWaitForEventTriggers()`. That gate is only released by `onEvent(...)`, which fires solely from the native in-process `PostHog.capture()` path. React Native captures events in its JS layer and sends them over its own network path, so `onEvent` never sees them — the native gate can **never** be satisfied, and RN event-triggered replay would never record (`isSessionReplayActive()` stays false, no snapshots).

This change makes `PostHogRemoteConfig.getEventTriggers()` return `null` when the SDK is driven by React Native (`PostHogSessionManager.isReactNative`, derived from `config.sdkName == "posthog-react-native"`), so the native recorder defers to the JS layer. That single chokepoint covers all three gate sites (`start`, `onEvent`, `onSessionIdChanged`) and survives remote-config refresh. Non-RN behavior is unchanged; the linked-flag / master recording flag and sampling gates still apply.

Part of a cross-repo change — see **Merge order**.

## :green_heart: How did you test it?

- **Manual, end-to-end:** built the posthog-js Expo example against this branch (published to `mavenLocal`, resolved into the example) on a Pixel 8 (API-equivalent) emulator, against a project configured with an `open_replay_screen_tapped` event trigger.
  - Before this change: the recorder logged "Integration will not start until any of these events are captured", `isSessionReplayActive()` was false, and 0 snapshots were buffered.
  - With this change: firing the configured event starts the native recorder — `$snapshot` events are captured and POST to `/s/` successfully, and the UI status reads `Active: true`. The "will not start" gate log is gone.
- **Non-RN unaffected:** `isReactNative` defaults to false and only flips for `sdkName == "posthog-react-native"`, so native Android / Flutter / JVM behavior is unchanged.
- **Unit test:** added `getEventTriggers returns null for react native even when configured` (covers both `isReactNative` branches) and reset `PostHogSessionManager.isReactNative` in `@BeforeTest` to avoid cross-suite leakage. `:posthog:test --tests PostHogRemoteConfigTest` passes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change (additive, gated on the RN SDK name) — changelog entry to be added.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file <!-- .changeset/rn-skip-event-trigger-gating.md (posthog + posthog-android: patch) -->

## Merge order

**Wave 1 (no dependencies).** Merge + release first as **posthog-android 3.51.1** (branch is rebased on `origin/main`; the exception-steps changeset is already released, so our `patch` changeset is the only one pending). Consumed by the `@posthog/react-native-plugin` pin-bump PR, which raises `com.posthog:posthog-android` to `3.51.1`.

Cross-repo chain: this PR **+** posthog-ios (Wave 1) → `@posthog/react-native-plugin` pin bump (Wave 2) → posthog-react-native implementation (Wave 3). Links: `PostHog/posthog-ios#671`, `PostHog/posthog-js#3931`, `PostHog/posthog-js#3932`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — assignee/DRI: @ioannisj
