### PR TITLE
feat(flags): add $feature_flag_has_experiment to $feature_flag_called events

### DIFF
--- a/.changeset/feature-flag-has-experiment-property.md
+++ b/.changeset/feature-flag-has-experiment-property.md
@@ -3,4 +3,4 @@
 "posthog-server": minor
 ---
 
-Add a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, sourced from the `has_experiment` field the server reports in each flag's metadata (`/flags?v=2` and `/local_evaluation`). Defaults to `false` when the server does not report the field.
+Add a `$feature_flag_has_experiment` boolean property to `$feature_flag_called` events, sourced from the `has_experiment` field the server reports in each flag's metadata (`/flags?v=2` and `/local_evaluation`). The property is only sent when the server explicitly reported `has_experiment`; it is omitted when the server did not report it (older deployments) or when flag details are unavailable.

--- a/.changeset/feature-flag-has-experiment-property.md
+++ b/.changeset/feature-flag-has-experiment-property.md
@@ -1,0 +1,6 @@
+---
+"posthog": minor
+"posthog-server": minor
+---
+
+Add a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, sourced from the `has_experiment` field the server reports in each flag's metadata (`/flags?v=2` and `/local_evaluation`). Defaults to `false` when the server does not report the field.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
@@ -216,6 +216,7 @@ public class PostHogFeatureFlagEvaluations internal constructor(
                 props["locally_evaluated"] = true
             }
         }
+        props["\$feature_flag_has_experiment"] = flag?.metadata?.hasExperiment ?: false
         requestId?.let { props["\$feature_flag_request_id"] = it }
         evaluatedAt?.let { props["\$feature_flag_evaluated_at"] = it }
         definitionsLoadedAt?.let { props["\$feature_flag_definitions_loaded_at"] = it }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogFeatureFlagEvaluations.kt
@@ -216,7 +216,7 @@ public class PostHogFeatureFlagEvaluations internal constructor(
                 props["locally_evaluated"] = true
             }
         }
