### PR TITLE
fix: don't crash when setup() runs in Direct Boot mode before first unlock

### DIFF
--- a/.changeset/direct-boot-shared-prefs.md
+++ b/.changeset/direct-boot-shared-prefs.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix a crash when `PostHogAndroid.setup()` runs in Direct Boot mode (after a reboot, before the user first unlocks the device): accessing SharedPreferences in credential encrypted storage threw `IllegalStateException` and took the host app down. The SDK now resolves SharedPreferences lazily, buffers writes in memory while storage is locked, and flushes them on the first access after unlock.

--- a/.changeset/direct-boot-transient-identity.md
+++ b/.changeset/direct-boot-transient-identity.md
@@ -9,3 +9,5 @@ Don't let state read while the preferences store is temporarily unreadable (Dire
 - the `isIdentified` and person-processing fallbacks are neither persisted nor cached, so the persisted values are re-resolved once the store unlocks
 - the persisted opt-out choice is resolved lazily on the capture path once the store is readable (gating on the `config.optOut` default until then) instead of being baked in at `setup()` — this also fixes a latent bug where the setup-time read consulted the in-memory fallback store and never honored a persisted opt-out
 - the Android app-install integration defers install/update detection instead of firing a spurious `Application Installed` for an existing install and overwriting the stored previous version
+
+Behavior change: `group()` now early-returns when the user is opted out, so it no longer registers `$groups` or reloads feature flags in that case (previously only the downstream `$groupidentify` event was suppressed). This is required for the lazy opt-out gating above to honor a persisted opt-out, and matches `posthog-ios`.

--- a/.changeset/direct-boot-transient-identity.md
+++ b/.changeset/direct-boot-transient-identity.md
@@ -1,0 +1,6 @@
+---
+"posthog": patch
+"posthog-android": patch
+---
+
+Don't overwrite a returning user's persisted identity when `setup()` runs in Direct Boot mode. While credential encrypted storage is locked, the persisted `anonymousId`/`deviceId` are unreadable, so the get-or-create getters minted fresh ids and buffered them — and the buffered write clobbered the real ids on the first access after unlock. `PostHogPreferences` now exposes `isAvailable()`, and ids generated while the store is unavailable stay transient (in memory only): after unlock, a previously persisted identity wins; on a fresh install the transient id is persisted on first use.

--- a/.changeset/direct-boot-transient-identity.md
+++ b/.changeset/direct-boot-transient-identity.md
@@ -3,4 +3,9 @@
 "posthog-android": patch
 ---
 
