### PR TITLE
fix: fail closed on malformed flags responses

### DIFF
--- a/.changeset/quiet-flags-json.md
+++ b/.changeset/quiet-flags-json.md
@@ -1,0 +1,7 @@
+---
+'posthog': patch
+'posthog-android': patch
+'posthog-server': patch
+---
+
+Fail closed instead of throwing when feature flag responses cannot be parsed as JSON.

--- a/posthog-server/src/test/java/com/posthog/server/internal/FeatureFlagErrorTrackingTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FeatureFlagErrorTrackingTest.kt
@@ -9,6 +9,7 @@ import com.posthog.server.createMockHttp
 import com.posthog.server.createTestConfig
 import com.posthog.server.errorResponse
 import com.posthog.server.jsonResponse
+import okhttp3.mockwebserver.MockResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -144,6 +145,34 @@ internal class FeatureFlagErrorTrackingTest {
             )
 
         assertEquals(FeatureFlagError.apiError(403), error)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `getFeatureFlagError returns unknown_error when success response is not JSON`() {
+        val mockServer = createMockHttp(MockResponse().setBody("<html>upstream error</html>"))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        config.featureFlagRequestMaxRetries = 0
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val value =
+            remoteConfig.getFeatureFlag(
+                key = "test-flag",
+                defaultValue = "default",
+                distinctId = "test-user",
+            )
+
+        val error =
+            remoteConfig.getFeatureFlagError(
+                key = "test-flag",
+                distinctId = "test-user",
+            )
+
+        assertEquals("default", value)
+        assertEquals(FeatureFlagError.UNKNOWN_ERROR, error)
         mockServer.shutdown()
     }
 

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -111,6 +111,21 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `getFeatureFlags returns null when success response is not JSON`() {
+        val mockServer = createMockHttp(MockResponse().setBody("<html>upstream error</html>"))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val remoteConfig = PostHogFeatureFlags(config, api, 60000, 100)
+
+        val result = remoteConfig.getFeatureFlags(distinctId = "test-user")
+
+        assertNull(result)
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `getFeatureFlagPayload returns payload when available`() {
         val flagsResponse = createFlagsResponse("test-flag", payload = "test-payload")
         val mockServer = createMockHttp(jsonResponse(flagsResponse))

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -1,5 +1,7 @@
 package com.posthog.internal
 
+import com.google.gson.JsonIOException
+import com.google.gson.JsonSyntaxException
 import com.posthog.PostHogConfig
 import com.posthog.PostHogConfig.Companion.DEFAULT_EU_ASSETS_HOST
 import com.posthog.PostHogConfig.Companion.DEFAULT_EU_HOST
@@ -249,7 +251,7 @@ public class PostHogApi(
             if (!response.isSuccessful) throw PostHogApiError(response.code, response.message, response.body)
 
             response.body?.let { body ->
-                return config.serializer.deserialize(body.charStream().buffered())
+                return deserializeFlagsResponse(body)
             }
             return null
         }
@@ -379,6 +381,20 @@ public class PostHogApi(
             return LocalEvaluationApiResponse.success(null, null)
         }
     }
+
+    private fun deserializeFlagsResponse(body: okhttp3.ResponseBody): PostHogFlagsResponse? =
+        try {
+            config.serializer.deserialize(body.charStream().buffered())
+        } catch (e: JsonSyntaxException) {
+            config.logger.log("Loading feature flags failed: response was not valid JSON: $e")
+            null
+        } catch (e: JsonIOException) {
+            config.logger.log("Loading feature flags failed: response was not valid JSON: $e")
+            null
+        } catch (e: Throwable) {
+            config.logger.log("Loading feature flags failed: response could not be parsed: $e")
+            null
+        }
 
     private fun logResponse(response: Response): Response {
         if (config.debug) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -16,6 +16,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.BufferedSink
 import java.io.EOFException
@@ -382,19 +383,19 @@ public class PostHogApi(
         }
     }
 
-    private fun deserializeFlagsResponse(body: okhttp3.ResponseBody): PostHogFlagsResponse? =
-        try {
-            config.serializer.deserialize(body.charStream().buffered())
-        } catch (e: JsonSyntaxException) {
-            config.logger.log("Loading feature flags failed: response was not valid JSON: $e")
-            null
-        } catch (e: JsonIOException) {
-            config.logger.log("Loading feature flags failed: response was not valid JSON: $e")
-            null
-        } catch (e: Throwable) {
-            config.logger.log("Loading feature flags failed: response could not be parsed: $e")
-            null
-        }
+    private fun deserializeFlagsResponse(body: ResponseBody): PostHogFlagsResponse? =
+        runCatching {
+            config.serializer.deserialize<PostHogFlagsResponse?>(body.charStream().buffered())
+        }.onFailure { error ->
+            val reason =
+                when (error) {
+                    is JsonIOException,
+                    is JsonSyntaxException,
+                    -> "response was not valid JSON"
+                    else -> "response could not be parsed"
+                }
+            config.logger.log("Loading feature flags failed: $reason: $error")
+        }.getOrNull()
 
     private fun logResponse(response: Response): Response {
         if (config.debug) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogApi.kt
@@ -384,18 +384,19 @@ public class PostHogApi(
     }
 
     private fun deserializeFlagsResponse(body: ResponseBody): PostHogFlagsResponse? =
-        runCatching {
-            config.serializer.deserialize<PostHogFlagsResponse?>(body.charStream().buffered())
-        }.onFailure { error ->
+        try {
+            config.serializer.deserialize(body.charStream().buffered())
+        } catch (e: Exception) {
             val reason =
-                when (error) {
+                when (e) {
                     is JsonIOException,
                     is JsonSyntaxException,
                     -> "response was not valid JSON"
                     else -> "response could not be parsed"
                 }
-            config.logger.log("Loading feature flags failed: $reason: $error")
-        }.getOrNull()
+            config.logger.log("Loading feature flags failed: $reason: $e")
+            null
+        }
 
     private fun logResponse(response: Response): Response {
         if (config.debug) {

--- a/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogApiTest.kt
@@ -262,6 +262,19 @@ internal class PostHogApiTest {
     }
 
     @Test
+    fun `flags returns null when success response is not JSON`() {
+        val http = mockHttp(response = MockResponse().setBody("<html>upstream error</html>"))
+        val url = http.url("/")
+
+        val sut = getSut(host = url.toString())
+
+        val response = sut.flags("distinctId", anonymousId = "anonId", groups = emptyMap())
+
+        assertNull(response)
+        assertEquals(1, http.requestCount)
+    }
+
+    @Test
     fun `flags retries transient IOException and returns successful response`() {
         val file = File("src/test/resources/json/flags-v1/basic-flags-no-errors.json")
         val responseFlagsApi = file.readText()


### PR DESCRIPTION
## :bulb: Motivation and Context
Feature flag lookups should fail closed when the `/flags` endpoint returns a successful HTTP response that cannot be parsed as the expected JSON shape. A malformed or non-JSON body should not bubble a Gson exception into application code calling feature flag APIs.

This changes `/flags` response parsing to return `null` after logging parse failures, which lets the existing feature flag paths fall back to defaults and record `unknown_error` where applicable.

## :green_heart: How did you test it?

```bash
./gradlew :posthog:test --tests "com.posthog.internal.PostHogApiTest"
./gradlew :posthog-server:test --tests "com.posthog.server.internal.PostHogFeatureFlagsTest" --tests "com.posthog.server.internal.FeatureFlagErrorTrackingTest"
make checkFormat
```

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi. The change was narrowed to the feature-flags parsing path: malformed/non-JSON successful `/flags` responses now fail closed instead of throwing into callers. Earlier broader ideas around payload coercion and retrying parse failures were intentionally dropped to keep the fix focused on the `getFeatureFlags` safety issue.