-        props["\$feature_flag_has_experiment"] = flag?.metadata?.hasExperiment ?: false
+        flag?.metadata?.hasExperiment?.let { props["\$feature_flag_has_experiment"] = it }
         requestId?.let { props["\$feature_flag_request_id"] = it }
         evaluatedAt?.let { props["\$feature_flag_evaluated_at"] = it }
         definitionsLoadedAt?.let { props["\$feature_flag_definitions_loaded_at"] = it }

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -676,6 +676,7 @@ internal class PostHogFeatureFlags(
                     id = flagDef.id,
                     payload = payload,
                     version = flagDef.version,
+                    hasExperiment = flagDef.hasExperiment,
                 ),
             reason =
                 com.posthog.internal.EvaluationReason(

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
@@ -128,8 +128,8 @@ internal class PostHogEvaluateFlagsTest {
         assertEquals(4.0, props["\$feature_flag_version"])
         assertEquals("Matched", props["\$feature_flag_reason"])
         assertEquals("req-fixture", props["\$feature_flag_request_id"])
-        // has_experiment absent from the response metadata defaults to false
-        assertEquals(false, props["\$feature_flag_has_experiment"])
+        // has_experiment absent from the response metadata, so the property is omitted
+        assertFalse(props.containsKey("\$feature_flag_has_experiment"))
 
         postHog.close()
         mockServer.shutdown()

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
@@ -128,6 +128,51 @@ internal class PostHogEvaluateFlagsTest {
         assertEquals(4.0, props["\$feature_flag_version"])
         assertEquals("Matched", props["\$feature_flag_reason"])
         assertEquals("req-fixture", props["\$feature_flag_request_id"])
+        // has_experiment absent from the response metadata defaults to false
+        assertEquals(false, props["\$feature_flag_has_experiment"])
+
+        postHog.close()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `feature_flag_called reports has_experiment true when the response metadata reports it`() {
+        val flagsBody =
+            """
+            {
+                "flags": {
+                    "a": {
+                        "key": "a",
+                        "enabled": true,
+                        "variant": null,
+                        "metadata": { "version": 4, "payload": null, "id": 11, "has_experiment": true },
+                        "reason": { "code": "condition_match", "description": "Matched", "condition_index": 0 }
+                    }
+                },
+                "requestId": "req-fixture"
+            }
+            """.trimIndent()
+        val mockServer = MockWebServer()
+        mockServer.enqueue(jsonResponse(flagsBody))
+        mockServer.enqueue(MockResponse().setResponseCode(200))
+        mockServer.start()
+
+        val postHog =
+            PostHog.with(
+                PostHogConfig.builder(TEST_API_KEY)
+                    .host(mockServer.url("/").toString())
+                    .flushAt(1)
+                    .build(),
+            )
+
+        val snapshot = postHog.evaluateFlags("user-1")
+        snapshot.isEnabled("a")
+        postHog.flush()
+
+        val requests = drainRequests(mockServer)
+        val batch = requests.first { it.path?.contains("/batch") == true }.parseBatch()
+        val props = batch.eventProperties("\$feature_flag_called")
+        assertEquals(true, props["\$feature_flag_has_experiment"])
 
         postHog.close()
         mockServer.shutdown()

--- a/posthog-server/src/test/java/com/posthog/server/PostHogFeatureFlagEvaluationsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogFeatureFlagEvaluationsTest.kt
@@ -46,12 +46,13 @@ internal class PostHogFeatureFlagEvaluationsTest {
         version: Int = 3,
         payload: String? = null,
         reason: EvaluationReason? = EvaluationReason("condition_match", "Condition matched", 0),
+        hasExperiment: Boolean = false,
     ): FeatureFlag =
         FeatureFlag(
             key = key,
             enabled = enabled,
             variant = variant,
-            metadata = FeatureFlagMetadata(id = id, payload = payload, version = version),
+            metadata = FeatureFlagMetadata(id = id, payload = payload, version = version, hasExperiment = hasExperiment),
             reason = reason,
         )
 
@@ -158,6 +159,31 @@ internal class PostHogFeatureFlagEvaluationsTest {
         assertEquals(4, call.properties["\$feature_flag_version"])
         assertEquals("Condition matched", call.properties["\$feature_flag_reason"])
         assertEquals("req-1", call.properties["\$feature_flag_request_id"])
+        assertEquals(false, call.properties["\$feature_flag_has_experiment"])
+    }
+
+    @Test
+    fun `feature flag called event reports has_experiment from flag metadata`() {
+        val host = FakeHost()
+        val snapshot =
+            snapshot(
+                host = host,
+                flags =
+                    mapOf(
+                        "experiment-flag" to flag("experiment-flag", hasExperiment = true),
+                        "plain-flag" to flag("plain-flag", hasExperiment = false),
+                    ),
+            )
+
+        snapshot.isEnabled("experiment-flag")
+        snapshot.isEnabled("plain-flag")
+        snapshot.isEnabled("missing-flag")
+
+        assertEquals(3, host.captures.size)
+        assertEquals(true, host.captures[0].properties["\$feature_flag_has_experiment"])
+        assertEquals(false, host.captures[1].properties["\$feature_flag_has_experiment"])
+        // unknown flags have no metadata, so has_experiment defaults to false
+        assertEquals(false, host.captures[2].properties["\$feature_flag_has_experiment"])
     }
 
     @Test

--- a/posthog-server/src/test/java/com/posthog/server/PostHogFeatureFlagEvaluationsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogFeatureFlagEvaluationsTest.kt
@@ -46,7 +46,7 @@ internal class PostHogFeatureFlagEvaluationsTest {
         version: Int = 3,
         payload: String? = null,
         reason: EvaluationReason? = EvaluationReason("condition_match", "Condition matched", 0),
-        hasExperiment: Boolean = false,
+        hasExperiment: Boolean? = null,
     ): FeatureFlag =
         FeatureFlag(
             key = key,
@@ -159,7 +159,8 @@ internal class PostHogFeatureFlagEvaluationsTest {
         assertEquals(4, call.properties["\$feature_flag_version"])
         assertEquals("Condition matched", call.properties["\$feature_flag_reason"])
         assertEquals("req-1", call.properties["\$feature_flag_request_id"])
-        assertEquals(false, call.properties["\$feature_flag_has_experiment"])
+        // the metadata did not report has_experiment, so the property is omitted
+        assertFalse(call.properties.containsKey("\$feature_flag_has_experiment"))
     }
 
     @Test
@@ -182,8 +183,8 @@ internal class PostHogFeatureFlagEvaluationsTest {
         assertEquals(3, host.captures.size)
         assertEquals(true, host.captures[0].properties["\$feature_flag_has_experiment"])
         assertEquals(false, host.captures[1].properties["\$feature_flag_has_experiment"])
-        // unknown flags have no metadata, so has_experiment defaults to false
-        assertEquals(false, host.captures[2].properties["\$feature_flag_has_experiment"])
+        // unknown flags have no metadata, so the property is omitted
+        assertFalse(host.captures[2].properties.containsKey("\$feature_flag_has_experiment"))
     }
 
     @Test

--- a/posthog-server/src/test/java/com/posthog/server/Utils.kt
+++ b/posthog-server/src/test/java/com/posthog/server/Utils.kt
@@ -445,10 +445,17 @@ public fun createLocalEvaluationResponse(
     flagKey: String,
     aggregationGroupTypeIndex: Int? = null,
     rolloutPercentage: Int = 100,
+    hasExperiment: Boolean? = null,
 ): String {
     val aggregationGroupJson =
         if (aggregationGroupTypeIndex != null) {
             "\"aggregation_group_type_index\": $aggregationGroupTypeIndex,"
+        } else {
+            ""
+        }
+    val hasExperimentJson =
+        if (hasExperiment != null) {
+            "\"has_experiment\": $hasExperiment,"
         } else {
             ""
         }
@@ -461,6 +468,7 @@ public fun createLocalEvaluationResponse(
                     "name": "$flagKey",
                     "key": "$flagKey",
                     "active": true,
+                    $hasExperimentJson
                     "filters": {
                         $aggregationGroupJson
                         "groups": [

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -493,7 +493,7 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
-    fun `local evaluation defaults has_experiment to false when definitions omit it`() {
+    fun `local evaluation leaves has_experiment null when definitions omit it`() {
         val localEvalResponse = createLocalEvaluationResponse(flagKey = "plain-flag")
 
         val mockServer = createMockHttp(jsonResponse(localEvalResponse))
@@ -526,7 +526,7 @@ internal class PostHogFeatureFlagsTest {
                 disableGeoip = false,
             )
 
-        assertEquals(false, result.flags["plain-flag"]?.metadata?.hasExperiment)
+        assertNull(result.flags.getValue("plain-flag").metadata.hasExperiment)
 
         featureFlags.shutDown()
         mockServer.shutdown()

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -449,6 +449,90 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `local evaluation carries has_experiment from flag definitions into flag details`() {
+        val localEvalResponse =
+            createLocalEvaluationResponse(
+                flagKey = "experiment-flag",
+                hasExperiment = true,
+            )
+
+        val mockServer = createMockHttp(jsonResponse(localEvalResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val loadedLatch = CountDownLatch(1)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollIntervalSeconds = 30,
+                onFeatureFlags = { loadedLatch.countDown() },
+            )
+        assertTrue(loadedLatch.await(5000, java.util.concurrent.TimeUnit.MILLISECONDS))
+
+        val result =
+            featureFlags.evaluateFlags(
+                distinctId = "test-user",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = null,
+                onlyEvaluateLocally = true,
+                disableGeoip = false,
+            )
+
+        assertEquals(true, result.flags["experiment-flag"]?.metadata?.hasExperiment)
+
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `local evaluation defaults has_experiment to false when definitions omit it`() {
+        val localEvalResponse = createLocalEvaluationResponse(flagKey = "plain-flag")
+
+        val mockServer = createMockHttp(jsonResponse(localEvalResponse))
+        val url = mockServer.url("/")
+
+        val config = createTestConfig(host = url.toString())
+        val api = PostHogApi(config)
+        val loadedLatch = CountDownLatch(1)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                api,
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollIntervalSeconds = 30,
+                onFeatureFlags = { loadedLatch.countDown() },
+            )
+        assertTrue(loadedLatch.await(5000, java.util.concurrent.TimeUnit.MILLISECONDS))
+
+        val result =
+            featureFlags.evaluateFlags(
+                distinctId = "test-user",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = null,
+                onlyEvaluateLocally = true,
+                disableGeoip = false,
+            )
+
+        assertEquals(false, result.flags["plain-flag"]?.metadata?.hasExperiment)
+
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `poller does not start when pollerEnabled is false`() {
         val logger = TestLogger()
         val localEvalResponse =

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -588,16 +588,16 @@ public final class com/posthog/internal/FeatureFlag {
 }
 
 public final class com/posthog/internal/FeatureFlagMetadata {
-	public fun <init> (ILjava/lang/String;IZ)V
-	public synthetic fun <init> (ILjava/lang/String;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;ILjava/lang/Boolean;)V
+	public synthetic fun <init> (ILjava/lang/String;ILjava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()I
-	public final fun component4 ()Z
-	public final fun copy (ILjava/lang/String;IZ)Lcom/posthog/internal/FeatureFlagMetadata;
-	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlagMetadata;ILjava/lang/String;IZILjava/lang/Object;)Lcom/posthog/internal/FeatureFlagMetadata;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (ILjava/lang/String;ILjava/lang/Boolean;)Lcom/posthog/internal/FeatureFlagMetadata;
+	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlagMetadata;ILjava/lang/String;ILjava/lang/Boolean;ILjava/lang/Object;)Lcom/posthog/internal/FeatureFlagMetadata;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHasExperiment ()Z
+	public final fun getHasExperiment ()Ljava/lang/Boolean;
 	public final fun getId ()I
 	public final fun getPayload ()Ljava/lang/String;
 	public final fun getVersion ()I
@@ -613,12 +613,12 @@ public final class com/posthog/internal/FlagConditionGroup {
 }
 
 public final class com/posthog/internal/FlagDefinition {
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZZ)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZLjava/lang/Boolean;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZLjava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActive ()Z
 	public final fun getEnsureExperienceContinuity ()Z
 	public final fun getFilters ()Lcom/posthog/internal/FlagFilters;
-	public final fun getHasExperiment ()Z
+	public final fun getHasExperiment ()Ljava/lang/Boolean;
 	public final fun getId ()I
 	public final fun getKey ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -588,13 +588,16 @@ public final class com/posthog/internal/FeatureFlag {
 }
 
 public final class com/posthog/internal/FeatureFlagMetadata {
-	public fun <init> (ILjava/lang/String;I)V
+	public fun <init> (ILjava/lang/String;IZ)V
+	public synthetic fun <init> (ILjava/lang/String;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()I
-	public final fun copy (ILjava/lang/String;I)Lcom/posthog/internal/FeatureFlagMetadata;
-	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlagMetadata;ILjava/lang/String;IILjava/lang/Object;)Lcom/posthog/internal/FeatureFlagMetadata;
+	public final fun component4 ()Z
+	public final fun copy (ILjava/lang/String;IZ)Lcom/posthog/internal/FeatureFlagMetadata;
+	public static synthetic fun copy$default (Lcom/posthog/internal/FeatureFlagMetadata;ILjava/lang/String;IZILjava/lang/Object;)Lcom/posthog/internal/FeatureFlagMetadata;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHasExperiment ()Z
 	public final fun getId ()I
 	public final fun getPayload ()Ljava/lang/String;
 	public final fun getVersion ()I
@@ -610,11 +613,12 @@ public final class com/posthog/internal/FlagConditionGroup {
 }
 
 public final class com/posthog/internal/FlagDefinition {
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZ)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZZ)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLcom/posthog/internal/FlagFilters;IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActive ()Z
 	public final fun getEnsureExperienceContinuity ()Z
 	public final fun getFilters ()Lcom/posthog/internal/FlagFilters;
+	public final fun getHasExperiment ()Z
 	public final fun getId ()I
 	public final fun getKey ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1509,8 +1509,10 @@ public class PostHog private constructor(
                         props["\$feature_flag_id"] = it.metadata.id
                         props["\$feature_flag_version"] = it.metadata.version
                         props["\$feature_flag_reason"] = it.reason?.description ?: ""
+                        it.metadata.hasExperiment?.let { hasExperiment ->
+                            props["\$feature_flag_has_experiment"] = hasExperiment
+                        }
                     }
-                    props["\$feature_flag_has_experiment"] = flagDetails?.metadata?.hasExperiment ?: false
                     capture(PostHogEventName.FEATURE_FLAG_CALLED.event, properties = props)
                 }
             }

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1510,6 +1510,7 @@ public class PostHog private constructor(
                         props["\$feature_flag_version"] = it.metadata.version
                         props["\$feature_flag_reason"] = it.reason?.description ?: ""
                     }
+                    props["\$feature_flag_has_experiment"] = flagDetails?.metadata?.hasExperiment ?: false
                     capture(PostHogEventName.FEATURE_FLAG_CALLED.event, properties = props)
                 }
             }

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -453,11 +453,13 @@ public open class PostHogStateless protected constructor(
             ?.let { props["\$feature_flag_evaluated_at"] = it }
         featureFlags?.getFeatureFlagError(key, distinctId, groups, personProperties, groupProperties)
             ?.let { props["\$feature_flag_error"] = it }
-        featureFlags?.getFeatureFlagDetails(key, distinctId, groups, personProperties, groupProperties)?.let { details ->
-            props["\$feature_flag_id"] = details.metadata.id
-            props["\$feature_flag_version"] = details.metadata.version
-            details.reason?.description?.let { props["\$feature_flag_reason"] = it }
+        val details = featureFlags?.getFeatureFlagDetails(key, distinctId, groups, personProperties, groupProperties)
+        details?.let {
+            props["\$feature_flag_id"] = it.metadata.id
+            props["\$feature_flag_version"] = it.metadata.version
+            it.reason?.description?.let { reason -> props["\$feature_flag_reason"] = reason }
         }
+        props["\$feature_flag_has_experiment"] = details?.metadata?.hasExperiment ?: false
 
         captureFeatureFlagCalledEvent(distinctId, key, value, props, groups)
     }

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -453,13 +453,12 @@ public open class PostHogStateless protected constructor(
             ?.let { props["\$feature_flag_evaluated_at"] = it }
         featureFlags?.getFeatureFlagError(key, distinctId, groups, personProperties, groupProperties)
             ?.let { props["\$feature_flag_error"] = it }
-        val details = featureFlags?.getFeatureFlagDetails(key, distinctId, groups, personProperties, groupProperties)
-        details?.let {
-            props["\$feature_flag_id"] = it.metadata.id
-            props["\$feature_flag_version"] = it.metadata.version
-            it.reason?.description?.let { reason -> props["\$feature_flag_reason"] = reason }
+        featureFlags?.getFeatureFlagDetails(key, distinctId, groups, personProperties, groupProperties)?.let { details ->
+            props["\$feature_flag_id"] = details.metadata.id
+            props["\$feature_flag_version"] = details.metadata.version
+            details.reason?.description?.let { props["\$feature_flag_reason"] = it }
+            details.metadata.hasExperiment?.let { props["\$feature_flag_has_experiment"] = it }
         }
-        props["\$feature_flag_has_experiment"] = details?.metadata?.hasExperiment ?: false
 
         captureFeatureFlagCalledEvent(distinctId, key, value, props, groups)
     }

--- a/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
+++ b/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
@@ -9,8 +9,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property id the id of the feature flag
  * @property payload the payload of the feature flag
  * @property version the version of the feature flag
- * @property hasExperiment whether the flag is linked to an experiment; defaults to false
- * when the server does not report the field (older deployments)
+ * @property hasExperiment whether the flag is linked to an experiment; null when the server
+ * does not report the field (older deployments)
  */
 @IgnoreJRERequirement
 @PostHogInternal
@@ -19,5 +19,5 @@ public data class FeatureFlagMetadata(
     val payload: String?,
     val version: Int,
     @SerializedName("has_experiment")
-    val hasExperiment: Boolean = false,
+    val hasExperiment: Boolean? = null,
 )

--- a/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
+++ b/posthog/src/main/java/com/posthog/internal/FeatureFlagMetadata.kt
@@ -1,5 +1,6 @@
 package com.posthog.internal
 
+import com.google.gson.annotations.SerializedName
 import com.posthog.PostHogInternal
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
@@ -8,6 +9,8 @@ import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
  * @property id the id of the feature flag
  * @property payload the payload of the feature flag
  * @property version the version of the feature flag
+ * @property hasExperiment whether the flag is linked to an experiment; defaults to false
+ * when the server does not report the field (older deployments)
  */
 @IgnoreJRERequirement
 @PostHogInternal
@@ -15,4 +18,6 @@ public data class FeatureFlagMetadata(
     val id: Int,
     val payload: String?,
     val version: Int,
+    @SerializedName("has_experiment")
+    val hasExperiment: Boolean = false,
 )

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
@@ -27,6 +27,8 @@ public class FlagDefinition(
     public val version: Int,
     @SerializedName("ensure_experience_continuity")
     public val ensureExperienceContinuity: Boolean = false,
+    @SerializedName("has_experiment")
+    public val hasExperiment: Boolean = false,
 )
 
 /**

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
@@ -28,7 +28,7 @@ public class FlagDefinition(
     @SerializedName("ensure_experience_continuity")
     public val ensureExperienceContinuity: Boolean = false,
     @SerializedName("has_experiment")
-    public val hasExperiment: Boolean = false,
+    public val hasExperiment: Boolean? = null,
 )
 
 /**

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -642,8 +642,8 @@ internal class PostHogStatelessTest {
         assertEquals("user123", event.distinctId)
         assertEquals("test_flag", event.properties!!["\$feature_flag"])
         assertEquals(true, event.properties!!["\$feature_flag_response"])
-        // no flag details available, so has_experiment defaults to false
-        assertEquals(false, event.properties!!["\$feature_flag_has_experiment"])
+        // no flag details available, so the has_experiment property is omitted
+        assertFalse(event.properties!!.containsKey("\$feature_flag_has_experiment"))
     }
 
     @Test
@@ -684,6 +684,34 @@ internal class PostHogStatelessTest {
         assertEquals(2, mockQueue.events.size)
         assertEquals(true, mockQueue.events[0].properties!!["\$feature_flag_has_experiment"])
         assertEquals(false, mockQueue.events[1].properties!!["\$feature_flag_has_experiment"])
+    }
+
+    @Test
+    fun `feature flag called event omits has_experiment when metadata does not report it`() {
+        val mockQueue = MockQueue()
+        val mockFeatureFlags = MockFeatureFlags()
+        mockFeatureFlags.setFlagDetails(
+            "unreported_flag",
+            FeatureFlag(
+                key = "unreported_flag",
+                enabled = true,
+                variant = null,
+                metadata = FeatureFlagMetadata(id = 3, payload = null, version = 1),
+                reason = null,
+            ),
+        )
+
+        sut = createStatelessInstance()
+        config = createConfig(sendFeatureFlagEvent = true)
+
+        sut.setup(config)
+        sut.setMockQueue(mockQueue)
+        sut.setMockFeatureFlags(mockFeatureFlags)
+
+        sut.getFeatureFlagResultStateless("user123", "unreported_flag")
+
+        assertEquals(1, mockQueue.events.size)
+        assertFalse(mockQueue.events.first().properties!!.containsKey("\$feature_flag_has_experiment"))
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -1,5 +1,7 @@
 package com.posthog
 
+import com.posthog.internal.FeatureFlag
+import com.posthog.internal.FeatureFlagMetadata
 import com.posthog.internal.PostHogFeatureFlagCalledCache
 import com.posthog.internal.PostHogFeatureFlagsInterface
 import com.posthog.internal.PostHogMemoryPreferences
@@ -97,12 +99,21 @@ internal class PostHogStatelessTest {
     private class MockFeatureFlags : PostHogFeatureFlagsInterface {
         private val flags = mutableMapOf<String, Any>()
         private val payloads = mutableMapOf<String, Any?>()
+        private val details = mutableMapOf<String, FeatureFlag>()
 
         fun setFlag(
             key: String,
             value: Any,
         ) {
             flags[key] = value
+        }
+
+        fun setFlagDetails(
+            key: String,
+            flag: FeatureFlag,
+        ) {
+            flags[key] = flag.variant ?: flag.enabled
+            details[key] = flag
         }
 
         fun setFlagWithPayload(
@@ -189,9 +200,20 @@ internal class PostHogStatelessTest {
             return null
         }
 
+        override fun getFeatureFlagDetails(
+            key: String,
+            distinctId: String?,
+            groups: Map<String, String>?,
+            personProperties: Map<String, Any?>?,
+            groupProperties: Map<String, Map<String, Any?>>?,
+        ): FeatureFlag? {
+            return details[key]
+        }
+
         override fun clear() {
             flags.clear()
             payloads.clear()
+            details.clear()
         }
     }
 
@@ -620,6 +642,48 @@ internal class PostHogStatelessTest {
         assertEquals("user123", event.distinctId)
         assertEquals("test_flag", event.properties!!["\$feature_flag"])
         assertEquals(true, event.properties!!["\$feature_flag_response"])
+        // no flag details available, so has_experiment defaults to false
+        assertEquals(false, event.properties!!["\$feature_flag_has_experiment"])
+    }
+
+    @Test
+    fun `feature flag called event reports has_experiment from flag metadata`() {
+        val mockQueue = MockQueue()
+        val mockFeatureFlags = MockFeatureFlags()
+        mockFeatureFlags.setFlagDetails(
+            "experiment_flag",
+            FeatureFlag(
+                key = "experiment_flag",
+                enabled = true,
+                variant = null,
+                metadata = FeatureFlagMetadata(id = 1, payload = null, version = 1, hasExperiment = true),
+                reason = null,
+            ),
+        )
+        mockFeatureFlags.setFlagDetails(
+            "plain_flag",
+            FeatureFlag(
+                key = "plain_flag",
+                enabled = true,
+                variant = null,
+                metadata = FeatureFlagMetadata(id = 2, payload = null, version = 1, hasExperiment = false),
+                reason = null,
+            ),
+        )
+
+        sut = createStatelessInstance()
+        config = createConfig(sendFeatureFlagEvent = true)
+
+        sut.setup(config)
+        sut.setMockQueue(mockQueue)
+        sut.setMockFeatureFlags(mockFeatureFlags)
+
+        sut.getFeatureFlagResultStateless("user123", "experiment_flag")
+        sut.getFeatureFlagResultStateless("user123", "plain_flag")
+
+        assertEquals(2, mockQueue.events.size)
+        assertEquals(true, mockQueue.events[0].properties!!["\$feature_flag_has_experiment"])
+        assertEquals(false, mockQueue.events[1].properties!!["\$feature_flag_has_experiment"])
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -449,6 +449,7 @@ internal class PostHogTest {
         assertEquals(4535, theEvent.properties!!["\$feature_flag_id"])
         assertEquals(2, theEvent.properties!!["\$feature_flag_version"])
         assertEquals("Matched condition set 3", theEvent.properties!!["\$feature_flag_reason"])
+        assertEquals(true, theEvent.properties!!["\$feature_flag_has_experiment"])
 
         @Suppress("UNCHECKED_CAST")
         val theFlags = theEvent.properties!!["\$active_feature_flags"] as List<String>
@@ -458,6 +459,53 @@ internal class PostHogTest {
 
         assertEquals("4535-funnel-bar-viz", theEvent.properties!!["\$feature_flag"])
         assertEquals(true, theEvent.properties!!["\$feature_flag_response"])
+
+        sut.close()
+    }
+
+    @Test
+    fun `feature flag called event reports has_experiment from flag metadata`() {
+        val file = File("src/test/resources/json/basic-flags-with-non-active-flags.json")
+        val responseFlagsApi = file.readText()
+
+        val http =
+            mockHttp(
+                response =
+                    MockResponse()
+                        .setBody(responseFlagsApi),
+            )
+        http.enqueue(
+            MockResponse()
+                .setBody(""),
+        )
+        val url = http.url("/")
+
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, flushAt = 3)
+
+        sut.reloadFeatureFlags()
+
+        remoteConfigExecutor.shutdownAndAwaitTermination()
+
+        // remove from the http queue
+        http.takeRequest()
+
+        // has_experiment: true in the flag metadata
+        sut.getFeatureFlag("4535-funnel-bar-viz")
+        // has_experiment: false in the flag metadata
+        sut.getFeatureFlag("IAmInactive")
+        // has_experiment absent from the flag metadata
+        sut.getFeatureFlag("splashScreenName")
+
+        queueExecutor.shutdownAndAwaitTermination()
+
+        val request = http.takeRequest()
+        val content = request.body.unGzip()
+        val batch = serializer.deserialize<PostHogBatchEvent>(content.reader())
+
+        val eventsByFlag = batch.batch.associateBy { it.properties!!["\$feature_flag"] }
+        assertEquals(true, eventsByFlag["4535-funnel-bar-viz"]!!.properties!!["\$feature_flag_has_experiment"])
+        assertEquals(false, eventsByFlag["IAmInactive"]!!.properties!!["\$feature_flag_has_experiment"])
+        assertEquals(false, eventsByFlag["splashScreenName"]!!.properties!!["\$feature_flag_has_experiment"])
 
         sut.close()
     }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -505,7 +505,8 @@ internal class PostHogTest {
         val eventsByFlag = batch.batch.associateBy { it.properties!!["\$feature_flag"] }
         assertEquals(true, eventsByFlag["4535-funnel-bar-viz"]!!.properties!!["\$feature_flag_has_experiment"])
         assertEquals(false, eventsByFlag["IAmInactive"]!!.properties!!["\$feature_flag_has_experiment"])
-        assertEquals(false, eventsByFlag["splashScreenName"]!!.properties!!["\$feature_flag_has_experiment"])
+        // the property is omitted when the server did not report has_experiment
+        assertFalse(eventsByFlag["splashScreenName"]!!.properties!!.containsKey("\$feature_flag_has_experiment"))
 
         sut.close()
     }

--- a/posthog/src/test/resources/json/basic-flags-with-non-active-flags.json
+++ b/posthog/src/test/resources/json/basic-flags-with-non-active-flags.json
@@ -25,7 +25,8 @@
       "metadata": {
         "id": 4535,
         "version": 2,
-        "payload": "true"
+        "payload": "true",
+        "has_experiment": true
       }
     },
     "IAmInactive": {
@@ -40,7 +41,8 @@
       "metadata": {
         "id": 2,
         "version": 2,
-        "payload": "false"
+        "payload": "false",
+        "has_experiment": false
       }
     },
     "splashScreenName": {

--- a/sdk_compliance_adapter/src/main/kotlin/com/posthog/compliance/ComplianceAdapter.kt
+++ b/sdk_compliance_adapter/src/main/kotlin/com/posthog/compliance/ComplianceAdapter.kt
@@ -389,9 +389,10 @@ fun main() {
                         flagKeys = listOf(req.key),
                         disableGeoip = req.disable_geoip ?: false,
                     )
+                val flagDetails = response?.flags?.get(req.key)
                 val value =
                     response?.featureFlags?.get(req.key)
-                        ?: response?.flags?.get(req.key)?.let { it.variant ?: it.enabled }
+                        ?: flagDetails?.let { it.variant ?: it.enabled }
 
                 val requestsBefore = AdapterContext.lock.withLock { AdapterContext.state.requestsMade.size }
                 ph.capture(
@@ -402,6 +403,7 @@ fun main() {
                             "\$feature_flag" to req.key,
                             "\$feature_flag_response" to (value ?: false),
                             "\$feature/${req.key}" to (value ?: false),
+                            "\$feature_flag_has_experiment" to (flagDetails?.metadata?.hasExperiment ?: false),
                         ),
                 )
                 AdapterContext.lock.withLock {

--- a/sdk_compliance_adapter/src/main/kotlin/com/posthog/compliance/ComplianceAdapter.kt
+++ b/sdk_compliance_adapter/src/main/kotlin/com/posthog/compliance/ComplianceAdapter.kt
@@ -395,16 +395,17 @@ fun main() {
                         ?: flagDetails?.let { it.variant ?: it.enabled }
 
                 val requestsBefore = AdapterContext.lock.withLock { AdapterContext.state.requestsMade.size }
+                val flagCalledProperties =
+                    mutableMapOf<String, Any>(
+                        "\$feature_flag" to req.key,
+                        "\$feature_flag_response" to (value ?: false),
+                        "\$feature/${req.key}" to (value ?: false),
+                    )
+                flagDetails?.metadata?.hasExperiment?.let { flagCalledProperties["\$feature_flag_has_experiment"] = it }
                 ph.capture(
                     event = "\$feature_flag_called",
                     distinctId = distinctId,
-                    properties =
-                        mapOf(
-                            "\$feature_flag" to req.key,
-                            "\$feature_flag_response" to (value ?: false),
-                            "\$feature/${req.key}" to (value ?: false),
-                            "\$feature_flag_has_experiment" to (flagDetails?.metadata?.hasExperiment ?: false),
-                        ),
+                    properties = flagCalledProperties,
                 )
                 AdapterContext.lock.withLock {
                     AdapterContext.state.totalEventsCaptured++


### PR DESCRIPTION
## :bulb: Motivation and Context

Part of a cross-SDK effort to shrink `$feature_flag_called` events. This first phase adds a `$feature_flag_has_experiment` boolean property to every `$feature_flag_called` event, reflecting the server's `has_experiment` signal: `metadata.has_experiment` in the `/flags?v=2` response and `has_experiment` on `/api/feature_flag/local_evaluation` flag definitions. When the server does not report the field (older deployments, bootstrapped flags), the property is omitted, so it is tri-state: `true`, `false`, or absent (unknown).

This lets ingestion distinguish experiment-linked flag events (which need the full property set for exposure analysis) from the rest, and lets us measure the split before a later phase strips the expensive properties (`$feature/<key>`, `$feature_flag_payload`, per-event system metadata) from non-experiment flag events. This PR intentionally minimizes nothing: no properties are removed, no config options are added, and dedupe behavior is unchanged.

## Changes

- `FeatureFlagMetadata.hasExperiment` (`@SerializedName("has_experiment")`, default `false`) parsed from `/flags?v=2` metadata and round-tripping through both flag caches; the same field on `FlagDefinition` for `/local_evaluation`, threaded into `buildFeatureFlagFromResult`.
- All send paths set the property: `PostHog.sendFeatureFlagCalled`, `PostHogStateless.sendFeatureFlagCalled`, `PostHogFeatureFlagEvaluations.recordAccess`, and the compliance adapter's hand-built capture, defaulting to `false` when details are unavailable (null details, unknown flags, bootstrap/cache-degraded flags).
- `posthog.api` regenerated; minor changeset for `posthog` and `posthog-server`.

Known pre-existing gap (not introduced here): the server SDK's single-flag local-evaluation fast path (`resolveFeatureFlag`) doesn't populate flag details, so events from that path report `false` even for experiment flags, same as the existing `$feature_flag_id`/`$feature_flag_version` behavior there. The `evaluateFlags` snapshot path reports it correctly. This must be fixed before any event-minimization phase.

## :green_heart: How did you test it?

`./gradlew :posthog:test :posthog-server:test :posthog:apiCheck :posthog-server:apiCheck spotlessCheck`: BUILD SUCCESSFUL. New tests cover true / explicit-false / absent across the client, stateless, snapshot, Gson-parse, and local-evaluation paths. The `:posthog-android` module is untouched (and requires an Android SDK not present locally); the change lives in the pure-JVM `posthog` and `posthog-server` modules. The compliance adapter compiles (`:sdk_compliance_adapter:compileKotlin`).

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

