### PR TITLE
fix: also send device user agent as $raw_user_agent

### DIFF
--- a/.changeset/mirror-raw-user-agent.md
+++ b/.changeset/mirror-raw-user-agent.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+fix: also send the device user agent as $raw_user_agent, the standardized property PostHog's server-side classification reads

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -74,6 +74,9 @@ internal class PostHogAndroidContext(
         dynamicContext["\$locale"] = "${Locale.getDefault().language}-${Locale.getDefault().country}"
         System.getProperty("http.agent")?.let {
             dynamicContext["\$user_agent"] = it
+            // Mirrored into $raw_user_agent, the standardized property PostHog's
+            // server-side classification (e.g. bot detection) reads
+            dynamicContext["\$raw_user_agent"] = it
         }
         dynamicContext["\$timezone"] = TimeZone.getDefault().id
 

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
@@ -89,6 +89,7 @@ internal class PostHogAndroidContextTest {
         // its dynamic
         assertNotNull(dynamicContext["\$locale"])
         assertEquals("value", dynamicContext["\$user_agent"])
+        assertEquals("value", dynamicContext["\$raw_user_agent"])
         assertNotNull(dynamicContext["\$timezone"])
 
         assertEquals("name", dynamicContext["\$network_carrier"])


### PR DESCRIPTION
## :bulb: Motivation and Context

The SDK attaches the device user agent (`http.agent`) to every event as `$user_agent`, but PostHog's server-side classification — web analytics bot detection (`$virt_is_bot` and friends) and the materialized-column fast path — keys on the standardized `$raw_user_agent` property (the one posthog-js sends). posthog-android is the only mobile SDK putting a real device UA in `$user_agent` while omitting `$raw_user_agent`, so its events can't be classified without an expensive fallback.

PostHog/posthog#68253 removes that fallback for performance (it forced a full properties-blob read on every classification query — see the PR for production measurements), so this change mirrors the user agent into `$raw_user_agent`, aligning Android with the standardized property. Related: PostHog/posthog#68232.

`$user_agent` is still sent for backwards compatibility.

## :green_heart: How did you test it?

Agent-authored. Extended the existing `PostHogAndroidContextTest` dynamic-context test to assert `$raw_user_agent` carries the same value as `$user_agent`; relying on CI to run the suite (no local Android toolchain in this session).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file (changeset file added manually with the same format)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code as part of a cross-repo effort to standardize on `$raw_user_agent` (PostHog/posthog#68232, PostHog/posthog#68253, with sibling PRs to posthog-python and posthog-ruby). The value duplicated is the existing `http.agent` string; no truncation added since the current `$user_agent` isn't truncated either.
