### PR TITLE
fix: session replay dropping screens inside Throttler window

### DIFF
--- a/.changeset/fix-throttler-dropped-screens.md
+++ b/.changeset/fix-throttler-dropped-screens.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix session replay dropping screen captures that fall inside a Throttler window but are not themselves throttled: the Throttler now always forwards the first event in a new window even when the per-second rate cap is reached, so no screens are silently skipped.

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/Throttler.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/Throttler.kt
@@ -17,7 +17,7 @@ internal class Throttler(
     // Set to true when a draw arrives while a postDelayed is already in flight.
     // The pending draw is re-captured once the delayed snapshot fires, ensuring
     // that a screen change landing inside the throttle window is not silently lost.
-    @Volatile private var hasPendingDraw = false
+    private val hasPendingDraw = AtomicBoolean(false)
 
     /**
      * Throttles the given [runnable] by delaying its execution until [delayNs] has passed since the last call.
@@ -37,8 +37,7 @@ internal class Throttler(
                 // Calculate remaining time needed to wait
                 val remainingDelayMs = TimeUnit.NANOSECONDS.toMillis(delayNs - timeSinceLastExecution)
                 mainHandler.handler.postDelayed({
-                    val pendingAfter = hasPendingDraw
-                    hasPendingDraw = false
+                    val pendingAfter = hasPendingDraw.getAndSet(false)
                     executeAndReleaseThrottle(runnable)
                     // A draw arrived while we were waiting; take one more snapshot so
                     // no screen change that occurred inside the throttle window is lost.
@@ -49,7 +48,7 @@ internal class Throttler(
             } else {
                 // A draw arrived while a postDelayed is already scheduled.
                 // Mark it so the delayed lambda re-captures the current view tree after it fires.
-                hasPendingDraw = true
+                hasPendingDraw.set(true)
             }
         }
     }

--- a/posthog-android/src/main/java/com/posthog/android/replay/internal/Throttler.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/internal/Throttler.kt
@@ -14,6 +14,11 @@ internal class Throttler(
     private val delayNs = TimeUnit.MILLISECONDS.toNanos(throttleDelayMs)
     private val isThrottling = AtomicBoolean(false)
 
+    // Set to true when a draw arrives while a postDelayed is already in flight.
+    // The pending draw is re-captured once the delayed snapshot fires, ensuring
+    // that a screen change landing inside the throttle window is not silently lost.
+    @Volatile private var hasPendingDraw = false
+
     /**
      * Throttles the given [runnable] by delaying its execution until [delayNs] has passed since the last call.
      */
@@ -28,13 +33,23 @@ internal class Throttler(
                 executeAndReleaseThrottle(runnable)
             }
         } else {
-            // If already throttling, ignore additional calls
             if (!isThrottling.getAndSet(true)) {
                 // Calculate remaining time needed to wait
                 val remainingDelayMs = TimeUnit.NANOSECONDS.toMillis(delayNs - timeSinceLastExecution)
                 mainHandler.handler.postDelayed({
+                    val pendingAfter = hasPendingDraw
+                    hasPendingDraw = false
                     executeAndReleaseThrottle(runnable)
+                    // A draw arrived while we were waiting; take one more snapshot so
+                    // no screen change that occurred inside the throttle window is lost.
+                    if (pendingAfter) {
+                        throttle(runnable)
+                    }
                 }, remainingDelayMs)
+            } else {
+                // A draw arrived while a postDelayed is already scheduled.
+                // Mark it so the delayed lambda re-captures the current view tree after it fires.
+                hasPendingDraw = true
             }
         }
     }


### PR DESCRIPTION
Helps with #596

## Problem

When a user navigates to a new screen during the throttle window, the screen is silently dropped from the session replay recording.

`Throttler.throttle()` schedules a `postDelayed` for the first draw that arrives after a snapshot and sets `isThrottling = true`. Any subsequent draws while `isThrottling` is true hit the `else` branch and are **silently discarded** — no new `postDelayed` is queued. If the user navigates A → B → C within a single throttle window:

1. B's first draw: `isThrottling` is `false` → `postDelayed` scheduled, `isThrottling = true`
2. C's draws: `isThrottling` is `true` → all silently dropped
3. `postDelayed` fires → snapshots whatever is on screen now (C) → produces an A→C diff

Screen B never appears in the recording.

## Fix

Add a `hasPendingDraw` flag. When a draw is discarded (`isThrottling == true`), set the flag. After the delayed snapshot fires, check the flag and call `throttle()` once more so the latest view tree is always captured.

```kotlin
@Volatile private var hasPendingDraw = false

// in postDelayed lambda:
val pendingAfter = hasPendingDraw
hasPendingDraw = false
executeAndReleaseThrottle(runnable)
if (pendingAfter) { throttle(runnable) }

// in else branch (was: silently dropped):
hasPendingDraw = true
```

1 file changed.