-Don't overwrite a returning user's persisted identity when `setup()` runs in Direct Boot mode. While credential encrypted storage is locked, the persisted `anonymousId`/`deviceId` are unreadable, so the get-or-create getters minted fresh ids and buffered them — and the buffered write clobbered the real ids on the first access after unlock. `PostHogPreferences` now exposes `isAvailable()`, and ids generated while the store is unavailable stay transient (in memory only): after unlock, a previously persisted identity wins; on a fresh install the transient id is persisted on first use.
+Don't let state read while the preferences store is temporarily unreadable (Direct Boot, before the first unlock) overwrite or shadow persisted values. `PostHogPreferences` now exposes `isAvailable()`, and while it is false:
+
+- auto-generated `anonymousId`/`deviceId` stay transient (in memory only) — after unlock a previously persisted identity wins; on a fresh install the transient id is persisted on first use
+- the `isIdentified` and person-processing fallbacks are neither persisted nor cached, so the persisted values are re-resolved once the store unlocks
+- the persisted opt-out choice is resolved lazily on the capture path once the store is readable (gating on the `config.optOut` default until then) instead of being baked in at `setup()` — this also fixes a latent bug where the setup-time read consulted the in-memory fallback store and never honored a persisted opt-out
+- the Android app-install integration defers install/update detection instead of firing a spurious `Application Installed` for an existing install and overwriting the stored previous version

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAppInstallIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAppInstallIntegration.kt
@@ -25,6 +25,13 @@ internal class PostHogAppInstallIntegration(
         if (integrationInstalled) {
             return
         }
+        // While the store is unreadable (Direct Boot) VERSION/BUILD read as absent, which would
+        // fire a spurious "Application Installed" for an existing install and overwrite the
+        // persisted previous build on unlock. Stay uninstalled so the correct event can still be
+        // emitted once the store is readable.
+        if (config.cachePreferences?.isAvailable() == false) {
+            return
+        }
         integrationInstalled = true
 
         getPackageInfo(context, config)?.let { packageInfo ->

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -12,17 +12,55 @@ import com.posthog.internal.PostHogPreferences.Companion.STRINGIFIED_KEYS
 /**
  * Reads and writes to the SDKs shared preferences
  * The shared pref is called "posthog-android-$apiKey"
+ *
+ * The underlying [SharedPreferences] is resolved lazily: in Direct Boot mode (after a reboot,
+ * before the user first unlocks the device) credential encrypted storage is unavailable and
+ * `context.getSharedPreferences` throws. Until storage becomes available, writes are buffered
+ * in memory and flushed on the first access after unlock.
+ *
  * @property context the App Context
  * @property config the Config
- * @property sharedPreferences The SharedPreferences, defaults to context.getSharedPreferences(...)
+ * @param sharedPreferences The SharedPreferences, defaults to context.getSharedPreferences(...)
  */
 internal class PostHogSharedPreferences(
     private val context: Context,
     private val config: PostHogAndroidConfig,
-    private val sharedPreferences: SharedPreferences = context.getSharedPreferences("posthog-android-${config.apiKey}", MODE_PRIVATE),
+    sharedPreferences: SharedPreferences? = null,
 ) :
     PostHogPreferences {
     private val lock = Any()
+
+    @Volatile
+    private var sharedPreferences: SharedPreferences? = sharedPreferences
+
+    // Writes made while credential encrypted storage is unavailable (Direct Boot),
+    // keyed by preference key. Guarded by lock.
+    private val pendingWrites = mutableMapOf<String, Any>()
+
+    // Returns the SharedPreferences, creating it on first use. Returns null while the device
+    // is locked (Direct Boot) and credential encrypted storage is still unavailable.
+    private fun getSharedPrefs(): SharedPreferences? {
+        sharedPreferences?.let { return it }
+        synchronized(lock) {
+            sharedPreferences?.let { return it }
+            val prefs =
+                try {
+                    context.getSharedPreferences("posthog-android-${config.apiKey}", MODE_PRIVATE)
+                } catch (e: IllegalStateException) {
+                    config.logger.log("Shared preferences are not available until the device is unlocked (Direct Boot): $e.")
+                    return null
+                } ?: return null
+            sharedPreferences = prefs
+            if (pendingWrites.isNotEmpty()) {
+                val pending = pendingWrites.toMap()
+                pendingWrites.clear()
+                for ((key, value) in pending) {
+                    setValue(key, value)
+                }
+            }
+            return prefs
+        }
+    }
 
     override fun getValue(
         key: String,
@@ -30,7 +68,13 @@ internal class PostHogSharedPreferences(
     ): Any? {
         val value: Any?
         synchronized(lock) {
-            value = sharedPreferences.all[key] ?: defaultValue
+            val prefs = getSharedPrefs()
+            value =
+                if (prefs != null) {
+                    prefs.all[key] ?: defaultValue
+                } else {
+                    pendingWrites[key] ?: defaultValue
+                }
         }
 
         val stringifiedKeys = getStringifiedKeys()
@@ -64,9 +108,13 @@ internal class PostHogSharedPreferences(
         key: String,
         value: Any,
     ) {
-        val edit = sharedPreferences.edit()
-
         synchronized(lock) {
+            val prefs = getSharedPrefs()
+            if (prefs == null) {
+                pendingWrites[key] = value
+                return
+            }
+            val edit = prefs.edit()
             when (value) {
                 is Boolean -> {
                     edit.putBoolean(key, value)
@@ -112,9 +160,14 @@ internal class PostHogSharedPreferences(
     }
 
     override fun clear(except: List<String>) {
-        val edit = sharedPreferences.edit()
-
         synchronized(lock) {
+            val prefs = getSharedPrefs()
+            if (prefs == null) {
+                pendingWrites.keys.retainAll { except.contains(it) }
+                return
+            }
+            val edit = prefs.edit()
+
             // Invariant: STRINGIFIED_KEYS must list exactly the serialized (Map/List) keys that survive.
             // It is itself a stored key, so it is excluded from removal below and rebuilt from the survivors.
             val survivingStringifiedKeys = getStringifiedKeys().filterTo(mutableSetOf()) { except.contains(it) }
@@ -123,7 +176,7 @@ internal class PostHogSharedPreferences(
             // removal list up front. STRINGIFIED_KEYS is excluded here because it is rebuilt below from
             // the survivors rather than removed, so a preserved serialized value still deserializes on read.
             val keysToRemove =
-                sharedPreferences.all.keys.filter {
+                prefs.all.keys.filter {
                     it != STRINGIFIED_KEYS && !except.contains(it)
                 }
             keysToRemove.forEach { edit.remove(it) }
@@ -159,7 +212,7 @@ internal class PostHogSharedPreferences(
     }
 
     private fun getStringifiedKeys(): Set<String> {
-        return sharedPreferences.getStringSet(STRINGIFIED_KEYS, setOf()) ?: setOf()
+        return getSharedPrefs()?.getStringSet(STRINGIFIED_KEYS, setOf()) ?: setOf()
     }
 
     private fun serializeObject(
@@ -193,8 +246,13 @@ internal class PostHogSharedPreferences(
     }
 
     override fun remove(key: String) {
-        val edit = sharedPreferences.edit()
         synchronized(lock) {
+            val prefs = getSharedPrefs()
+            if (prefs == null) {
+                pendingWrites.remove(key)
+                return
+            }
+            val edit = prefs.edit()
             edit.remove(key)
             removeFromStringifiedKeys(key, edit)
             edit.apply()
@@ -204,8 +262,14 @@ internal class PostHogSharedPreferences(
     override fun getAll(): Map<String, Any> {
         val allPreferences: Map<String, Any>
         synchronized(lock) {
-            @Suppress("UNCHECKED_CAST")
-            allPreferences = sharedPreferences.all.toMap() as? Map<String, Any> ?: emptyMap()
+            val prefs = getSharedPrefs()
+            allPreferences =
+                if (prefs != null) {
+                    @Suppress("UNCHECKED_CAST")
+                    prefs.all.toMap() as? Map<String, Any> ?: emptyMap()
+                } else {
+                    pendingWrites.toMap()
+                }
         }
         val filteredPreferences =
             allPreferences.filterKeys { key ->

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -15,8 +15,9 @@ import com.posthog.internal.PostHogPreferences.Companion.STRINGIFIED_KEYS
  *
  * The underlying [SharedPreferences] is resolved lazily: in Direct Boot mode (after a reboot,
  * before the user first unlocks the device) credential encrypted storage is unavailable and
- * `context.getSharedPreferences` throws. Until storage becomes available, writes are buffered
- * in memory and flushed on the first access after unlock.
+ * `context.getSharedPreferences` throws. Until storage becomes available, writes, removals,
+ * and clears are buffered in memory and replayed against the real preferences on the first
+ * access after unlock.
  *
  * @property context the App Context
  * @property config the Config
@@ -33,9 +34,12 @@ internal class PostHogSharedPreferences(
     @Volatile
     private var sharedPreferences: SharedPreferences? = sharedPreferences
 
-    // Writes made while credential encrypted storage is unavailable (Direct Boot),
-    // keyed by preference key. Guarded by lock.
+    // Operations made while credential encrypted storage is unavailable (Direct Boot),
+    // replayed in order (clear, then removals, then writes) on the first access after
+    // unlock so that deletions of previously persisted values are not lost. Guarded by lock.
     private val pendingWrites = mutableMapOf<String, Any>()
+    private val pendingRemovals = mutableSetOf<String>()
+    private var pendingClearExcept: List<String>? = null
 
     // Returns the SharedPreferences, creating it on first use. Returns null while the device
     // is locked (Direct Boot) and credential encrypted storage is still unavailable.
@@ -51,12 +55,16 @@ internal class PostHogSharedPreferences(
                     return null
                 } ?: return null
             sharedPreferences = prefs
-            if (pendingWrites.isNotEmpty()) {
-                val pending = pendingWrites.toMap()
-                pendingWrites.clear()
-                for ((key, value) in pending) {
-                    setValue(key, value)
-                }
+            val clearExcept = pendingClearExcept
+            pendingClearExcept = null
+            val removals = pendingRemovals.toList()
+            pendingRemovals.clear()
+            val writes = pendingWrites.toMap()
+            pendingWrites.clear()
+            clearExcept?.let { clear(it) }
+            removals.forEach { remove(it) }
+            for ((key, value) in writes) {
+                setValue(key, value)
             }
             return prefs
         }
@@ -111,6 +119,7 @@ internal class PostHogSharedPreferences(
         synchronized(lock) {
             val prefs = getSharedPrefs()
             if (prefs == null) {
+                pendingRemovals.remove(key)
                 pendingWrites[key] = value
                 return
             }
@@ -164,6 +173,9 @@ internal class PostHogSharedPreferences(
             val prefs = getSharedPrefs()
             if (prefs == null) {
                 pendingWrites.keys.retainAll { except.contains(it) }
+                // Persisted keys can't be enumerated while locked; record the clear and
+                // apply it against the real preferences on the first access after unlock.
+                pendingClearExcept = except
                 return
             }
             val edit = prefs.edit()
@@ -250,6 +262,8 @@ internal class PostHogSharedPreferences(
             val prefs = getSharedPrefs()
             if (prefs == null) {
                 pendingWrites.remove(key)
+                // Tombstone so a previously persisted value is also removed after unlock.
+                pendingRemovals.add(key)
                 return
             }
             val edit = prefs.edit()

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogSharedPreferences.kt
@@ -70,6 +70,10 @@ internal class PostHogSharedPreferences(
         }
     }
 
+    override fun isAvailable(): Boolean {
+        return getSharedPrefs() != null
+    }
+
     override fun getValue(
         key: String,
         defaultValue: Any?,

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAppInstallIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAppInstallIntegrationTest.kt
@@ -8,6 +8,9 @@ import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.createPostHogFake
 import com.posthog.android.mockPackageInfo
 import com.posthog.internal.PostHogMemoryPreferences
+import com.posthog.internal.PostHogPreferences
+import com.posthog.internal.PostHogPreferences.Companion.BUILD
+import com.posthog.internal.PostHogPreferences.Companion.VERSION
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import kotlin.test.BeforeTest
@@ -18,10 +21,10 @@ import kotlin.test.assertEquals
 internal class PostHogAppInstallIntegrationTest {
     private val context = mock<Context>()
 
-    private fun getSut(): PostHogAppInstallIntegration {
+    private fun getSut(preferences: PostHogPreferences = PostHogMemoryPreferences()): PostHogAppInstallIntegration {
         val config =
             PostHogAndroidConfig(API_KEY).apply {
-                cachePreferences = PostHogMemoryPreferences()
+                cachePreferences = preferences
             }
         return PostHogAppInstallIntegration(context, config)
     }
@@ -89,6 +92,37 @@ internal class PostHogAppInstallIntegrationTest {
 
         // sanity check
         assertEquals(1, fake.captures)
+
+        sut.uninstall()
+    }
+
+    @Test
+    fun `install defers until preferences are readable instead of firing a spurious install event`() {
+        val delegate = PostHogMemoryPreferences()
+        var available = false
+        val preferences =
+            object : PostHogPreferences by delegate {
+                override fun isAvailable(): Boolean = available
+            }
+        // an existing install whose stored version is unreadable while locked
+        delegate.setValue(VERSION, "1.0.0")
+        delegate.setValue(BUILD, 1L)
+        val sut = getSut(preferences)
+
+        context.mockPackageInfo("2.0.0", 2)
+
+        val fake = createPostHogFake()
+
+        sut.install(fake)
+
+        assertEquals(0, fake.captures)
+
+        available = true
+        sut.install(fake)
+
+        assertEquals("Application Updated", fake.event)
+        assertEquals("1.0.0", fake.properties?.get("previous_version"))
+        assertEquals(1L, fake.properties?.get("previous_build"))
 
         sut.uninstall()
     }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -363,4 +363,17 @@ internal class PostHogSharedPreferencesTests {
         assertEquals("new", sut.getValue("key"))
         assertEquals("new", directBootContext.realPreferences.getString("key", null))
     }
+
+    @Test
+    fun `serialized values written while locked survive the unlock replay`() {
+        val directBootContext = DirectBootContext()
+        val sut = getDirectBootSut(directBootContext)
+
+        sut.setValue("map", mapOf("k" to "v"))
+        directBootContext.locked = false
+
+        assertEquals(mapOf("k" to "v"), sut.getValue("map"))
+        val stringifiedKeys: Set<String>? = directBootContext.realPreferences.getStringSet(STRINGIFIED_KEYS, mutableSetOf())
+        assertEquals(setOf("map"), stringifiedKeys)
+    }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -306,4 +306,48 @@ internal class PostHogSharedPreferencesTests {
         assertEquals("value", sut.getValue("key"))
         assertEquals("value", directBootContext.realPreferences.getString("key", null))
     }
+
+    @Test
+    fun `remove while locked also removes a previously persisted value after unlock`() {
+        val directBootContext = DirectBootContext()
+        directBootContext.realPreferences.edit().putString("persisted", "old").apply()
+        val sut = getDirectBootSut(directBootContext)
+
+        sut.remove("persisted")
+        directBootContext.locked = false
+
+        assertNull(sut.getValue("persisted"))
+        assertNull(directBootContext.realPreferences.getString("persisted", null))
+    }
+
+    @Test
+    fun `clear while locked also clears previously persisted values after unlock`() {
+        val directBootContext = DirectBootContext()
+        directBootContext.realPreferences.edit()
+            .putString("persisted", "old")
+            .putString("kept", "old")
+            .apply()
+        val sut = getDirectBootSut(directBootContext)
+
+        sut.clear(except = listOf("kept"))
+        directBootContext.locked = false
+
+        assertNull(sut.getValue("persisted"))
+        assertEquals("old", sut.getValue("kept"))
+        assertNull(directBootContext.realPreferences.getString("persisted", null))
+    }
+
+    @Test
+    fun `set after remove while locked keeps the new value after unlock`() {
+        val directBootContext = DirectBootContext()
+        directBootContext.realPreferences.edit().putString("key", "old").apply()
+        val sut = getDirectBootSut(directBootContext)
+
+        sut.remove("key")
+        sut.setValue("key", "new")
+        directBootContext.locked = false
+
+        assertEquals("new", sut.getValue("key"))
+        assertEquals("new", directBootContext.realPreferences.getString("key", null))
+    }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -8,6 +8,8 @@ import com.posthog.android.PostHogAndroidConfig
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.STRINGIFIED_KEYS
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -242,5 +244,66 @@ internal class PostHogSharedPreferencesTests {
         assertEquals("value", sut.getValue("key") as String)
         assertEquals("value", sut.getValue("somethingElse") as String)
         assertEquals(2, sut.getAll().size)
+    }
+
+    // Direct Boot: before the user first unlocks the device, credential encrypted storage is
+    // unavailable and context.getSharedPreferences throws IllegalStateException.
+
+    private class DirectBootContext {
+        var locked = true
+        val realPreferences = FakeSharedPreferences()
+        val context =
+            mock<Context> {
+                on { getSharedPreferences(any(), any()) } doAnswer {
+                    if (locked) {
+                        throw IllegalStateException(
+                            "SharedPreferences in credential encrypted storage are not available until after user (id 0) is unlocked",
+                        )
+                    }
+                    realPreferences
+                }
+            }
+    }
+
+    private fun getDirectBootSut(directBootContext: DirectBootContext): PostHogSharedPreferences {
+        val config = PostHogAndroidConfig(API_KEY)
+        return PostHogSharedPreferences(directBootContext.context, config)
+    }
+
+    @Test
+    fun `preferences do not crash while device is locked`() {
+        val sut = getDirectBootSut(DirectBootContext())
+
+        sut.setValue("key", "value")
+
+        assertEquals("value", sut.getValue("key"))
+        assertEquals(mapOf<String, Any>("key" to "value"), sut.getAll())
+    }
+
+    @Test
+    fun `preferences remove and clear pending writes while device is locked`() {
+        val sut = getDirectBootSut(DirectBootContext())
+
+        sut.setValue("removed", "value")
+        sut.remove("removed")
+        sut.setValue("cleared", "value")
+        sut.setValue("kept", "value")
+        sut.clear(except = listOf("kept"))
+
+        assertNull(sut.getValue("removed"))
+        assertNull(sut.getValue("cleared"))
+        assertEquals("value", sut.getValue("kept"))
+    }
+
+    @Test
+    fun `preferences flush pending writes once the device is unlocked`() {
+        val directBootContext = DirectBootContext()
+        val sut = getDirectBootSut(directBootContext)
+
+        sut.setValue("key", "value")
+        directBootContext.locked = false
+
+        assertEquals("value", sut.getValue("key"))
+        assertEquals("value", directBootContext.realPreferences.getString("key", null))
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogSharedPreferencesTests.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -268,6 +269,18 @@ internal class PostHogSharedPreferencesTests {
     private fun getDirectBootSut(directBootContext: DirectBootContext): PostHogSharedPreferences {
         val config = PostHogAndroidConfig(API_KEY)
         return PostHogSharedPreferences(directBootContext.context, config)
+    }
+
+    @Test
+    fun `preferences are unavailable while locked and available after unlock`() {
+        val directBootContext = DirectBootContext()
+        val sut = getDirectBootSut(directBootContext)
+
+        assertFalse(sut.isAvailable())
+
+        directBootContext.locked = false
+
+        assertTrue(sut.isAvailable())
     }
 
     @Test

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -826,6 +826,7 @@ public final class com/posthog/internal/PostHogMemoryPreferences : com/posthog/i
 	public fun clear (Ljava/util/List;)V
 	public fun getAll ()Ljava/util/Map;
 	public fun getValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun isAvailable ()Z
 	public fun remove (Ljava/lang/String;)V
 	public fun setValue (Ljava/lang/String;Ljava/lang/Object;)V
 }
@@ -865,6 +866,7 @@ public abstract interface class com/posthog/internal/PostHogPreferences {
 	public abstract fun clear (Ljava/util/List;)V
 	public abstract fun getAll ()Ljava/util/Map;
 	public abstract fun getValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun isAvailable ()Z
 	public abstract fun remove (Ljava/lang/String;)V
 	public abstract fun setValue (Ljava/lang/String;Ljava/lang/Object;)V
 }
@@ -885,6 +887,7 @@ public final class com/posthog/internal/PostHogPreferences$Companion {
 public final class com/posthog/internal/PostHogPreferences$DefaultImpls {
 	public static synthetic fun clear$default (Lcom/posthog/internal/PostHogPreferences;Ljava/util/List;ILjava/lang/Object;)V
 	public static synthetic fun getValue$default (Lcom/posthog/internal/PostHogPreferences;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Ljava/lang/Object;
+	public static fun isAvailable (Lcom/posthog/internal/PostHogPreferences;)Z
 }
 
 public final class com/posthog/internal/PostHogPrintLogger : com/posthog/internal/PostHogLogger {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -414,18 +414,35 @@ public class PostHog private constructor(
         }
     }
 
+    // An anonymousId generated while the preferences store was unavailable (see
+    // PostHogPreferences.isAvailable): kept in memory only, so it cannot overwrite a persisted
+    // id that was merely unreadable at the time. Guarded by anonymousLock.
+    private var transientAnonymousId: String? = null
+
     @get:JvmName("getAnonymousIdInternal")
     private var anonymousId: String
         get() {
             var anonymousId: String?
             synchronized(anonymousLock) {
+                // read availability before the value: if the store becomes readable in between,
+                // this call stays on the transient path and the persisted id is never overwritten
+                val preferencesAvailable = getPreferences().isAvailable()
                 anonymousId = getPreferences().getValue(ANONYMOUS_ID) as? String
                 if (anonymousId.isNullOrBlank()) {
-                    var uuid = TimeBasedEpochGenerator.generate()
-                    // when getAnonymousId method is available, pass-through the value for modification
-                    config?.getAnonymousId?.let { uuid = it(uuid) }
-                    anonymousId = uuid.toString()
-                    this.anonymousId = anonymousId ?: ""
+                    anonymousId = transientAnonymousId ?: run {
+                        var uuid = TimeBasedEpochGenerator.generate()
+                        // when getAnonymousId method is available, pass-through the value for modification
+                        config?.getAnonymousId?.let { uuid = it(uuid) }
+                        uuid.toString()
+                    }
+                    if (preferencesAvailable) {
+                        this.anonymousId = anonymousId ?: ""
+                        transientAnonymousId = null
+                    } else {
+                        // an absent value is indistinguishable from an unreadable one, so persisting
+                        // now could overwrite a returning user's id once the store unlocks
+                        transientAnonymousId = anonymousId
+                    }
                 }
             }
             return anonymousId ?: ""
@@ -1655,6 +1672,9 @@ public class PostHog private constructor(
         synchronized(personProcessingLock) {
             isPersonProcessingLoaded = false
         }
+        synchronized(anonymousLock) {
+            transientAnonymousId = null
+        }
 
         endSession()
         startSession()
@@ -1706,12 +1726,16 @@ public class PostHog private constructor(
             return ""
         }
         synchronized(deviceIdLock) {
+            // read availability before the value (see the anonymousId getter)
+            val preferencesAvailable = getPreferences().isAvailable()
             val deviceId = getPreferences().getValue(DEVICE_ID) as? String
             if (deviceId.isNullOrBlank()) {
                 // Lazy init for upgrades: existing installs won't have a device_id yet
                 val anonId = anonymousId
                 if (anonId.isNotBlank()) {
-                    getPreferences().setValue(DEVICE_ID, anonId)
+                    if (preferencesAvailable) {
+                        getPreferences().setValue(DEVICE_ID, anonId)
+                    }
                     return anonId
                 }
                 return ""

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -216,15 +216,9 @@ public class PostHog private constructor(
                         },
                     )
 
-                // no need to lock optOut here since the setup is locked already
-                val optOut =
-                    getPreferences().getValue(
-                        OPT_OUT,
-                        defaultValue = config.optOut,
-                    ) as? Boolean
-                optOut?.let {
-                    config.optOut = optOut
-                }
+                // The persisted OPT_OUT is resolved lazily by isOptedOut(): at this point
+                // this.config is not assigned yet (so getPreferences() would read the in-memory
+                // fallback), and in Direct Boot the store is not readable yet either.
 
                 val sendCachedEventsIntegration =
                     PostHogSendCachedEventsIntegration(
@@ -466,9 +460,20 @@ public class PostHog private constructor(
         get() {
             synchronized(identifiedLock) {
                 if (!isIdentifiedLoaded) {
-                    isIdentified = getPreferences().getValue(IS_IDENTIFIED) as? Boolean
-                        ?: (distinctId != anonymousId)
-                    isIdentifiedLoaded = true
+                    // read availability before the value (see the anonymousId getter)
+                    val preferencesAvailable = getPreferences().isAvailable()
+                    val value =
+                        getPreferences().getValue(IS_IDENTIFIED) as? Boolean
+                            ?: (distinctId != anonymousId)
+                    if (preferencesAvailable) {
+                        isIdentified = value
+                        isIdentifiedLoaded = true
+                    } else {
+                        // the fallback was computed against a transient identity; assigning through
+                        // the setter would buffer it and clobber the persisted value on unlock, and
+                        // caching it would hide the persisted value for the process lifetime
+                        field = value
+                    }
                 }
             }
             return field
@@ -610,7 +615,7 @@ public class PostHog private constructor(
             if (!isEnabled()) {
                 return
             }
-            if (config?.optOut == true) {
+            if (isOptedOut()) {
                 config?.logger?.log("PostHog is in OptOut state.")
                 return
             }
@@ -776,7 +781,7 @@ public class PostHog private constructor(
             if (!isEnabled()) {
                 return
             }
-            if (config?.optOut == true) {
+            if (isOptedOut()) {
                 return
             }
             val buffer = exceptionStepsBuffer ?: return
@@ -820,7 +825,7 @@ public class PostHog private constructor(
         try {
             if (!isEnabled()) return
             val cfg = config ?: return
-            if (cfg.optOut) return
+            if (isOptedOut()) return
             if (message.isBlank()) return
 
             // Filter + sort done inside PostHogRemoteConfig's existing lock
@@ -942,6 +947,27 @@ public class PostHog private constructor(
         }
     }
 
+    // Whether the persisted OPT_OUT value has been resolved into config.optOut. Resolution is
+    // deferred until the preferences store is readable (it is not in Direct Boot), gating on the
+    // developer-supplied config.optOut default until then. Guarded by optOutLock.
+    @Volatile
+    private var optOutLoaded = false
+
+    private fun isOptedOut(): Boolean {
+        val config = this.config ?: return true
+        if (!optOutLoaded) {
+            synchronized(optOutLock) {
+                if (!optOutLoaded && getPreferences().isAvailable()) {
+                    (getPreferences().getValue(OPT_OUT, defaultValue = config.optOut) as? Boolean)?.let {
+                        config.optOut = it
+                    }
+                    optOutLoaded = true
+                }
+            }
+        }
+        return config.optOut
+    }
+
     public override fun optIn() {
         if (!isEnabled()) {
             return
@@ -950,6 +976,8 @@ public class PostHog private constructor(
         synchronized(optOutLock) {
             config?.optOut = false
             getPreferences().setValue(OPT_OUT, false)
+            // an explicit runtime choice; the deferred read must not override it
+            optOutLoaded = true
         }
     }
 
@@ -961,6 +989,7 @@ public class PostHog private constructor(
         synchronized(optOutLock) {
             config?.optOut = true
             getPreferences().setValue(OPT_OUT, true)
+            optOutLoaded = true
             exceptionStepsBuffer?.clear()
         }
     }
@@ -972,7 +1001,7 @@ public class PostHog private constructor(
         if (!isEnabled()) {
             return true
         }
-        return config?.optOut ?: true
+        return isOptedOut()
     }
 
     /**
@@ -1322,10 +1351,20 @@ public class PostHog private constructor(
         get() {
             synchronized(personProcessingLock) {
                 if (!isPersonProcessingLoaded) {
-                    isPersonProcessingEnabled =
+                    // read availability before the value (see the anonymousId getter)
+                    val preferencesAvailable = getPreferences().isAvailable()
+                    val value =
                         getPreferences().getValue(PERSON_PROCESSING) as? Boolean
                             ?: false
-                    isPersonProcessingLoaded = true
+                    if (preferencesAvailable) {
+                        isPersonProcessingEnabled = value
+                        isPersonProcessingLoaded = true
+                    } else {
+                        // don't cache: the persisted value is unreadable, not absent, and must be
+                        // re-resolved once the store unlocks (the setter's equality guard is what
+                        // keeps this read-back from persisting)
+                        field = value
+                    }
                 }
             }
             return field

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -218,7 +218,9 @@ public class PostHog private constructor(
 
                 // The persisted OPT_OUT is resolved lazily by isOptedOut(): at this point
                 // this.config is not assigned yet (so getPreferences() would read the in-memory
-                // fallback), and in Direct Boot the store is not readable yet either.
+                // fallback), and in Direct Boot the store is not readable yet either. The latch is
+                // per config, so a re-setup after close() re-resolves against the new config.
+                optOutLoaded = false
 
                 val sendCachedEventsIntegration =
                     PostHogSendCachedEventsIntegration(
@@ -1385,6 +1387,13 @@ public class PostHog private constructor(
         groupProperties: Map<String, Any>?,
     ) {
         if (!isEnabled()) {
+            return
+        }
+
+        // gate here rather than relying on the stateless capture path, which reads the raw
+        // config.optOut and would miss a persisted opt-out that isOptedOut() has not resolved yet
+        if (isOptedOut()) {
+            config?.logger?.log("PostHog is in OptOut state.")
             return
         }
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -24,6 +24,16 @@ public interface PostHogPreferences {
 
     public fun getAll(): Map<String, Any>
 
+    /**
+     * Whether the backing store is currently readable. Returns false while persisted values are
+     * temporarily unreadable (e.g. Android Direct Boot, before the user first unlocks the device),
+     * in which case [getValue] cannot distinguish an absent key from an unreadable one. Callers
+     * that generate-and-persist a default on a missing value should skip persisting while
+     * unavailable, so the generated default cannot overwrite a persisted value once the store
+     * becomes readable again.
+     */
+    public fun isAvailable(): Boolean = true
+
     public companion object {
         public const val GROUPS: String = "groups"
         public const val ANONYMOUS_ID: String = "anonymousId"

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -7,9 +7,13 @@ import com.posthog.internal.PostHogPreferences
 import com.posthog.internal.PostHogPreferences.Companion.ANONYMOUS_ID
 import com.posthog.internal.PostHogPreferences.Companion.CAPTURE_PERFORMANCE
 import com.posthog.internal.PostHogPreferences.Companion.DEVICE_ID
+import com.posthog.internal.PostHogPreferences.Companion.DISTINCT_ID
 import com.posthog.internal.PostHogPreferences.Companion.ERROR_TRACKING
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.GROUP_PROPERTIES_FOR_FLAGS
+import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
+import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
+import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROPERTIES_FOR_FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
 import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
@@ -3448,6 +3452,125 @@ internal class PostHogTest {
         // nothing was persisted, so the id minted while locked is kept and persists now
         assertEquals(lockedDeviceId, sut.getDeviceId())
         assertEquals(lockedDeviceId, preferences.persisted.getValue(DEVICE_ID))
+
+        sut.close()
+    }
+
+    @Test
+    fun `capture while preferences are unavailable does not clobber the persisted identified state`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        preferences.persisted.setValue(ANONYMOUS_ID, "returning-anon-id")
+        preferences.persisted.setValue(DISTINCT_ID, "user-123")
+        preferences.persisted.setValue(IS_IDENTIFIED, true)
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        // reads isIdentified while locked; the computed fallback must not be buffered
+        sut.capture("locked event")
+        preferences.available = true
+
+        assertEquals(true, preferences.persisted.getValue(IS_IDENTIFIED))
+
+        sut.close()
+    }
+
+    @Test
+    fun `persisted opt-out is honored once preferences become available`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        preferences.persisted.setValue(OPT_OUT, true)
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        // while locked the persisted choice is unreadable; the config default applies
+        assertFalse(sut.isOptOut())
+
+        preferences.available = true
+
+        assertTrue(sut.isOptOut())
+        assertEquals(true, preferences.persisted.getValue(OPT_OUT))
+
+        sut.close()
+    }
+
+    @Test
+    fun `optOut called while preferences are unavailable persists after unlock`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        sut.optOut()
+        assertTrue(sut.isOptOut())
+
+        preferences.available = true
+
+        // the explicit runtime choice wins over the deferred re-read
+        assertTrue(sut.isOptOut())
+        assertEquals(true, preferences.persisted.getValue(OPT_OUT))
+
+        sut.close()
+    }
+
+    @Test
+    fun `persisted opt-out is honored after setup`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = PostHogMemoryPreferences()
+        preferences.setValue(OPT_OUT, true)
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        assertTrue(sut.isOptOut())
+
+        sut.close()
+    }
+
+    @Test
+    fun `persisted person processing is re-read once preferences become available`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        preferences.persisted.setValue(PERSON_PROCESSING, true)
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        // reads the flag while locked; the miss must not be cached for the process
+        sut.capture("locked event")
+        preferences.available = true
+        sut.capture("unlocked event")
+
+        queueExecutor.shutdownAndAwaitTermination()
+
+        http.takeRequest()
+        val request = http.takeRequest()
+        val content = request.body.unGzip()
+        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
+        assertEquals(true, batch.batch[0].properties?.get("\$process_person_profile"))
+
+        sut.close()
+    }
+
+    @Test
+    fun `reset while preferences are unavailable hands out a new transient anonymous id`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        val lockedAnonymousId = sut.getAnonymousId()
+        sut.reset()
+
+        assertNotEquals(lockedAnonymousId, sut.getAnonymousId())
 
         sut.close()
     }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -3,7 +3,10 @@ package com.posthog
 import com.posthog.internal.PostHogBatchEvent
 import com.posthog.internal.PostHogContext
 import com.posthog.internal.PostHogMemoryPreferences
+import com.posthog.internal.PostHogPreferences
+import com.posthog.internal.PostHogPreferences.Companion.ANONYMOUS_ID
 import com.posthog.internal.PostHogPreferences.Companion.CAPTURE_PERFORMANCE
+import com.posthog.internal.PostHogPreferences.Companion.DEVICE_ID
 import com.posthog.internal.PostHogPreferences.Companion.ERROR_TRACKING
 import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.GROUP_PROPERTIES_FOR_FLAGS
@@ -63,7 +66,7 @@ internal class PostHogTest {
         integration: PostHogIntegration? = null,
         remoteConfig: Boolean = false,
         surveys: Boolean = false,
-        cachePreferences: PostHogMemoryPreferences = PostHogMemoryPreferences(),
+        cachePreferences: PostHogPreferences = PostHogMemoryPreferences(),
         propertiesSanitizer: PostHogPropertiesSanitizer? = null,
         beforeSend: PostHogBeforeSend? = null,
         evaluationContexts: List<String>? = null,
@@ -3361,6 +3364,90 @@ internal class PostHogTest {
         assertEquals("\$set", batch.batch[0].event)
         assertEquals(userPropertiesToSet, batch.batch[0].properties!!["\$set"])
         assertEquals(userPropertiesToSetOnce, batch.batch[0].properties!!["\$set_once"])
+
+        sut.close()
+    }
+
+    // Mirrors the Android Direct Boot behavior: while unavailable, persisted values are
+    // unreadable and writes buffer in memory; the buffer flushes once the store unlocks.
+    private class LockablePreferences : PostHogPreferences {
+        val persisted = PostHogMemoryPreferences()
+        private val pending = mutableMapOf<String, Any>()
+        var available = false
+            set(value) {
+                field = value
+                if (value) {
+                    pending.forEach { (key, pendingValue) -> persisted.setValue(key, pendingValue) }
+                    pending.clear()
+                }
+            }
+
+        override fun getValue(
+            key: String,
+            defaultValue: Any?,
+        ): Any? = if (available) persisted.getValue(key, defaultValue) else pending[key] ?: defaultValue
+
+        override fun setValue(
+            key: String,
+            value: Any,
+        ) {
+            if (available) persisted.setValue(key, value) else pending[key] = value
+        }
+
+        override fun clear(except: List<String>) {
+            if (available) persisted.clear(except) else pending.keys.retainAll { except.contains(it) }
+        }
+
+        override fun remove(key: String) {
+            if (available) persisted.remove(key) else pending.remove(key)
+        }
+
+        override fun getAll(): Map<String, Any> = if (available) persisted.getAll() else pending.toMap()
+
+        override fun isAvailable(): Boolean = available
+    }
+
+    @Test
+    fun `getDeviceId does not overwrite a persisted identity while preferences are unavailable`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        preferences.persisted.setValue(ANONYMOUS_ID, "returning-anon-id")
+        preferences.persisted.setValue(DEVICE_ID, "returning-device-id")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        // While locked the persisted id is unreadable, so a stable transient one is handed out
+        val lockedDeviceId = sut.getDeviceId()
+        assertTrue(lockedDeviceId.isNotBlank())
+        assertEquals(lockedDeviceId, sut.getDeviceId())
+
+        preferences.available = true
+
+        // and the persisted identity survives the unlock instead of being overwritten
+        assertEquals("returning-device-id", sut.getDeviceId())
+        assertEquals("returning-anon-id", sut.getAnonymousId())
+
+        sut.close()
+    }
+
+    @Test
+    fun `getDeviceId generated while preferences are unavailable persists after unlock on a fresh install`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = LockablePreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        val lockedDeviceId = sut.getDeviceId()
+        assertNull(preferences.persisted.getValue(DEVICE_ID))
+
+        preferences.available = true
+
+        // nothing was persisted, so the id minted while locked is kept and persists now
+        assertEquals(lockedDeviceId, sut.getDeviceId())
+        assertEquals(lockedDeviceId, preferences.persisted.getValue(DEVICE_ID))
 
         sut.close()
     }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -3534,6 +3534,59 @@ internal class PostHogTest {
     }
 
     @Test
+    fun `persisted opt-out gates group as the first call`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = PostHogMemoryPreferences()
+        preferences.setValue(OPT_OUT, true)
+
+        val sut =
+            getSut(
+                url.toString(),
+                preloadFeatureFlags = false,
+                reloadFeatureFlags = false,
+                cachePreferences = preferences,
+                personProfiles = PersonProfiles.ALWAYS,
+            )
+
+        sut.group("company", "acme")
+
+        queueExecutor.shutdownAndAwaitTermination()
+
+        assertEquals(0, http.requestCount)
+
+        sut.close()
+    }
+
+    @Test
+    fun `persisted opt-out is honored again after close and re-setup`() {
+        val http = mockHttp()
+        val url = http.url("/")
+
+        val preferences = PostHogMemoryPreferences()
+        preferences.setValue(OPT_OUT, true)
+
+        // the same instance is re-setup with a fresh config (the static shared API does this),
+        // so the resolved value latched into the old config must not satisfy the new one
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+        assertTrue(sut.isOptOut())
+        sut.close()
+
+        val newConfig =
+            PostHogConfig(API_KEY, url.toString()).apply {
+                this.storagePrefix = tmpDir.newFolder().absolutePath
+                this.preloadFeatureFlags = false
+                this.cachePreferences = preferences
+            }
+        sut.setup(newConfig)
+
+        assertTrue(sut.isOptOut())
+
+        sut.close()
+    }
+
+    @Test
     fun `persisted person processing is re-read once preferences become available`() {
         val http = mockHttp()
         val url = http.url("/")


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogAndroid.setup()` crashes the host app in Direct Boot mode (after a reboot, before the user first unlocks the device). `PostHogSharedPreferences` eagerly calls `context.getSharedPreferences(...)` in its constructor, and credential encrypted storage throws until first unlock:

```
java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user (id 0) is unlocked
  at android.app.ContextImpl.getSharedPreferences (ContextImpl.java:643)
  at com.posthog.android.internal.PostHogSharedPreferences.<init> (PostHogSharedPreferences.kt:22)
  at com.posthog.android.PostHogAndroid$Companion.setAndroidConfig
  at com.posthog.android.PostHogAndroid$Companion.setup
```

Any app with a `directBootAware` component that triggers `Application.onCreate` before unlock is exposed — Play SDK Console cluster [4852cce0](https://play.google.com/sdk-console/accounts/3843563740275146028/sdks/7065738917375733979/crashes/4852cce0/details) (450 occurrences / 117 users on a single app, all SDK versions affected in principle).

The fix resolves the `SharedPreferences` lazily. While storage is locked, reads return defaults (same as a fresh install — the persisted values are physically unreadable) and writes are buffered in memory; the buffer is flushed to the real `SharedPreferences` on the first access after unlock. Buffering (rather than dropping writes or a for-the-process-lifetime in-memory fallback) is deliberate: the core SDK persists identity and opt-out through this class, so writes from the locked window must survive into unlocked storage within the same process.

## :green_heart: How did you test it?

- New unit tests simulating a Direct Boot context (throws `IllegalStateException` until "unlocked"): no crash while locked, buffered reads/writes/remove/clear work, and pending writes flush to the real `SharedPreferences` after unlock.
- Full `:posthog-android` and `:posthog` unit test suites pass; `spotlessCheck` clean.
- **Reproduced and verified end-to-end on an emulator (Pixel 9, API 37) in real Direct Boot mode** — sample app given a `directBootAware` `LOCKED_BOOT_COMPLETED` receiver, lock-screen PIN set, rebooted without unlocking:
  - Without this fix: `FATAL EXCEPTION ... Unable to create application ... Caused by: java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user (id 0) is unlocked` at `PostHogSharedPreferences.<init>` — the exact Play SDK Console cluster signature.
  - With this fix: no crash; the SDK logs `Shared preferences are not available until the device is unlocked (Direct Boot)` and a `PostHog.capture()` from the locked window succeeds.
  - Same-process flush: with the Direct Boot process kept alive across the unlock, the `anonymousId` generated while locked (`019f6651-c4c0-…`) was persisted verbatim to the real prefs XML after unlock — identity is continuous.
  - Fresh-process path: when the locked process is reaped before unlock, the next launch creates prefs normally.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) implemented this while triaging Play SDK Console crash clusters with Anna. The cluster's stack pinned the eager `getSharedPreferences` call in the `PostHogSharedPreferences` constructor; the fix was verified against current `main` before implementing. Considered and rejected: device-protected storage (would split identity across two prefs files and require migrating all existing users) and a process-lifetime in-memory fallback (would ignore opt-out/identity writes until process restart). Chose lazy resolution with a buffered flush on unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
