### PR TITLE
fix: Retry flags requests on 502 and 504

### DIFF
--- a/.changeset/tiny-flags-retry.md
+++ b/.changeset/tiny-flags-retry.md
@@ -1,6 +1,7 @@
 ---
 'posthog': patch
 'posthog-android': patch
+'posthog-server': patch
 ---
 
 Retry `/flags` requests once by default when the flags endpoint returns HTTP 502 or 504, respecting `featureFlagRequestMaxRetries`.

--- a/.changeset/tiny-flags-retry.md
+++ b/.changeset/tiny-flags-retry.md
@@ -1,0 +1,6 @@
+---
+'posthog': patch
+'posthog-android': patch
+---
+
+Retry `/flags` requests once by default when the flags endpoint returns HTTP 502 or 504, respecting `featureFlagRequestMaxRetries`.

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -217,6 +217,13 @@ public class PostHogApi(
         while (true) {
             try {
                 return executeFlagsRequest(request)
+            } catch (e: PostHogApiError) {
+                if (retryAttempt >= maxRetries || !isRetryableFlagsApiError(e)) {
+                    throw e
+                }
+
+                retryAttempt++
+                sleepBeforeFlagsRetry(retryAttempt)
             } catch (e: IOException) {
                 if (retryAttempt >= maxRetries || !isRetryableFlagsIOException(e)) {
                     throw e
@@ -226,6 +233,10 @@ public class PostHogApi(
                 sleepBeforeFlagsRetry(retryAttempt)
             }
         }
+    }
+
+    private fun isRetryableFlagsApiError(error: PostHogApiError): Boolean {
+        return error.statusCode == 502 || error.statusCode == 504
     }
 
     private fun isRetryableFlagsIOException(error: IOException): Boolean {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -217,32 +217,26 @@ public class PostHogApi(
         while (true) {
             try {
                 return executeFlagsRequest(request)
-            } catch (e: PostHogApiError) {
-                if (retryAttempt >= maxRetries || !isRetryableFlagsApiError(e)) {
+            } catch (e: Exception) {
+                if (retryAttempt >= maxRetries || !isRetryableFlagsError(e)) {
                     throw e
                 }
-
-                retryAttempt++
-                sleepBeforeFlagsRetry(retryAttempt)
-            } catch (e: IOException) {
-                if (retryAttempt >= maxRetries || !isRetryableFlagsIOException(e)) {
-                    throw e
-                }
-
-                retryAttempt++
-                sleepBeforeFlagsRetry(retryAttempt)
             }
+
+            retryAttempt++
+            sleepBeforeFlagsRetry(retryAttempt)
         }
     }
 
-    private fun isRetryableFlagsApiError(error: PostHogApiError): Boolean {
-        return error.statusCode == 502 || error.statusCode == 504
-    }
-
-    private fun isRetryableFlagsIOException(error: IOException): Boolean {
-        return error is SocketTimeoutException ||
-            error is EOFException ||
-            (error is SocketException && error.message?.contains("reset", ignoreCase = true) == true)
+    private fun isRetryableFlagsError(error: Exception): Boolean {
+        return when (error) {
+            is PostHogApiError -> error.statusCode == 502 || error.statusCode == 504
+            is IOException ->
+                error is SocketTimeoutException ||
+                    error is EOFException ||
+                    (error is SocketException && error.message?.contains("reset", ignoreCase = true) == true)
+            else -> false
+        }
     }
 
     @Throws(PostHogApiError::class, IOException::class)

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -753,11 +753,69 @@ internal class PostHogApiTest {
 }
 
 @RunWith(Parameterized::class)
+internal class PostHogApiFlagsRetryableHttpErrorTest(
+    private val statusCode: Int,
+) {
+    @Test
+    fun `flags retries HTTP 502 and 504 responses by default`() {
+        val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
+        val responseFlagsApi = file.readText()
+        val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
+        http.enqueue(MockResponse().setBody(responseFlagsApi))
+        val url = http.url("/")
+
+        try {
+            val sut = PostHogApi(PostHogConfig(API_KEY, url.toString()))
+
+            val response = sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+
+            assertNotNull(response)
+            assertEquals(true, response.featureFlags?.get("4535-funnel-bar-viz"))
+            assertEquals(2, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    @Test
+    fun `flags does not retry HTTP 502 and 504 responses when feature flag retries are disabled`() {
+        val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
+        val url = http.url("/")
+
+        try {
+            val config = PostHogConfig(API_KEY, url.toString())
+            config.featureFlagRequestMaxRetries = 0
+            val sut = PostHogApi(config)
+
+            val exc =
+                assertThrows(PostHogApiError::class.java) {
+                    sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+                }
+
+            assertEquals(statusCode, exc.statusCode)
+            assertEquals(1, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    private companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "statusCode={0}")
+        fun statusCodes(): Collection<Array<Int>> =
+            listOf(
+                arrayOf(502),
+                arrayOf(504),
+            )
+    }
+}
+
+@RunWith(Parameterized::class)
 internal class PostHogApiFlagsHttpErrorTest(
     private val statusCode: Int,
 ) {
     @Test
-    fun `flags does not retry HTTP error responses`() {
+    fun `flags does not retry non-retryable HTTP error responses`() {
         val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
         val url = http.url("/")
 
@@ -784,7 +842,6 @@ internal class PostHogApiFlagsHttpErrorTest(
                 arrayOf(408),
                 arrayOf(429),
                 arrayOf(500),
-                arrayOf(502),
                 arrayOf(503),
             )
     }

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -799,6 +799,54 @@ internal class PostHogApiFlagsRetryableHttpErrorTest(
         }
     }
 
+    @Test
+    fun `flags throws HTTP 502 and 504 responses after exhausting retries`() {
+        val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
+        http.enqueue(MockResponse().setResponseCode(statusCode).setBody("error"))
+        http.enqueue(MockResponse().setResponseCode(statusCode).setBody("error"))
+        val url = http.url("/")
+
+        try {
+            val config = PostHogConfig(API_KEY, url.toString())
+            config.featureFlagRequestMaxRetries = 2
+            val sut = PostHogApi(config)
+
+            val exc =
+                assertThrows(PostHogApiError::class.java) {
+                    sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+                }
+
+            assertEquals(statusCode, exc.statusCode)
+            assertEquals(3, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
+    @Test
+    fun `flags succeeds after multiple HTTP 502 and 504 retries`() {
+        val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
+        val responseFlagsApi = file.readText()
+        val http = mockHttp(response = MockResponse().setResponseCode(statusCode).setBody("error"))
+        http.enqueue(MockResponse().setResponseCode(statusCode).setBody("error"))
+        http.enqueue(MockResponse().setBody(responseFlagsApi))
+        val url = http.url("/")
+
+        try {
+            val config = PostHogConfig(API_KEY, url.toString())
+            config.featureFlagRequestMaxRetries = 2
+            val sut = PostHogApi(config)
+
+            val response = sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+
+            assertNotNull(response)
+            assertEquals(true, response.featureFlags?.get("4535-funnel-bar-viz"))
+            assertEquals(3, http.requestCount)
+        } finally {
+            http.shutdown()
+        }
+    }
+
     private companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "statusCode={0}")


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK already retries selected transient network failures for `/flags`, but HTTP 502 and 504 responses were surfaced immediately. The SDK test harness now covers `502 -> 200` and `504 -> 200` contract cases, expecting `/flags` to retry once by default and return the successful flag response.

This change keeps retry handling scoped to `/flags` and respects `featureFlagRequestMaxRetries`.

## :green_heart: How did you test it?

```bash
./gradlew :posthog:test --tests "com.posthog.internal.PostHogApiFlagsRetryableHttpErrorTest" --tests "com.posthog.internal.PostHogApiFlagsHttpErrorTest"
make checkFormat
```

Both commands passed locally.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added `.changeset/tiny-flags-retry.md`

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An AI implementation agent made the requested scoped change. The retry predicate was limited to HTTP 502 and 504 from the `/flags` execution path, leaving event capture and other HTTP status handling unchanged. Focused parameterized tests cover the successful default retry for 502/504 and verify disabling `featureFlagRequestMaxRetries` prevents those retries.
