### PR TITLE
chore(deps): bump codeql-action to 4.36.3 and setup-java to 5.5.0, group codeql Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       interval: weekly
     reviewers:
       - "PostHog/team-client-libraries"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: 'Set up Java 17'
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,13 +28,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
             - name: 'Set up Java 17'
-              uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
+              uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
               with:
                   java-version: '17'
                   distribution: 'temurin'


### PR DESCRIPTION
## :bulb: Motivation and Context

Combines Dependabot PRs #614, #615, and #616 into a single change:

- `github/codeql-action/init` and `github/codeql-action/analyze` 4.36.2 → 4.36.3
- `actions/setup-java` 5.4.0 → 5.5.0

It also addresses why #614 and #615 existed as separate PRs in the first place: `init` and `analyze` live in the same upstream repo and always bump together, but our `dependabot.yml` had no `groups` config, so each one got its own PR. This adds a `codeql-action` group matching what posthog-ios did in PostHog/posthog-ios#707, so future codeql bumps arrive as one PR.

## :green_heart: How did you test it?

SHA pins and version comments were taken verbatim from the Dependabot PR diffs. `dependabot.yml` grouping mirrors the posthog-ios config already in production.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code combined the three open Dependabot PRs at Anna's request and ported the Dependabot `groups` fix from posthog-ios (#707) as the root-cause change. Bumps were copied exactly from the Dependabot diffs; the only authored change is the `groups` block in `dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
