### PR TITLE
fix: stop duplicating distinct_id in flags person properties

### DIFF
--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.changeset/quiet-wolves-fix.md
+++ b/.changeset/quiet-wolves-fix.md
@@ -1,5 +1,7 @@
 ---
 "posthog": patch
+"posthog-android": patch
+"posthog-server": patch
 ---
 
 Stop duplicating `distinct_id` inside `/flags` person properties.

--- a/.github/workflows/sdk-compliance-tests.yml
+++ b/.github/workflows/sdk-compliance-tests.yml
@@ -22,9 +22,9 @@ permissions:
 
 jobs:
   test-android-sdk:
-    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@68498bcf3ae95ac941476e6ca3d42d6086e1c7fd
+    uses: PostHog/posthog-sdk-test-harness/.github/workflows/test-sdk-action.yml@02c049e529001d02f37a534745678e057d371fb0
     with:
       adapter-dockerfile: sdk_compliance_adapter/Dockerfile
       adapter-context: .
-      test-harness-version: "0.9.0"
+      test-harness-version: "0.10.0"
       report-name: android-sdk-compliance-report

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -182,7 +182,7 @@ internal class PostHogFeatureFlags(
             if (flagDef != null) {
                 try {
                     config.logger.log("Attempting local evaluation for flag '$key' for distinctId: $distinctId")
-                    val props = (personProperties ?: EMPTY_PROPERTIES).toMutableMap()
+                    val props = localPersonProperties(distinctId, personProperties)
 
                     val result =
                         computeFlagLocally(
@@ -257,7 +257,7 @@ internal class PostHogFeatureFlags(
 
         config.logger.log("Attempting local evaluation for distinctId: $distinctId")
         val localFlags = mutableMapOf<String, FeatureFlag>()
-        val props = (personProperties ?: EMPTY_PROPERTIES).toMutableMap()
+        val props = localPersonProperties(distinctId, personProperties)
 
         // Evaluate all flags locally
         for ((key, flagDef) in currentFlagDefinitions) {
@@ -283,6 +283,15 @@ internal class PostHogFeatureFlags(
 
         config.logger.log("Local evaluation successful for ${localFlags.size} flags")
         return localFlags
+    }
+
+    private fun localPersonProperties(
+        distinctId: String,
+        personProperties: Map<String, Any?>?,
+    ): MutableMap<String, Any?> {
+        val props = (personProperties ?: EMPTY_PROPERTIES).toMutableMap()
+        props.putIfAbsent("distinct_id", distinctId)
+        return props
     }
 
     private fun getFeatureFlagsFromRemote(

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -811,6 +811,78 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `distinct_id is available for local evaluation only`() {
+        val logger = TestLogger()
+        val localEvalResponse =
+            """
+            {
+                "flags": [
+                    {
+                        "id": 1,
+                        "name": "distinct-id-feature",
+                        "key": "distinct-id-feature",
+                        "active": true,
+                        "filters": {
+                            "groups": [
+                                {
+                                    "properties": [
+                                        {
+                                            "key": "distinct_id",
+                                            "operator": "exact",
+                                            "value": "user-123",
+                                            "type": "person"
+                                        }
+                                    ],
+                                    "rollout_percentage": 100
+                                }
+                            ]
+                        },
+                        "version": 1
+                    }
+                ],
+                "group_type_mapping": {},
+                "cohorts": {}
+            }
+            """.trimIndent()
+
+        val mockServer =
+            createMockHttp(
+                jsonResponse(localEvalResponse),
+            )
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(logger, url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+            )
+
+        Thread.sleep(1000)
+
+        val personProperties = mapOf<String, Any?>("region" to "USA")
+        val result =
+            remoteConfig.getFeatureFlag(
+                key = "distinct-id-feature",
+                defaultValue = false,
+                distinctId = "user-123",
+                personProperties = personProperties,
+            )
+
+        assertEquals(true, result)
+        assertEquals(mapOf("region" to "USA"), personProperties)
+        assertEquals(1, mockServer.requestCount, "local evaluation should not fall back to /flags")
+
+        remoteConfig.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `loadFeatureFlagDefinitions overwrites existing definitions on reload`() {
         val logger = TestLogger()
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogFlagsRequest.kt
@@ -29,12 +29,7 @@ internal class PostHogFlagsRequest(
         }
         this["groups"] = groups ?: emptyMap<String, String>()
         if (personProperties?.isNotEmpty() == true) {
-            this["person_properties"] =
-                personProperties.toMutableMap().apply {
-                    if (!containsKey("distinct_id")) {
-                        this["distinct_id"] = distinctId
-                    }
-                }
+            this["person_properties"] = personProperties
         }
         this["group_properties"] = groupProperties ?: emptyMap<String, Map<String, Any?>>()
         if (evaluationContexts?.isNotEmpty() == true) {

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -2581,7 +2581,6 @@ internal class PostHogTest {
                 "\$device_type" to "Mobile",
                 "\$lib" to "posthog-android",
                 "\$lib_version" to "1.2.3",
-                "distinct_id" to requestBody["distinct_id"],
             ),
             personProperties,
         )

--- a/posthog/src/test/java/com/posthog/internal/PostHogFlagsRequestTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFlagsRequestTest.kt
@@ -109,30 +109,20 @@ internal class PostHogFlagsRequestTest {
     }
 
     @Test
-    fun `does not add distinct_id to non-empty person properties`() {
-        val request =
-            PostHogFlagsRequest(
-                API_KEY,
-                DISTINCT_ID,
-                personProperties = mapOf("email" to "example@example.com"),
-            )
-
-        assertEquals(
+    fun `preserves caller person properties without adding distinct_id`() {
+        listOf(
             mapOf("email" to "example@example.com"),
-            request["person_properties"],
-        )
-    }
+            mapOf("distinct_id" to "custom-distinct-id"),
+        ).forEach { personProperties ->
+            val request =
+                PostHogFlagsRequest(
+                    API_KEY,
+                    DISTINCT_ID,
+                    personProperties = personProperties,
+                )
 
-    @Test
-    fun `does not overwrite explicit person property distinct_id`() {
-        val request =
-            PostHogFlagsRequest(
-                API_KEY,
-                DISTINCT_ID,
-                personProperties = mapOf("distinct_id" to "custom-distinct-id"),
-            )
-
-        assertEquals(mapOf("distinct_id" to "custom-distinct-id"), request["person_properties"])
+            assertEquals(personProperties, request["person_properties"])
+        }
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogFlagsRequestTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogFlagsRequestTest.kt
@@ -27,7 +27,7 @@ internal class PostHogFlagsRequestTest {
         assertEquals(DISTINCT_ID, request["distinct_id"])
         assertEquals(ANON_ID, request["\$anon_distinct_id"])
         assertEquals(groups, request["groups"])
-        assertEquals(personProperties + ("distinct_id" to DISTINCT_ID), request["person_properties"])
+        assertEquals(personProperties, request["person_properties"])
         assertEquals(groupProperties, request["group_properties"])
     }
 
@@ -109,7 +109,7 @@ internal class PostHogFlagsRequestTest {
     }
 
     @Test
-    fun `adds distinct_id to non-empty person properties`() {
+    fun `does not add distinct_id to non-empty person properties`() {
         val request =
             PostHogFlagsRequest(
                 API_KEY,
@@ -118,7 +118,7 @@ internal class PostHogFlagsRequestTest {
             )
 
         assertEquals(
-            mapOf("email" to "example@example.com", "distinct_id" to DISTINCT_ID),
+            mapOf("email" to "example@example.com"),
             request["person_properties"],
         )
     }

--- a/posthog/src/test/java/com/posthog/internal/PostHogSerializerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogSerializerTest.kt
@@ -212,8 +212,7 @@ internal class PostHogSerializerTest {
                     "custom_prop": {
                         "field1": "custom",
                         "field2": 999
-                    },
-                    "distinct_id": "test_user"
+                    }
                 },
                 "groups": {}
             }

--- a/sdk_compliance_adapter/docker-compose.yml
+++ b/sdk_compliance_adapter/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - JAVA_TOOL_OPTIONS=-Xmx512m
 
   test-harness:
-    image: ghcr.io/posthog/sdk-test-harness:0.9.0
+    image: ghcr.io/posthog/sdk-test-harness:0.10.0
     command: ["run", "--adapter-url", "http://sdk-adapter:8080", "--mock-url", "http://test-harness:8081", "--sdk-type", "server", "--debug"]
     networks:
       - test-network


### PR DESCRIPTION
## :bulb: Motivation and Context
`/flags` requests already send `distinct_id` at the top level. Automatically copying the same value into `person_properties.distinct_id` sends duplicated identity data and differs from the desired payload shape.

This PR keeps the top-level `distinct_id` and stops automatically injecting it into `person_properties`. Caller-provided person properties are still forwarded.

## :green_heart: How did you test it?

- `./gradlew :posthog:test --tests com.posthog.internal.PostHogFlagsRequestTest --tests com.posthog.PostHogTest`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This was implemented with pi in dedicated git worktrees. I changed the /flags request construction so SDKs keep the top-level distinct_id while no longer auto-copying it into person_properties; explicit caller-provided person_properties['distinct_id'] values are still preserved where covered.
