### PR TITLE
fix(flags): retry flag requests on transient network errors

### DIFF
--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -2,4 +2,4 @@
 'posthog': patch
 ---
 
-Retry feature flag requests after network errors only.
+Retry feature flag requests after transient network errors only.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -1,0 +1,5 @@
+---
+'posthog': patch
+---
+
+Retry feature flag requests after network errors only.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -1,5 +1,7 @@
 ---
 'posthog': patch
+'posthog-android': patch
+'posthog-server': patch
 ---
 
 Retry feature flag requests after transient network errors only. The feature flag request retry count defaults to 1 and can be set to 0 to disable retries.

--- a/.changeset/quiet-flags-retry.md
+++ b/.changeset/quiet-flags-retry.md
@@ -2,4 +2,4 @@
 'posthog': patch
 ---
 
-Retry feature flag requests after transient network errors only.
+Retry feature flag requests after transient network errors only. The feature flag request retry count defaults to 1 and can be set to 0 to disable retries.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -132,8 +132,8 @@ public class com/posthog/PostHogConfig {
 	public static final field DEFAULT_MAX_QUEUE_SIZE I
 	public static final field DEFAULT_US_ASSETS_HOST Ljava/lang/String;
 	public static final field DEFAULT_US_HOST Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lcom/posthog/logs/PostHogLogsConfig;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lcom/posthog/logs/PostHogLogsConfig;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lcom/posthog/logs/PostHogLogsConfig;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZIZLjava/util/List;ZZIIIIIILcom/posthog/PostHogEncryption;Lcom/posthog/PostHogOnFeatureFlags;ZLcom/posthog/PostHogPropertiesSanitizer;Lkotlin/jvm/functions/Function1;ZLcom/posthog/PersonProfiles;ZLjava/net/Proxy;Lcom/posthog/surveys/PostHogSurveysConfig;Lcom/posthog/logs/PostHogLogsConfig;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lcom/posthog/errortracking/PostHogErrorTrackingConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addBeforeSend (Lcom/posthog/PostHogBeforeSend;)V
 	public final fun addIntegration (Lcom/posthog/PostHogIntegration;)V
 	public final fun getApiKey ()Ljava/lang/String;
@@ -147,6 +147,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getEvaluationContexts ()Ljava/util/List;
 	public final fun getEvaluationEnvironments ()Ljava/util/List;
 	public final fun getFeatureFlagCalledCacheSize ()I
+	public final fun getFeatureFlagRequestMaxRetries ()I
 	public final fun getFlushAt ()I
 	public final fun getFlushIntervalSeconds ()I
 	public final fun getGetAnonymousId ()Lkotlin/jvm/functions/Function1;
@@ -196,6 +197,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setEvaluationContexts (Ljava/util/List;)V
 	public final fun setEvaluationEnvironments (Ljava/util/List;)V
 	public final fun setFeatureFlagCalledCacheSize (I)V
+	public final fun setFeatureFlagRequestMaxRetries (I)V
 	public final fun setFlushAt (I)V
 	public final fun setFlushIntervalSeconds (I)V
 	public final fun setGetAnonymousId (Lkotlin/jvm/functions/Function1;)V

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -129,6 +129,11 @@ public open class PostHogConfig(
      * Defaults to 3
      */
     public var maxRetries: Int = 3,
+    /**
+     * Maximum number of retries for feature flag requests after transient network errors.
+     * Defaults to 1. Set to 0 to disable feature flag request retries.
+     */
+    public var featureFlagRequestMaxRetries: Int = 1,
     // (30).toDuration(DurationUnit.SECONDS) requires Kotlin 1.6
     /**
      * Interval in seconds for sending events over the wire

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -209,7 +209,7 @@ public class PostHogApi(
 
     @Throws(PostHogApiError::class, IOException::class)
     private fun executeFlagsWithRetry(request: Request): PostHogFlagsResponse? {
-        val maxRetries = config.maxRetries.coerceAtLeast(0)
+        val maxRetries = config.featureFlagRequestMaxRetries.coerceAtLeast(0)
         var retryAttempt = 0
 
         while (true) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -32,7 +32,7 @@ public class PostHogApi(
 ) {
     private companion object {
         private const val APP_JSON_UTF_8 = "application/json; charset=utf-8"
-        private const val FLAGS_INITIAL_RETRY_DELAY_MS = 1_000L
+        private const val FLAGS_INITIAL_RETRY_DELAY_MS = 300L
         private const val FLAGS_MAX_RETRY_DELAY_MS = 30_000L
     }
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -18,9 +18,9 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.BufferedSink
 import java.io.EOFException
 import java.io.IOException
+import java.io.OutputStream
 import java.net.SocketException
 import java.net.SocketTimeoutException
-import java.io.OutputStream
 
 /**
  * The class that calls the PostHog API
@@ -227,9 +227,9 @@ public class PostHogApi(
     }
 
     private fun isRetryableFlagsIOException(error: IOException): Boolean {
-        return error is SocketTimeoutException
-            || error is EOFException
-            || (error is SocketException && error.message?.contains("reset", ignoreCase = true) == true)
+        return error is SocketTimeoutException ||
+            error is EOFException ||
+            (error is SocketException && error.message?.contains("reset", ignoreCase = true) == true)
     }
 
     @Throws(PostHogApiError::class, IOException::class)

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -29,6 +29,8 @@ public class PostHogApi(
 ) {
     private companion object {
         private const val APP_JSON_UTF_8 = "application/json; charset=utf-8"
+        private const val FLAGS_INITIAL_RETRY_DELAY_MS = 1_000L
+        private const val FLAGS_MAX_RETRY_DELAY_MS = 30_000L
     }
 
     private val mediaType by lazy {
@@ -45,6 +47,12 @@ public class PostHogApi(
             .proxy(config.proxy)
             .addInterceptor(GzipRequestInterceptor(config))
             .build()
+
+    private val flagsClient: OkHttpClient by lazy {
+        client.newBuilder()
+            .retryOnConnectionFailure(false)
+            .build()
+    }
 
     private val theHost: String
         get() {
@@ -193,9 +201,33 @@ public class PostHogApi(
                 config.serializer.serialize(flagsRequest, it.bufferedWriter())
             }
 
+        return executeFlagsWithRetry(request)
+    }
+
+    @Throws(PostHogApiError::class, IOException::class)
+    private fun executeFlagsWithRetry(request: Request): PostHogFlagsResponse? {
+        val maxRetries = config.maxRetries.coerceAtLeast(0)
+        var retryAttempt = 0
+
+        while (true) {
+            try {
+                return executeFlagsRequest(request)
+            } catch (e: IOException) {
+                if (retryAttempt >= maxRetries) {
+                    throw e
+                }
+
+                retryAttempt++
+                sleepBeforeFlagsRetry(retryAttempt)
+            }
+        }
+    }
+
+    @Throws(PostHogApiError::class, IOException::class)
+    private fun executeFlagsRequest(request: Request): PostHogFlagsResponse? {
         logRequestHeaders(request)
 
-        client.newCall(request).execute().use {
+        flagsClient.newCall(request).execute().use {
             val response = logResponse(it)
 
             if (!response.isSuccessful) throw PostHogApiError(response.code, response.message, response.body)
@@ -205,6 +237,27 @@ public class PostHogApi(
             }
             return null
         }
+    }
+
+    @Throws(IOException::class)
+    private fun sleepBeforeFlagsRetry(retryAttempt: Int) {
+        try {
+            Thread.sleep(flagsRetryDelayMillis(retryAttempt))
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw IOException("Interrupted while waiting to retry feature flags request.", e)
+        }
+    }
+
+    private fun flagsRetryDelayMillis(retryAttempt: Int): Long {
+        var delay = FLAGS_INITIAL_RETRY_DELAY_MS
+        repeat((retryAttempt - 1).coerceAtLeast(0)) {
+            if (delay >= FLAGS_MAX_RETRY_DELAY_MS / 2) {
+                return FLAGS_MAX_RETRY_DELAY_MS
+            }
+            delay *= 2
+        }
+        return delay.coerceAtMost(FLAGS_MAX_RETRY_DELAY_MS)
     }
 
     @Throws(PostHogApiError::class, IOException::class)

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -16,7 +16,10 @@ import okhttp3.RequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.BufferedSink
+import java.io.EOFException
 import java.io.IOException
+import java.net.SocketException
+import java.net.SocketTimeoutException
 import java.io.OutputStream
 
 /**
@@ -213,7 +216,7 @@ public class PostHogApi(
             try {
                 return executeFlagsRequest(request)
             } catch (e: IOException) {
-                if (retryAttempt >= maxRetries) {
+                if (retryAttempt >= maxRetries || !isRetryableFlagsIOException(e)) {
                     throw e
                 }
 
@@ -221,6 +224,12 @@ public class PostHogApi(
                 sleepBeforeFlagsRetry(retryAttempt)
             }
         }
+    }
+
+    private fun isRetryableFlagsIOException(error: IOException): Boolean {
+        return error is SocketTimeoutException
+            || error is EOFException
+            || (error is SocketException && error.message?.contains("reset", ignoreCase = true) == true)
     }
 
     @Throws(PostHogApiError::class, IOException::class)

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -12,12 +12,14 @@ import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertThrows
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.io.IOException
 import java.net.InetAddress
-import java.net.SocketException
 import java.net.InetSocketAddress
 import java.net.Proxy
+import java.net.SocketException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -207,6 +209,33 @@ internal class PostHogApiTest {
     }
 
     @Test
+    fun `flags rethrows retryable IOException after max retry attempts`() {
+        val attempts = AtomicInteger(0)
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor {
+                    attempts.incrementAndGet()
+                    throw SocketException("Connection reset")
+                }
+                .build()
+        val http = mockHttp(response = MockResponse().setBody("{}"))
+        val url = http.url("/")
+
+        try {
+            val sut = getSut(host = url.toString(), httpClient = client, featureFlagRequestMaxRetries = 1)
+
+            assertThrows(IOException::class.java) {
+                sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+            }
+
+            assertEquals(2, attempts.get())
+            assertEquals(0, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    @Test
     fun `flags does not retry connection refused`() {
         val attempts = AtomicInteger(0)
         val client =
@@ -230,28 +259,6 @@ internal class PostHogApiTest {
             assertEquals(0, http.requestCount)
         } finally {
             http.shutdown()
-        }
-    }
-
-    @Test
-    fun `flags does not retry HTTP error responses`() {
-        listOf(408, 429, 500, 502, 503).forEach { statusCode ->
-            val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
-            val url = http.url("/")
-
-            try {
-                val sut = getSut(host = url.toString())
-
-                val exc =
-                    assertThrows(PostHogApiError::class.java) {
-                        sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
-                    }
-
-                assertEquals(statusCode, exc.statusCode)
-                assertEquals(1, http.requestCount)
-            } finally {
-                http.shutdown()
-            }
         }
     }
 
@@ -632,5 +639,43 @@ internal class PostHogApiTest {
                 sut.sendLogs(listOf(record), emptyMap())
             }
         assertEquals(408, exc.statusCode)
+    }
+}
+
+@RunWith(Parameterized::class)
+internal class PostHogApiFlagsHttpErrorTest(
+    private val statusCode: Int,
+) {
+    @Test
+    fun `flags does not retry HTTP error responses`() {
+        val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
+        val url = http.url("/")
+
+        try {
+            val sut = PostHogApi(PostHogConfig(API_KEY, url.toString()))
+
+            val exc =
+                assertThrows(PostHogApiError::class.java) {
+                    sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+                }
+
+            assertEquals(statusCode, exc.statusCode)
+            assertEquals(1, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    private companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "statusCode={0}")
+        fun statusCodes(): Collection<Array<Int>> =
+            listOf(
+                arrayOf(408),
+                arrayOf(429),
+                arrayOf(500),
+                arrayOf(502),
+                arrayOf(503),
+            )
     }
 }

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -8,13 +8,16 @@ import com.posthog.logs.PostHogLogRecord
 import com.posthog.logs.PostHogLogSeverity
 import com.posthog.mockHttp
 import com.posthog.unGzip
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertThrows
 import java.io.File
+import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,12 +41,20 @@ internal class PostHogApiTest {
         proxy: Proxy? = null,
         debug: Boolean = false,
         logger: PostHogLogger? = null,
+        httpClient: OkHttpClient? = null,
+        maxRetries: Int? = null,
     ): PostHogApi {
         val config = PostHogConfig(API_KEY, host)
         config.proxy = proxy
         config.debug = debug
         if (logger != null) {
             config.logger = logger
+        }
+        if (httpClient != null) {
+            config.httpClient = httpClient
+        }
+        if (maxRetries != null) {
+            config.maxRetries = maxRetries
         }
         return PostHogApi(config)
     }
@@ -131,6 +142,58 @@ internal class PostHogApiTest {
         assertEquals(400, exc.statusCode)
         assertEquals("Client Error", exc.message)
         assertNotNull(exc.body)
+    }
+
+    @Test
+    fun `flags retries IOException and returns successful response`() {
+        val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
+        val responseFlagsApi = file.readText()
+        val attempts = AtomicInteger(0)
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    if (attempts.incrementAndGet() == 1) {
+                        throw IOException("network failure")
+                    }
+                    chain.proceed(chain.request())
+                }
+                .build()
+        val http = mockHttp(response = MockResponse().setBody(responseFlagsApi))
+        val url = http.url("/")
+
+        try {
+            val sut = getSut(host = url.toString(), httpClient = client, maxRetries = 1)
+
+            val response = sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+
+            assertNotNull(response)
+            assertEquals(2, attempts.get())
+            assertEquals(1, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    @Test
+    fun `flags does not retry HTTP error responses`() {
+        listOf(408, 429, 500, 502, 503).forEach { statusCode ->
+            val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
+            val url = http.url("/")
+
+            try {
+                val sut = getSut(host = url.toString())
+
+                val exc =
+                    assertThrows(PostHogApiError::class.java) {
+                        sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+                    }
+
+                assertEquals(statusCode, exc.statusCode)
+                assertEquals(1, http.requestCount)
+            } finally {
+                http.shutdown()
+            }
+        }
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -44,6 +44,7 @@ internal class PostHogApiTest {
         logger: PostHogLogger? = null,
         httpClient: OkHttpClient? = null,
         maxRetries: Int? = null,
+        featureFlagRequestMaxRetries: Int? = null,
     ): PostHogApi {
         val config = PostHogConfig(API_KEY, host)
         config.proxy = proxy
@@ -56,6 +57,9 @@ internal class PostHogApiTest {
         }
         if (maxRetries != null) {
             config.maxRetries = maxRetries
+        }
+        if (featureFlagRequestMaxRetries != null) {
+            config.featureFlagRequestMaxRetries = featureFlagRequestMaxRetries
         }
         return PostHogApi(config)
     }
@@ -163,13 +167,40 @@ internal class PostHogApiTest {
         val url = http.url("/")
 
         try {
-            val sut = getSut(host = url.toString(), httpClient = client, maxRetries = 1)
+            val sut = getSut(host = url.toString(), httpClient = client, featureFlagRequestMaxRetries = 1)
 
             val response = sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
 
             assertNotNull(response)
             assertEquals(2, attempts.get())
             assertEquals(1, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    @Test
+    fun `flags does not retry when feature flag request max retries is zero`() {
+        val attempts = AtomicInteger(0)
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor {
+                    attempts.incrementAndGet()
+                    throw SocketException("Connection reset")
+                }
+                .build()
+        val http = mockHttp(response = MockResponse().setBody("{}"))
+        val url = http.url("/")
+
+        try {
+            val sut = getSut(host = url.toString(), httpClient = client, featureFlagRequestMaxRetries = 0)
+
+            assertThrows(IOException::class.java) {
+                sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+            }
+
+            assertEquals(1, attempts.get())
+            assertEquals(0, http.requestCount)
         } finally {
             http.shutdown()
         }
@@ -189,7 +220,7 @@ internal class PostHogApiTest {
         val url = http.url("/")
 
         try {
-            val sut = getSut(host = url.toString(), httpClient = client, maxRetries = 1)
+            val sut = getSut(host = url.toString(), httpClient = client, featureFlagRequestMaxRetries = 1)
 
             assertThrows(IOException::class.java) {
                 sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertThrows
 import java.io.File
 import java.io.IOException
 import java.net.InetAddress
+import java.net.SocketException
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.util.concurrent.atomic.AtomicInteger
@@ -145,7 +146,7 @@ internal class PostHogApiTest {
     }
 
     @Test
-    fun `flags retries IOException and returns successful response`() {
+    fun `flags retries transient IOException and returns successful response`() {
         val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
         val responseFlagsApi = file.readText()
         val attempts = AtomicInteger(0)
@@ -153,7 +154,7 @@ internal class PostHogApiTest {
             OkHttpClient.Builder()
                 .addInterceptor { chain ->
                     if (attempts.incrementAndGet() == 1) {
-                        throw IOException("network failure")
+                        throw SocketException("Connection reset")
                     }
                     chain.proceed(chain.request())
                 }
@@ -169,6 +170,33 @@ internal class PostHogApiTest {
             assertNotNull(response)
             assertEquals(2, attempts.get())
             assertEquals(1, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    @Test
+    fun `flags does not retry connection refused`() {
+        val attempts = AtomicInteger(0)
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor {
+                    attempts.incrementAndGet()
+                    throw SocketException("Connection refused")
+                }
+                .build()
+        val http = mockHttp(response = MockResponse().setBody("{}"))
+        val url = http.url("/")
+
+        try {
+            val sut = getSut(host = url.toString(), httpClient = client, maxRetries = 1)
+
+            assertThrows(IOException::class.java) {
+                sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+            }
+
+            assertEquals(1, attempts.get())
+            assertEquals(0, http.requestCount)
         } finally {
             http.shutdown()
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

`/flags/?v=2` evaluation should tolerate transient network failures, but should not retry HTTP/API responses such as 408, 429, or 5xx.

This PR adds bounded retry/backoff only for transient network failures (timeouts, connection resets/lost connections, and EOF-style failures) and keeps HTTP/API status errors terminal.

## :green_heart: How did you test it?

See the repo-specific command below.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by pi after a maintainer-directed cross-SDK pass. The chosen policy is transient network-only retry/backoff for `/flags/?v=2`; HTTP/API statuses remain non-retryable by design. Connection-refused failures also fail fast where the platform exposes that distinction.

Tested with:

```bash
./gradlew :posthog:test --tests com.posthog.internal.PostHogApiTest --no-daemon
```
