### PR TITLE
feat: add requestHeaders config option

### DIFF
--- a/.changeset/request-headers.md
+++ b/.changeset/request-headers.md
@@ -1,6 +1,6 @@
 ---
-'posthog': patch
-'posthog-android': patch
+'posthog': minor
+'posthog-android': minor
 ---
 
 Add `requestHeaders` config option to send custom headers (e.g. `Authorization`) with every request to the PostHog API. Useful for reverse-proxy setups that require authentication.

--- a/.changeset/request-headers.md
+++ b/.changeset/request-headers.md
@@ -1,0 +1,6 @@
+---
+'posthog': patch
+'posthog-android': patch
+---
+
+Add `requestHeaders` config option to send custom headers (e.g. `Authorization`) with every request to the PostHog API. Useful for reverse-proxy setups that require authentication.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -174,6 +174,7 @@ public class com/posthog/PostHogConfig {
 	public final fun getRemoteConfigHolder ()Lcom/posthog/internal/PostHogRemoteConfig;
 	public final fun getRemoteConfigProvider ()Lkotlin/jvm/functions/Function6;
 	public final fun getReplayStoragePrefix ()Ljava/lang/String;
+	public final fun getRequestHeaders ()Ljava/util/Map;
 	public final fun getReuseAnonymousId ()Z
 	public final fun getSampleRateProvider ()Lkotlin/jvm/functions/Function0;
 	public final fun getSdkName ()Ljava/lang/String;
@@ -220,6 +221,7 @@ public class com/posthog/PostHogConfig {
 	public final fun setRemoteConfig (Z)V
 	public final fun setRemoteConfigHolder (Lcom/posthog/internal/PostHogRemoteConfig;)V
 	public final fun setReplayStoragePrefix (Ljava/lang/String;)V
+	public final fun setRequestHeaders (Ljava/util/Map;)V
 	public final fun setReuseAnonymousId (Z)V
 	public final fun setSampleRateProvider (Lkotlin/jvm/functions/Function0;)V
 	public final fun setSdkName (Ljava/lang/String;)V
@@ -525,6 +527,11 @@ public final class com/posthog/errortracking/PostHogExceptionStepsConfig {
 	public final fun getMaxBytes ()I
 	public final fun setEnabled (Z)V
 	public final fun setMaxBytes (I)V
+}
+
+public final class com/posthog/internal/CustomHeadersInterceptor : okhttp3/Interceptor {
+	public fun <init> (Lcom/posthog/PostHogConfig;)V
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 }
 
 public final class com/posthog/internal/EndpointSpec {

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -355,6 +355,15 @@ public open class PostHogConfig(
     public var httpClient: OkHttpClient? = null
 
     /**
+     * Custom headers to send with every request to the PostHog API.
+     *
+     * Useful for reverse-proxy setups that require authentication, e.g. an `Authorization` header.
+     *
+     * Default: empty (no extra headers).
+     */
+    public var requestHeaders: Map<String, String> = emptyMap()
+
+    /**
      * The PostHog project API key, trimmed of leading and trailing whitespace.
      */
     public val apiKey: String = apiKey.trim()

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -361,6 +361,7 @@ public open class PostHogConfig(
      *
      * Default: empty (no extra headers).
      */
+    @Volatile
     public var requestHeaders: Map<String, String> = emptyMap()
 
     /**

--- a/posthog/src/main/java/com/posthog/PostHogConfig.kt
+++ b/posthog/src/main/java/com/posthog/PostHogConfig.kt
@@ -359,6 +359,8 @@ public open class PostHogConfig(
      *
      * Useful for reverse-proxy setups that require authentication, e.g. an `Authorization` header.
      *
+     * Read once when the SDK is set up; changes after setup are ignored.
+     *
      * Default: empty (no extra headers).
      */
     @Volatile

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -2,6 +2,7 @@ package com.posthog.internal
 
 import com.posthog.PostHogConfig
 import com.posthog.PostHogInternal
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
@@ -13,20 +14,26 @@ import java.io.IOException
  */
 @PostHogInternal
 public class CustomHeadersInterceptor(private val config: PostHogConfig) : Interceptor {
+    private val configuredHost: String? = config.host.toHttpUrlOrNull()?.host
+
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val requestHeaders = config.requestHeaders
-        if (requestHeaders.isEmpty()) {
-            return chain.proceed(chain.request())
+        val request = chain.request()
+        // Only attach to the configured host so headers aren't sent to rewritten hosts (e.g. the CDN).
+        if (requestHeaders.isEmpty() || request.url.host != configuredHost) {
+            return chain.proceed(request)
         }
 
-        val request = chain.request()
         val builder = request.newBuilder()
         for ((key, value) in requestHeaders) {
-            // Keep headers the SDK already set on the request (e.g. localEvaluation's
-            // Authorization personal API key); those take precedence over config values.
-            if (request.header(key) == null) {
+            // SDK-set request headers (e.g. localEvaluation's Authorization) take precedence.
+            if (request.header(key) != null) continue
+            try {
                 builder.header(key, value)
+            } catch (e: IllegalArgumentException) {
+                // Drop headers okhttp rejects rather than failing the request.
+                config.logger.log("Dropping invalid request header '$key': ${e.message}")
             }
         }
         return chain.proceed(builder.build())

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -4,6 +4,7 @@ import com.posthog.PostHogConfig
 import com.posthog.PostHogInternal
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
 
@@ -28,14 +29,20 @@ public class CustomHeadersInterceptor(private val config: PostHogConfig) : Inter
         val builder = request.newBuilder()
         for ((key, value) in requestHeaders) {
             // SDK-set request headers (e.g. localEvaluation's Authorization) take precedence.
-            if (request.header(key) != null) continue
-            try {
-                builder.header(key, value)
-            } catch (e: IllegalArgumentException) {
-                // Drop headers okhttp rejects rather than failing the request.
-                config.logger.log("Dropping invalid request header '$key': ${e.message}")
-            }
+            request.header(key) ?: builder.addCustomHeader(key, value)
         }
         return chain.proceed(builder.build())
+    }
+
+    private fun Request.Builder.addCustomHeader(
+        key: String,
+        value: String,
+    ) {
+        try {
+            header(key, value)
+        } catch (e: IllegalArgumentException) {
+            // Drop headers okhttp rejects rather than failing the request.
+            config.logger.log("Dropping invalid request header '$key': ${e.message}")
+        }
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -15,6 +15,11 @@ import java.io.IOException
  */
 @PostHogInternal
 public class CustomHeadersInterceptor(private val config: PostHogConfig) : Interceptor {
+    private companion object {
+        // SDK-managed headers that custom values can't override (compared lowercase).
+        private val RESERVED_HEADERS = setOf("content-type", "user-agent", "accept-encoding", "content-encoding")
+    }
+
     private val configuredHost: String? = config.host.toHttpUrlOrNull()?.host
 
     // Snapshot a copy at construction so config is treated as immutable after setup.
@@ -30,6 +35,7 @@ public class CustomHeadersInterceptor(private val config: PostHogConfig) : Inter
 
         val builder = request.newBuilder()
         for ((key, value) in requestHeaders) {
+            if (key.lowercase() in RESERVED_HEADERS) continue
             // SDK-set request headers (e.g. localEvaluation's Authorization) take precedence.
             request.header(key) ?: builder.addCustomHeader(key, value)
         }

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -20,9 +20,14 @@ public class CustomHeadersInterceptor(private val config: PostHogConfig) : Inter
             return chain.proceed(chain.request())
         }
 
-        val builder = chain.request().newBuilder()
+        val request = chain.request()
+        val builder = request.newBuilder()
         for ((key, value) in requestHeaders) {
-            builder.header(key, value)
+            // Keep headers the SDK already set on the request (e.g. localEvaluation's
+            // Authorization personal API key); those take precedence over config values.
+            if (request.header(key) == null) {
+                builder.header(key, value)
+            }
         }
         return chain.proceed(builder.build())
     }

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -17,9 +17,11 @@ import java.io.IOException
 public class CustomHeadersInterceptor(private val config: PostHogConfig) : Interceptor {
     private val configuredHost: String? = config.host.toHttpUrlOrNull()?.host
 
+    // Snapshot at construction so config is treated as immutable after setup.
+    private val requestHeaders: Map<String, String> = config.requestHeaders
+
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
-        val requestHeaders = config.requestHeaders
         val request = chain.request()
         // Only attach to the configured host so headers aren't sent to rewritten hosts (e.g. the CDN).
         if (requestHeaders.isEmpty() || request.url.host != configuredHost) {

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -17,8 +17,8 @@ import java.io.IOException
 public class CustomHeadersInterceptor(private val config: PostHogConfig) : Interceptor {
     private val configuredHost: String? = config.host.toHttpUrlOrNull()?.host
 
-    // Snapshot at construction so config is treated as immutable after setup.
-    private val requestHeaders: Map<String, String> = config.requestHeaders
+    // Snapshot a copy at construction so config is treated as immutable after setup.
+    private val requestHeaders: Map<String, String> = config.requestHeaders.toMap()
 
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
+++ b/posthog/src/main/java/com/posthog/internal/CustomHeadersInterceptor.kt
@@ -1,0 +1,29 @@
+package com.posthog.internal
+
+import com.posthog.PostHogConfig
+import com.posthog.PostHogInternal
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * Adds the caller-supplied [PostHogConfig.requestHeaders] (e.g. an `Authorization` header for a
+ * reverse proxy) to every request the SDK sends.
+ * @property config The Config
+ */
+@PostHogInternal
+public class CustomHeadersInterceptor(private val config: PostHogConfig) : Interceptor {
+    @Throws(IOException::class)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val requestHeaders = config.requestHeaders
+        if (requestHeaders.isEmpty()) {
+            return chain.proceed(chain.request())
+        }
+
+        val builder = chain.request().newBuilder()
+        for ((key, value) in requestHeaders) {
+            builder.header(key, value)
+        }
+        return chain.proceed(builder.build())
+    }
+}

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -46,9 +46,15 @@ public class PostHogApi(
     }
 
     private val client: OkHttpClient =
-        config.httpClient ?: OkHttpClient.Builder()
-            .proxy(config.proxy)
-            .addInterceptor(GzipRequestInterceptor(config))
+        (
+            config.httpClient ?: OkHttpClient.Builder()
+                .proxy(config.proxy)
+                .addInterceptor(GzipRequestInterceptor(config))
+                .build()
+        )
+            // Applies config.requestHeaders to every request; no-ops when none are set.
+            .newBuilder()
+            .addInterceptor(CustomHeadersInterceptor(config))
             .build()
 
     private val flagsClient: OkHttpClient by lazy {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -49,7 +49,9 @@ public class PostHogApi(
         config.httpClient ?: OkHttpClient.Builder()
             .proxy(config.proxy)
             .addInterceptor(GzipRequestInterceptor(config))
-            .addInterceptor(CustomHeadersInterceptor(config))
+            // Network interceptor so the host check re-runs per hop and custom headers are never
+            // added to a redirect that leaves the configured host.
+            .addNetworkInterceptor(CustomHeadersInterceptor(config))
             .build()
 
     private val flagsClient: OkHttpClient by lazy {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -46,14 +46,9 @@ public class PostHogApi(
     }
 
     private val client: OkHttpClient =
-        (
-            config.httpClient ?: OkHttpClient.Builder()
-                .proxy(config.proxy)
-                .addInterceptor(GzipRequestInterceptor(config))
-                .build()
-        )
-            // Applies config.requestHeaders to every request; no-ops when none are set.
-            .newBuilder()
+        config.httpClient ?: OkHttpClient.Builder()
+            .proxy(config.proxy)
+            .addInterceptor(GzipRequestInterceptor(config))
             .addInterceptor(CustomHeadersInterceptor(config))
             .build()
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -49,8 +49,7 @@ public class PostHogApi(
         config.httpClient ?: OkHttpClient.Builder()
             .proxy(config.proxy)
             .addInterceptor(GzipRequestInterceptor(config))
-            // Network interceptor so the host check re-runs per hop and custom headers are never
-            // added to a redirect that leaves the configured host.
+            // Network interceptor so the host check re-runs on each redirect hop.
             .addNetworkInterceptor(CustomHeadersInterceptor(config))
             .build()
 

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -9,6 +9,7 @@ import com.posthog.logs.PostHogLogSeverity
 import com.posthog.mockHttp
 import com.posthog.unGzip
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertThrows
@@ -130,6 +131,21 @@ internal class PostHogApiTest {
 
         val request = http.takeRequest()
         assertEquals("Bearer test-personal-key", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `does not attach custom headers when the request host differs from the configured host`() {
+        val http = mockHttp()
+
+        // Configured host differs from the request host, mirroring the static-config CDN.
+        val config = PostHogConfig(API_KEY, "https://different-host.example.com")
+        config.requestHeaders = mapOf("Authorization" to "Bearer test-jwt")
+        val client = OkHttpClient.Builder().addInterceptor(CustomHeadersInterceptor(config)).build()
+
+        client.newCall(Request.Builder().url(http.url("/")).build()).execute().close()
+
+        val request = http.takeRequest()
+        assertNull(request.headers["Authorization"])
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -120,6 +120,19 @@ internal class PostHogApiTest {
     }
 
     @Test
+    fun `custom Authorization header does not override localEvaluation personal API key`() {
+        val http = mockHttp(response = MockResponse().setBody(createLocalEvaluationJson()))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString(), requestHeaders = mapOf("Authorization" to "Bearer custom"))
+
+        sut.localEvaluation("test-personal-key")
+
+        val request = http.takeRequest()
+        assertEquals("Bearer test-personal-key", request.headers["Authorization"])
+    }
+
+    @Test
     fun `does not send an Authorization header when no custom headers are set`() {
         val http = mockHttp()
         val url = http.url("/")

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -162,6 +162,42 @@ internal class PostHogApiTest {
     }
 
     @Test
+    fun `custom headers do not override SDK-managed headers`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString(), requestHeaders = mapOf("User-Agent" to "evil"))
+
+        sut.batch(listOf(generateEvent()))
+
+        val request = http.takeRequest()
+        assertEquals("posthog-java/${BuildConfig.VERSION_NAME}", request.headers["User-Agent"])
+    }
+
+    @Test
+    fun `drops a header okhttp rejects without failing the request`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut =
+            getSut(
+                host = url.toString(),
+                requestHeaders =
+                    mapOf(
+                        // A newline makes okhttp's header() throw.
+                        "X-Bad" to "bad\nvalue",
+                        "Authorization" to "Bearer ok",
+                    ),
+            )
+
+        sut.batch(listOf(generateEvent()))
+
+        val request = http.takeRequest()
+        assertNull(request.headers["X-Bad"])
+        assertEquals("Bearer ok", request.headers["Authorization"])
+    }
+
+    @Test
     fun `batch throws if not successful`() {
         val http = mockHttp(response = MockResponse().setResponseCode(400).setBody("error"))
         val url = http.url("/")

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -47,10 +47,14 @@ internal class PostHogApiTest {
         httpClient: OkHttpClient? = null,
         maxRetries: Int? = null,
         featureFlagRequestMaxRetries: Int? = null,
+        requestHeaders: Map<String, String>? = null,
     ): PostHogApi {
         val config = PostHogConfig(API_KEY, host)
         config.proxy = proxy
         config.debug = debug
+        if (requestHeaders != null) {
+            config.requestHeaders = requestHeaders
+        }
         if (logger != null) {
             config.logger = logger
         }
@@ -86,6 +90,46 @@ internal class PostHogApiTest {
         assertEquals("gzip", request.headers["Content-Encoding"])
         assertEquals("gzip", request.headers["Accept-Encoding"])
         assertEquals("application/json; charset=utf-8", request.headers["Content-Type"])
+    }
+
+    @Test
+    fun `batch includes custom request headers`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString(), requestHeaders = mapOf("Authorization" to "Bearer test-jwt"))
+
+        sut.batch(listOf(generateEvent()))
+
+        val request = http.takeRequest()
+        assertEquals("Bearer test-jwt", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `flags includes custom request headers`() {
+        val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
+        val http = mockHttp(response = MockResponse().setBody(file.readText()))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString(), requestHeaders = mapOf("Authorization" to "Bearer test-jwt"))
+
+        sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+
+        val request = http.takeRequest()
+        assertEquals("Bearer test-jwt", request.headers["Authorization"])
+    }
+
+    @Test
+    fun `does not send an Authorization header when no custom headers are set`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        sut.batch(listOf(generateEvent()))
+
+        val request = http.takeRequest()
+        assertNull(request.headers["Authorization"])
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -53,7 +53,7 @@ internal class PostHogApiTest {
         val config = PostHogConfig(API_KEY, host)
         config.proxy = proxy
         config.debug = debug
-        if (requestHeaders != null) {
+        if (!requestHeaders.isNullOrEmpty()) {
             config.requestHeaders = requestHeaders
         }
         if (logger != null) {
@@ -166,12 +166,13 @@ internal class PostHogApiTest {
         val http = mockHttp()
         val url = http.url("/")
 
-        val sut = getSut(host = url.toString(), requestHeaders = mapOf("User-Agent" to "evil"))
+        val sut = getSut(host = url.toString(), requestHeaders = mapOf("User-Agent" to "evil", "Content-Type" to "text/plain"))
 
         sut.batch(listOf(generateEvent()))
 
         val request = http.takeRequest()
         assertEquals("posthog-java/${BuildConfig.VERSION_NAME}", request.headers["User-Agent"])
+        assertEquals("application/json; charset=utf-8", request.headers["Content-Type"])
     }
 
     @Test


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of the cross-SDK work for PostHog/posthog-js#2132 (no way to include `Authorization` headers in reverse-proxy setups). React Native session replay and native crash uploads are sent directly by this native SDK, so they bypass any JS-layer header support. This adds first-class custom-header support to the Android SDK so those (and all other) requests can carry an `Authorization` header for an authenticated reverse proxy.

## :green_heart: How did you test it?

- Added tests in `PostHogApiTest` asserting the header reaches `/batch` and `/flags`, and is absent when unset (uses the existing MockWebServer harness).
- `./gradlew :posthog:test --tests "com.posthog.internal.PostHogApiTest"` passes.
- `./gradlew spotlessCheck` passes.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @ioannisj / @marandaneto while wiring `requestHeaders` through for React Native — the native SDK must honor the header for replay/crash uploads. Applied the headers via a small `CustomHeadersInterceptor` added to the OkHttp client (covers every endpoint, including the derived `flagsClient`, and no-ops when no headers are set), keeping the SDK's existing gzip interceptor and default client setup intact. Tool used: Claude Code.

---

Related: PostHog/posthog-js#2132
