### PR TITLE
fix(replay): skip empty screenshot wireframe to avoid placeholder flash

### DIFF
--- a/.changeset/skip-empty-screenshot-wireframe.md
+++ b/.changeset/skip-empty-screenshot-wireframe.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Session Replay (screenshot mode): skip a frame when the screenshot capture is discarded instead of sending an imageless `screenshot` wireframe. An empty wireframe was rendered by the player as a placeholder tile, causing a brief visual flash before the next successful capture.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -506,7 +506,8 @@ public class PostHogReplayIntegration(
         }?.toRGBColor()
     }
 
-    private fun generateSnapshot(
+    // internal (not private) so tests can drive a snapshot pass directly.
+    internal fun generateSnapshot(
         viewRef: WeakReference<View>,
         windowRef: WeakReference<Window>,
     ) {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -1116,6 +1116,15 @@ public class PostHogReplayIntegration(
             }
         }
 
+        // A discarded capture (PixelCopy failure, or a redraw race that
+        // invalidates mask alignment) leaves base64 null. Emitting the
+        // wireframe anyway ships an imageless "screenshot" that the player
+        // renders as its placeholder tile — a visible flash. Skip the frame
+        // instead; the caller retries on the next capture.
+        if (base64 == null) {
+            return null
+        }
+
         return RRWireframe(
             id = viewId,
             x = x,

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -1,11 +1,14 @@
 package com.posthog.android.replay
 
+import android.app.Activity
 import android.content.Context
 import android.os.Looper
 import android.view.View
+import android.view.Window
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.posthog.PostHogEvent
+import com.posthog.PostHogFake
 import com.posthog.PostHogInterface
 import com.posthog.android.API_KEY
 import com.posthog.android.PostHogAndroidConfig
@@ -30,8 +33,11 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPixelCopy
+import java.lang.ref.WeakReference
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
@@ -424,6 +430,7 @@ internal class PostHogReplayIntegrationTest {
         sessionReplay: Boolean = true,
         samplingPasses: Boolean = true,
         preloadFeatureFlags: Boolean = true,
+        integrationContext: Context = mock<Context>(),
     ): RealQueueFixture {
         val remoteConfig =
             mock<PostHogRemoteConfig> {
@@ -449,7 +456,7 @@ internal class PostHogReplayIntegrationTest {
             )
         val replayQueue = PostHogReplayQueue(config, innerQueue, storagePrefix, executor)
         config.replayQueueHolder = replayQueue
-        val sut = PostHogReplayIntegration(mock<Context>(), config, MainHandler())
+        val sut = PostHogReplayIntegration(integrationContext, config, MainHandler())
         return RealQueueFixture(sut, replayQueue, innerQueue, config, remoteConfig)
     }
 
@@ -1210,6 +1217,79 @@ internal class PostHogReplayIntegrationTest {
             assertEquals(0, fx.replayQueue.bufferDepth)
             assertEquals(0, fx.replayQueue.depth)
             assertFalse(fx.sut.isActive())
+        } finally {
+            fx.sut.uninstall()
+        }
+    }
+
+    // Robolectric never runs the ViewRootImpl traversal that copies the window's
+    // visibility into AttachInfo, so getWindowVisibility() stays GONE and the
+    // integration treats the decor view as invisible. Set it directly.
+    private fun makeWindowVisible(decorView: View) {
+        val attachInfo =
+            View::class.java.getDeclaredField("mAttachInfo")
+                .apply { isAccessible = true }
+                .get(decorView)
+        attachInfo.javaClass.getDeclaredField("mWindowVisibility")
+            .apply { isAccessible = true }
+            .setInt(attachInfo, View.VISIBLE)
+    }
+
+    private fun screenshotFixture(): Pair<RealQueueFixture, PostHogFake> {
+        val fx =
+            createIntegrationWithRealQueue(
+                flagActive = true,
+                hasFetched = true,
+                integrationContext = ApplicationProvider.getApplicationContext(),
+            )
+        fx.config.sessionReplayConfig.screenshot = true
+        val fake = PostHogFake()
+        fx.sut.install(fake)
+        fx.sut.start(resumeCurrent = true)
+        return fx to fake
+    }
+
+    @Test
+    fun `screenshot mode skips the frame when the capture is discarded`() {
+        // A window without a decor view makes PixelCopy.request throw, so the capture is
+        // discarded (the same outcome as a PixelCopy failure or a redraw race in
+        // production). No event may be emitted: an imageless "screenshot" wireframe is
+        // rendered by the player as a placeholder tile, flashing until the next capture.
+        val (fx, fake) = screenshotFixture()
+        try {
+            assertTrue(fx.sut.isActive())
+            val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+            shadowOf(Looper.getMainLooper()).idle()
+            val decorView = activity.window.decorView
+            makeWindowVisible(decorView)
+            fx.sut.decorViews[decorView] = ViewTreeSnapshotStatus(mock<NextDrawListener>())
+
+            fx.sut.generateSnapshot(WeakReference(decorView), WeakReference(mock<Window>()))
+
+            assertEquals(0, fake.captures)
+        } finally {
+            fx.sut.uninstall()
+        }
+    }
+
+    @Test
+    @Config(sdk = [26], shadows = [ShadowPixelCopy::class])
+    fun `screenshot mode emits meta and full snapshot when the capture succeeds`() {
+        // Control for the discarded-capture test: with PixelCopy succeeding, the same
+        // pipeline must emit the snapshot event.
+        val (fx, fake) = screenshotFixture()
+        try {
+            assertTrue(fx.sut.isActive())
+            val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+            shadowOf(Looper.getMainLooper()).idle()
+            val decorView = activity.window.decorView
+            makeWindowVisible(decorView)
+            fx.sut.decorViews[decorView] = ViewTreeSnapshotStatus(mock<NextDrawListener>())
+
+            fx.sut.generateSnapshot(WeakReference(decorView), WeakReference(activity.window))
+
+            assertEquals(1, fake.captures)
+            assertEquals("\$snapshot", fake.event)
         } finally {
             fx.sut.uninstall()
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

In screenshot-mode session replay on Android, `View.toScreenshotWireframe(window)` returns a `type = "screenshot"` wireframe even when the capture was discarded — a PixelCopy failure, or the SDK's own "screenshot discarded due to screen changes" redraw-race guard — leaving `base64 = null`. `generateSnapshot` then ships that imageless wireframe.

The replay player renders a null-image screenshot as a placeholder tile (diagonal hatch + play icon + "screenshot" watermark), producing a brief flash before the next successful capture repaints the real screen. This is most visible right after a new screen is presented, when a redraw is likely in flight.

## :green_heart: How did you test it?

Return `null` from `toScreenshotWireframe` when the capture produced no image. The caller already treats null as "skip this frame" (`view.toScreenshotWireframe(window) ?: return false`) and retries on the next capture, so no empty screenshot is ever enqueued.

iOS already guards this in `renderAndEnqueueScreenshot` (`guard let image = window.toImage(...) else { return false }`); this brings Android to parity.

Verified with `./gradlew :posthog-android:compileDebugKotlin` (passes).

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Change isolated and applied with Claude Code (Edit/Bash tools). The single-line behavioral change (return `null` on a discarded capture) mirrors the existing iOS guard; the caller path already handles a null return, so no caller change was needed. A changeset was added; no version bump or unrelated wiring is included.

# no longer see this:
<img width="439" height="877" alt="Screenshot 2026-07-09 at 6 30 39 PM" src="https://github.com/user-attachments/assets/f97477a7-6c6b-479b-a0bd-3cce447a43e7" />


