### PR TITLE
test(replay): await buffer migration before idling looper in gate test

### DIFF
--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -903,9 +903,14 @@ internal class PostHogReplayIntegrationTest {
             // hasRemoteConfigFetched before notifying), so the gate stays disarmed after this delivery.
             whenever(fx.remoteConfig.hasRemoteConfigFetched()).thenReturn(true)
             fx.sut.onRemoteConfig()
-            shadowOf(Looper.getMainLooper()).idle()
 
+            // onRemoteConfig() schedules the buffer migration on the replay executor. Await it before
+            // idling the looper: idle() runs the posted resume-start(), whose resetBufferingState()
+            // clears the buffer on the replay executor — a clear that races the in-flight migration on
+            // a separate executor and, if it wins, discards the window before it migrates. Awaiting the
+            // migrated result first makes that clear a no-op on an already-empty buffer.
             awaitCondition { fx.replayQueue.bufferDepth == 0 && fx.replayQueue.depth == 2 }
+            shadowOf(Looper.getMainLooper()).idle()
 
             // Gate disarmed on the single delivery: a snapshot added afterwards persists straight to
             // the inner queue instead of routing back into the buffer.

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -904,11 +904,12 @@ internal class PostHogReplayIntegrationTest {
             whenever(fx.remoteConfig.hasRemoteConfigFetched()).thenReturn(true)
             fx.sut.onRemoteConfig()
 
-            // onRemoteConfig() schedules the buffer migration on the replay executor. Await it before
-            // idling the looper: idle() runs the posted resume-start(), whose resetBufferingState()
-            // clears the buffer on the replay executor — a clear that races the in-flight migration on
-            // a separate executor and, if it wins, discards the window before it migrates. Awaiting the
-            // migrated result first makes that clear a no-op on an already-empty buffer.
+            // onRemoteConfig() schedules the buffer migration on the replay executor. Await its result
+            // before idling the looper: idle() runs the posted resume-start(resumeCurrent = true), and
+            // because replaySessionId is still null here that routes through resetSessionStateIfNeeded
+            // -> resetBufferingState -> clearBuffer on the replay executor. That clear races the
+            // in-flight migration on a separate executor and, if it wins, discards the window before it
+            // migrates. Awaiting the migrated result first makes the clear a no-op on an empty buffer.
             awaitCondition { fx.replayQueue.bufferDepth == 0 && fx.replayQueue.depth == 2 }
             shadowOf(Looper.getMainLooper()).idle()
 


### PR DESCRIPTION
## :bulb: Motivation and Context

`:posthog-android:testReleaseUnitTest` is red on `main`. One test, `PostHogReplayIntegrationTest > single onRemoteConfig delivery resolves the gate without a second callback`, times out under CI load (`error("Timed out waiting for condition")` at `PostHogReplayIntegrationTest.kt:475`). It passes in isolation on a fast machine and fails on a loaded runner.

I traced it to a cross-executor race in the test, not a product regression. In this scenario a single `onRemoteConfig()` fans out into two operations that land on two different single-threaded executors with no ordering between them:

- the migrate: `resolveFirstRemoteConfig()` moves the buffered snapshot window on the integration's private `PostHogReplayThread`.
- the clear: the test never called `start()`, so `reevaluateRecordingState` posts a resume-`start()`; `idle()` runs it, and its `resetBufferingState()` clears the buffer on the replay/queue executor.

The test asserts the migrated result (`bufferDepth == 0 && depth == 2`). If the clear wins, it wipes the buffer before the migration moves the files, the migration finds nothing, `depth` stays 0, and the 2s `awaitCondition` never resolves. On a fast machine the migration always wins; under CI contention `PostHogReplayThread` starves and the clear gets there first.

This showed up after #612 (clear the replay buffer off the main thread), but I don't think #612 introduced the race: the pre-#612 blocking clear fails the same way once the migration is delayed. #612 only dropped a blocking wait, which shifted timing enough that a loaded runner now loses a race it used to win. Product behavior is unchanged.

The fix is a deterministic wait rather than a bigger timeout: await the migration's observable result before idling the looper, so the resume-triggered clear runs against an already-empty buffer. This matches the sibling test that already awaits the migration without idling first. A longer timeout would just make the lucky ordering more likely, not remove the race.

## :green_heart: How did you test it?

- I reproduced the failure deterministically by injecting a temporary migration-thread stall to simulate CI starvation: the run fails at the same `PostHogReplayIntegrationTest.kt:475`, and with this fix in place it passes even with the stall still there, which is what tells me the wait is deterministic and not luck. I reverted the stall after.
- `./gradlew :posthog-android:testReleaseUnitTest` is green, run twice with `--rerun-tasks`.
- The diff is test-only, no product code changed, so there's no changeset.

## :pencil: Checklist

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
