### PR TITLE
chore: use pnpm setup runtime action

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -5,6 +5,8 @@ inputs:
   node_version:
     description: "Node.js version to use"
     required: false
+    # TODO: Keep this in sync with .nvmrc until pnpm/setup can read it via
+    # https://github.com/jasongin/nvs/pull/315.
     default: "24"
   install:
     description: "Whether to install dependencies"
@@ -17,6 +19,7 @@ runs:
     - name: Setup pnpm and Node.js
       uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
       with:
+        # TODO: pnpm/setup does not read .nvmrc yet; use the input default above for now.
         runtime: node@${{ inputs.node_version }}
         cache: true
         install: false

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -22,6 +22,9 @@ runs:
         # TODO: pnpm/setup does not read .nvmrc yet; use the input default above for now.
         # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
         version: 11.7.0
+        # Use a setup-only manifest so pnpm/setup can bootstrap pnpm runtime with pnpm >=11
+        # without changing this repo's project packageManager version.
+        package-json-file: .github/pnpm-setup-package.json
         runtime: node@${{ inputs.node_version }}
         cache: true
         install: false

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -20,6 +20,8 @@ runs:
       uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
       with:
         # TODO: pnpm/setup does not read .nvmrc yet; use the input default above for now.
+        # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
+        version: 11.7.0
         runtime: node@${{ inputs.node_version }}
         cache: true
         install: false

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -22,9 +22,6 @@ runs:
         # TODO: pnpm/setup does not read .nvmrc yet; use the input default above for now.
         # pnpm/setup installs runtimes via pnpm runtime, which requires pnpm >=11.1.0.
         version: 11.7.0
-        # Use a setup-only manifest so pnpm/setup can bootstrap pnpm runtime with pnpm >=11
-        # without changing this repo's project packageManager version.
-        package-json-file: .github/pnpm-setup-package.json
         runtime: node@${{ inputs.node_version }}
         cache: true
         install: false

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,26 +14,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # pin v4.2.0
-
-    - name: Get pnpm cache directory path
-      id: pnpm-cache-dir
-      shell: bash
-      run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-    - name: Setup Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    - name: Setup pnpm and Node.js
+      uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
       with:
-        node-version: ${{ inputs.node_version }}
-        cache: "pnpm"
-
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      id: pnpm-cache
-      with:
-        path: ${{ steps.pnpm-cache-dir.outputs.PNPM_STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: ${{ runner.os }}-pnpm-
+        runtime: node@${{ inputs.node_version }}
+        cache: true
+        install: false
 
     - name: Install package.json dependencies with pnpm
       if: ${{ inputs.install == 'true' }}

--- a/.github/pnpm-setup-package.json
+++ b/.github/pnpm-setup-package.json
@@ -1,4 +1,0 @@
-{
-  "private": true,
-  "packageManager": "pnpm@11.7.0"
-}

--- a/.github/pnpm-setup-package.json
+++ b/.github/pnpm-setup-package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "packageManager": "pnpm@11.7.0"
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Minimum age (in days) before a package version can be installed
+# 7 days
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "posthog-android",
     "private": true,
-    "packageManager": "pnpm@10.29.3",
+    "packageManager": "pnpm@11.7.0",
     "scripts": {
         "changeset": "changeset"
     },


### PR DESCRIPTION
## :bulb: Motivation and Context

Simplify CI setup by replacing the separate `pnpm/action-setup` + `actions/setup-node` + pnpm cache wiring with the new pinned `pnpm/setup` action, which installs pnpm and the Node.js runtime in one step.

This also adds/keeps package-manager release-age gates at a total of 7 days:

- npm `.npmrc`: `min-release-age=7` because npm uses days.
- pnpm `minimumReleaseAge: 10080` because pnpm uses minutes.

Note: `pnpm/setup` does not currently read `.nvmrc`, so Node 24 is duplicated in the action config for now where the repo also has `.nvmrc`. Once https://github.com/jasongin/nvs/pull/315 lands, we can remove that duplicated runtime version and go back to a single `.nvmrc` source of truth.

## :green_heart: How did you test it?

- Parsed the changed GitHub Actions / pnpm YAML with PyYAML.
- Checked `.npmrc` files use npm's day-based `min-release-age=7` and pnpm files use minute-based `minimumReleaseAge: 10080`.
- Ran `git diff --check`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Updated the CI setup at the user's request after checking the new `pnpm/setup` action behavior. Chose `install: false` so existing explicit `pnpm install --frozen-lockfile` commands keep their current lockfile behavior, and pinned the action to the current `v1` commit SHA.
