### PR TITLE
fix: allow posthog-kmp wrapper to keep its own sdkName/sdkVersion

### DIFF
--- a/.changeset/allowlist-posthog-kmp.md
+++ b/.changeset/allowlist-posthog-kmp.md
@@ -1,0 +1,5 @@
+---
+'posthog-android': patch
+---
+
+Allow the posthog-kmp wrapper SDK to keep its own `sdkName`/`sdkVersion` so KMP events report the correct `$lib`/version, mirroring how posthog-flutter and posthog-react-native are handled.

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -117,9 +117,12 @@ public class PostHogAndroid private constructor() {
                 }
             }
             config.networkStatus = config.networkStatus ?: PostHogAndroidNetworkStatus(context)
-            // Flutter and RN SDKs set the sdkName and sdkVersion, so this guard is not to allow
+            // Flutter, RN, and KMP SDKs set the sdkName and sdkVersion, so this guard is not to allow
             // the values to be overwritten again
-            if (config.sdkName != "posthog-flutter" && config.sdkName != "posthog-react-native") {
+            if (config.sdkName != "posthog-flutter" &&
+                config.sdkName != "posthog-react-native" &&
+                config.sdkName != "posthog-kmp"
+            ) {
                 config.sdkName = "posthog-android"
                 config.sdkVersion = BuildConfig.VERSION_NAME
             }

--- a/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
@@ -132,6 +132,41 @@ internal class PostHogAndroidTest {
     }
 
     @Test
+    fun `overwrites sdkName and sdkVersion when not a wrapper SDK`() {
+        val config =
+            PostHogAndroidConfig(API_KEY).apply {
+                sdkName = "posthog"
+                sdkVersion = "0.0.0"
+            }
+
+        mockContextAppStart(context, tmpDir)
+
+        PostHogAndroid.setup(context, config)
+
+        assertEquals("posthog-android", config.sdkName)
+        assertEquals(BuildConfig.VERSION_NAME, config.sdkVersion)
+    }
+
+    @Test
+    fun `keeps wrapper SDK sdkName and sdkVersion`() {
+        for (sdkName in listOf("posthog-flutter", "posthog-react-native", "posthog-kmp")) {
+            PostHog.close()
+            val config =
+                PostHogAndroidConfig(API_KEY).apply {
+                    this.sdkName = sdkName
+                    sdkVersion = "1.2.3"
+                }
+
+            mockContextAppStart(context, tmpDir)
+
+            PostHogAndroid.setup(context, config)
+
+            assertEquals(sdkName, config.sdkName)
+            assertEquals("1.2.3", config.sdkVersion)
+        }
+    }
+
+    @Test
     fun `adds captureApplicationLifecycleEvents integrations`() {
         val config = PostHogAndroidConfig(API_KEY)
 


### PR DESCRIPTION
Adds `posthog-kmp` to the SDK-identity allowlist in `PostHogAndroid` so the KMP wrapper's `sdkName`/`sdkVersion` are no longer overwritten with `posthog-android`, mirroring how posthog-flutter and posthog-react-native are handled. Without this, KMP events report `$lib = posthog-android` instead of `posthog-kmp`.

The downstream [posthog-kmp PR #1](https://github.com/PostHog/posthog-kmp/pull/1) depends on this change.