### PR TITLE
fix: Clear feature flag called cache on close

### DIFF
--- a/.changeset/clear-flag-cache-close.md
+++ b/.changeset/clear-flag-cache-close.md
@@ -1,8 +1,6 @@
 ---
 'posthog': patch
-'posthog-android': patch
 'posthog-server': patch
-'posthog-android-surveys-compose': patch
 ---
 
 Clear the feature flag called cache when closing the SDK.

--- a/.changeset/clear-flag-cache-close.md
+++ b/.changeset/clear-flag-cache-close.md
@@ -1,0 +1,8 @@
+---
+'posthog': patch
+'posthog-android': patch
+'posthog-server': patch
+'posthog-android-surveys-compose': patch
+---
+
+Clear the feature flag called cache when closing the SDK.

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -127,6 +127,7 @@ public open class PostHogStateless protected constructor(
 
                 queue?.stop()
                 featureFlags?.shutDown()
+                featureFlagsCalled?.clear()
             } catch (e: Throwable) {
                 config?.logger?.log("Close failed: $e.")
             }

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -1,5 +1,6 @@
 package com.posthog
 
+import com.posthog.internal.PostHogFeatureFlagCalledCache
 import com.posthog.internal.PostHogFeatureFlagsInterface
 import com.posthog.internal.PostHogMemoryPreferences
 import com.posthog.internal.PostHogPreferences
@@ -52,6 +53,12 @@ internal class PostHogStatelessTest {
 
         fun testMergeGroups(givenGroups: Map<String, String>?): Map<String, String>? {
             return mergeGroups(givenGroups)
+        }
+
+        fun featureFlagsCalledCacheSize(): Int {
+            val field = PostHogStateless::class.java.getDeclaredField("featureFlagsCalled")
+            field.isAccessible = true
+            return (field.get(this) as? PostHogFeatureFlagCalledCache)?.size() ?: 0
         }
 
         fun getPreferencesPublic(): PostHogPreferences {
@@ -1017,6 +1024,27 @@ internal class PostHogStatelessTest {
         assertEquals("variant_a", mockQueue.events[0].properties!!["${'$'}feature_flag_response"])
         assertEquals("user456", mockQueue.events[1].distinctId)
         assertEquals("variant_a", mockQueue.events[1].properties!!["${'$'}feature_flag_response"])
+    }
+
+    @Test
+    fun `close clears feature flag called cache`() {
+        val mockQueue = MockQueue()
+        val mockFeatureFlags = MockFeatureFlags()
+        mockFeatureFlags.setFlag("test_flag", "variant_a")
+
+        sut = createStatelessInstance()
+        config = createConfig(sendFeatureFlagEvent = true)
+
+        sut.setup(config)
+        sut.setMockQueue(mockQueue)
+        sut.setMockFeatureFlags(mockFeatureFlags)
+
+        sut.getFeatureFlagStateless("user123", "test_flag")
+        assertEquals(1, sut.featureFlagsCalledCacheSize())
+
+        sut.close()
+
+        assertEquals(0, sut.featureFlagsCalledCacheSize())
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -1027,8 +1027,9 @@ internal class PostHogStatelessTest {
     }
 
     @Test
-    fun `close clears feature flag called cache`() {
-        val mockQueue = MockQueue()
+    fun `close resets feature flag called cache before setup again`() {
+        val firstQueue = MockQueue()
+        val secondQueue = MockQueue()
         val mockFeatureFlags = MockFeatureFlags()
         mockFeatureFlags.setFlag("test_flag", "variant_a")
 
@@ -1036,15 +1037,26 @@ internal class PostHogStatelessTest {
         config = createConfig(sendFeatureFlagEvent = true)
 
         sut.setup(config)
-        sut.setMockQueue(mockQueue)
+        sut.setMockQueue(firstQueue)
         sut.setMockFeatureFlags(mockFeatureFlags)
 
         sut.getFeatureFlagStateless("user123", "test_flag")
+        sut.getFeatureFlagStateless("user123", "test_flag")
+        assertEquals(1, firstQueue.events.size)
         assertEquals(1, sut.featureFlagsCalledCacheSize())
 
         sut.close()
-
         assertEquals(0, sut.featureFlagsCalledCacheSize())
+
+        sut.setup(config)
+        sut.setMockQueue(secondQueue)
+        sut.setMockFeatureFlags(mockFeatureFlags)
+
+        sut.getFeatureFlagStateless("user123", "test_flag")
+
+        assertEquals(1, secondQueue.events.size)
+        assertEquals("user123", secondQueue.events[0].distinctId)
+        assertEquals("variant_a", secondQueue.events[0].properties!!["${'$'}feature_flag_response"])
     }
 
     @Test


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogStateless.close()` shut down the queue and feature flag provider but left the in-memory feature flag called cache populated. If the same SDK instance is closed and set up again, stale cache entries can suppress future `$feature_flag_called` events for values that were only seen before shutdown.

This PR clears the feature flag called cache during close and adds regression coverage for that behavior.

## :green_heart: How did you test it?

- `make stop && ./gradlew :posthog:test --tests "com.posthog.PostHogStatelessTest.close clears feature flag called cache"`
- `make checkFormat`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An OpenAI API coding agent prepared this PR using the existing dedicated `fix/ff-called-cache-shutdown` worktree. The branch was fast-forwarded to the latest `main` before committing because it was behind the base branch.

The implementation is intentionally narrow: clear the existing feature flag called cache during SDK close, add a regression test, and add a patch changeset for the affected release packages.
