### PR TITLE
feat: send error tracking stack frames in canonical bottom-up order

### DIFF
--- a/.changeset/canonical-frame-order.md
+++ b/.changeset/canonical-frame-order.md
@@ -1,0 +1,7 @@
+---
+'posthog': minor
+'posthog-android': minor
+'posthog-server': minor
+---
+
+Send error tracking stack frames in canonical bottom-up order: `frames[0]` is the outermost/entry point and the last frame is the crash site. Previously frames were emitted in Java's native innermost-first order. This aligns the wire format with the cross-SDK convention and affects both the `posthog-android` and `posthog-server` `$lib`s, which share the exception coercer.

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -68,7 +68,9 @@ public class ThrowableCoercer {
             if (stackTraces.isNotEmpty()) {
                 val frames = mutableListOf<Map<String, Any>>()
 
-                stackTraces.forEach { frame ->
+                // Emit frames bottom-up (canonical order): frames[0] is the outermost/entry point,
+                // the last frame is the crash site. Java's native stackTrace is innermost-first, so reverse it.
+                stackTraces.reversed().forEach { frame ->
                     val myFrame = mutableMapOf<String, Any>()
 
                     myFrame["module"] = frame.className

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -2540,8 +2540,17 @@ internal class PostHogTest {
         assertTrue(firstFrameMainException.containsKey("module"))
         assertTrue(firstFrameMainException.containsKey("function"))
         assertEquals("java", firstFrameMainException["platform"])
-        assertTrue(firstFrameMainException["in_app"] as Boolean)
-        assertTrue(firstFrameMainException["lineno"] is Number)
+
+        // Frames are emitted in canonical bottom-up order: frames[0] is the outermost/entry point,
+        // the last frame is the crash site. This is the reverse of Java's native innermost-first stackTrace.
+        val nativeMainFrames = exception.stackTrace
+        assertEquals(nativeMainFrames.size, framesMainException.size)
+        assertEquals(nativeMainFrames.last().methodName, firstFrameMainException["function"])
+        // The crash site (last frame) is the in-app test method that threw.
+        val lastFrameMainException = framesMainException.last() as Map<*, *>
+        assertEquals(nativeMainFrames.first().methodName, lastFrameMainException["function"])
+        assertTrue(lastFrameMainException["in_app"] as Boolean)
+        assertTrue(lastFrameMainException["lineno"] is Number)
 
         // Verify stack trace structure for cause exception
         val stackTraceCauseException = causeExceptionData["stacktrace"] as Map<*, *>
@@ -2555,8 +2564,16 @@ internal class PostHogTest {
         assertTrue(firstFrameCauseException.containsKey("module"))
         assertTrue(firstFrameCauseException.containsKey("function"))
         assertEquals("java", firstFrameCauseException["platform"])
-        assertTrue(firstFrameCauseException["in_app"] as Boolean)
-        assertTrue(firstFrameCauseException["lineno"] is Number)
+
+        // Canonical bottom-up order also applies to the cause's frames.
+        val nativeCauseFrames = causeException.stackTrace
+        assertEquals(nativeCauseFrames.size, framesCauseException.size)
+        assertEquals(nativeCauseFrames.last().methodName, firstFrameCauseException["function"])
+        // The crash site (last frame) is the in-app test method that threw.
+        val lastFrameCauseException = framesCauseException.last() as Map<*, *>
+        assertEquals(nativeCauseFrames.first().methodName, lastFrameCauseException["function"])
+        assertTrue(lastFrameCauseException["in_app"] as Boolean)
+        assertTrue(lastFrameCauseException["lineno"] is Number)
 
         sut.close()
     }
@@ -2625,8 +2642,17 @@ internal class PostHogTest {
         assertTrue(firstFrameMainException.containsKey("module"))
         assertTrue(firstFrameMainException.containsKey("function"))
         assertEquals("java", firstFrameMainException["platform"])
-        assertTrue(firstFrameMainException["in_app"] as Boolean)
-        assertTrue(firstFrameMainException["lineno"] is Number)
+
+        // Frames are emitted in canonical bottom-up order (entry point first, crash site last),
+        // the reverse of Java's native innermost-first stackTrace.
+        val nativeMainFrames = causeException.stackTrace
+        assertEquals(nativeMainFrames.size, framesMainException.size)
+        assertEquals(nativeMainFrames.last().methodName, firstFrameMainException["function"])
+        // The crash site (last frame) is the in-app test method that threw.
+        val lastFrameMainException = framesMainException.last() as Map<*, *>
+        assertEquals(nativeMainFrames.first().methodName, lastFrameMainException["function"])
+        assertTrue(lastFrameMainException["in_app"] as Boolean)
+        assertTrue(lastFrameMainException["lineno"] is Number)
 
         sut.close()
     }


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of cross-SDK error tracking standardization: PostHog/sdk-specs#11.

The canonical wire order for `$exception_list[].stacktrace.frames` is **bottom-up**: `frames[0]` is the outermost/entry point and the **last** frame is the crash site. Today the shared exception coercer emits Java's native **innermost-first** order (crash site first), which is the opposite of the canonical convention.

This PR flips the frame order to match the spec.

## :wrench: The change

`ThrowableCoercer.fromThrowableToPostHogProperties` now walks `throwable.stackTrace` in reverse when building the `frames` list, so the emitted order is entry-point-first / crash-site-last.

The `$exception_list` ordering itself is unchanged (already canonical: `[0]` = outermost exception, built by walking `.cause`). Only the per-exception frame order flips.

Because this coercer is shared, the change covers **both** shipped `$lib`s:

- `posthog-android` (Android SDK)
- `posthog-server` (Java server SDK)

## :green_heart: How did you test it?

- Updated the existing frame-order assertions in `posthog/src/test/java/com/posthog/PostHogTest.kt`.
- Added explicit regression assertions: the emitted frames are the reverse of the native `stackTrace` — first frame = entry point, last frame = crash site, and the crash-site (last) frame is the in-app method that threw.
- `./gradlew spotlessCheck :posthog:test` passes (748 tests).

## :handshake: Coordination

**This is a BREAKING wire-order change.** Merge and release only after the ingestion pipeline's frame-order normalization gate (cymbal) is live, so older-order and newer-order events are both normalized correctly server-side.

The release must be a **MINOR** version bump for both `posthog-android` and `posthog-server` so the pipeline can gate normalization on `$lib_version`. The changeset in this PR declares minor bumps for `posthog`, `posthog-android`, and `posthog-server`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] Ran the changeset (`.changeset/canonical-frame-order.md`, minor bumps).
- [ ] Added the "release" label to the PR (hold until the normalization gate is live).