### PR TITLE
chore: patch-release posthog-android to re-pin core 6.24.0

### DIFF
--- a/.changeset/repin-core-for-ignored-exception-types.md
+++ b/.changeset/repin-core-for-ignored-exception-types.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Re-pin the core dependency so `errorTrackingConfig.ignoredExceptionTypes` (core 6.24.0) is reachable for posthog-android consumers without an explicit core override.


### PR DESCRIPTION
## :bulb: Motivation and Context

#608 shipped `errorTrackingConfig.ignoredExceptionTypes` as core 6.24.0, but its changeset didn't bump `posthog-android`, whose published 3.53.5 POM still pins core 6.23.3 — so consumers depending on `posthog-android` can't reach the new API without an explicit `com.posthog:posthog:6.24.0` override (surfaced in review of PostHog/posthog-js#4126). This changeset-only patch release re-pins core via the `api(project(":posthog"))` dependency at publish time.

## :green_heart: How did you test it?

No code change — changeset only. The published POM pin comes from `coreVersion` (already 6.24.0 on main) at release time.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session directed by @turnipdabeets, follow-up to #608 after ioannisj's review question on the RN plugin's explicit core dependency.
