### PR TITLE
fix(replay): skip per-touch capture work when replay is inactive

### DIFF
--- a/.changeset/replay-touch-gate-inactive.md
+++ b/.changeset/replay-touch-gate-inactive.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Session Replay: skip per-touch capture work when replay is not actively recording. The touch interceptor previously copied the `MotionEvent` and submitted a task to the replay executor on every touch, gating on the recording state only inside the submitted task. For sessions that are sampled out (the common case) this ran on the main thread and contended on the single replay executor's work-queue lock, which could stall the UI under load. The recording state is now checked before any allocation or executor submission.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -95,6 +95,7 @@ import java.lang.ref.WeakReference
 import java.util.Collections
 import java.util.WeakHashMap
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -118,8 +119,19 @@ public class PostHogReplayIntegration(
             InputType.TYPE_NUMBER_VARIATION_PASSWORD,
         )
 
-    private val executor by lazy {
-        Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("PostHogReplayThread"))
+    internal constructor(
+        context: Context,
+        config: PostHogAndroidConfig,
+        mainHandler: MainHandler,
+        replayExecutor: ExecutorService,
+    ) : this(context, config, mainHandler) {
+        injectedExecutor = replayExecutor
+    }
+
+    private var injectedExecutor: ExecutorService? = null
+
+    private val executor: ExecutorService by lazy {
+        injectedExecutor ?: Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("PostHogReplayThread"))
     }
 
     // Reuse a single HandlerThread for PixelCopy callbacks instead of
@@ -325,12 +337,15 @@ public class PostHogReplayIntegration(
         return Pair(imeVisible, event)
     }
 
-    private val onTouchEventListener =
+    internal val onTouchEventListener =
         TouchEventInterceptor { motionEvent, dispatch ->
             val timestamp = config.dateProvider.currentTimeMillis()
             try {
                 val state = dispatch(motionEvent)
                 try {
+                    if (!isActive()) {
+                        return@TouchEventInterceptor state
+                    }
                     // 1. prevent MotionEvent Object Is Recycled or Invalid
                     // 2. pointerCount Changed Between Checks and Access (since we call on a background thread)
                     val safeMotionEvent = MotionEvent.obtain(motionEvent)

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -339,13 +339,13 @@ public class PostHogReplayIntegration(
 
     internal val onTouchEventListener =
         TouchEventInterceptor { motionEvent, dispatch ->
-            val timestamp = config.dateProvider.currentTimeMillis()
             try {
                 val state = dispatch(motionEvent)
                 try {
                     if (!isActive()) {
                         return@TouchEventInterceptor state
                     }
+                    val timestamp = config.dateProvider.currentTimeMillis()
                     // 1. prevent MotionEvent Object Is Recycled or Invalid
                     // 2. pointerCount Changed Between Checks and Access (since we call on a background thread)
                     val safeMotionEvent = MotionEvent.obtain(motionEvent)

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -19,6 +19,8 @@ import com.posthog.android.replay.internal.NextDrawListener
 import com.posthog.android.replay.internal.ViewTreeSnapshotStatus
 import com.posthog.internal.EndpointSpec
 import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogDateProvider
+import com.posthog.internal.PostHogDeviceDateProvider
 import com.posthog.internal.PostHogLogger
 import com.posthog.internal.PostHogMemoryPreferences
 import com.posthog.internal.PostHogNetworkStatus
@@ -40,6 +42,7 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowPixelCopy
 import java.lang.ref.WeakReference
+import java.util.Date
 import java.util.UUID
 import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
@@ -207,10 +210,30 @@ internal class PostHogReplayIntegrationTest {
         return PostHogReplayIntegration(context, config, MainHandler(), executor)
     }
 
+    // currentTimeMillis() on Android does a network-time lookup; count how often the touch path
+    // invokes it so we can prove it is skipped when replay is inactive.
+    private class CountingDateProvider(val calls: AtomicInteger) : PostHogDateProvider {
+        private val delegate = PostHogDeviceDateProvider()
+
+        override fun currentTimeMillis(): Long {
+            calls.incrementAndGet()
+            return delegate.currentTimeMillis()
+        }
+
+        override fun currentDate(): Date = delegate.currentDate()
+
+        override fun addSecondsToCurrentDate(seconds: Int): Date = delegate.addSecondsToCurrentDate(seconds)
+
+        override fun nanoTime(): Long = delegate.nanoTime()
+    }
+
     @Test
     fun `touch does not submit capture work to the replay executor when inactive`() {
         val submits = AtomicInteger(0)
-        val sut = getSutWithExecutor(configWithSampling(flagActive = false, samplingPasses = true), countingReplayExecutor(submits))
+        val dateCalls = AtomicInteger(0)
+        val config = configWithSampling(flagActive = false, samplingPasses = true)
+        config.dateProvider = CountingDateProvider(dateCalls)
+        val sut = getSutWithExecutor(config, countingReplayExecutor(submits))
         val fake = createPostHogFake()
         sut.install(fake)
         try {
@@ -223,6 +246,7 @@ internal class PostHogReplayIntegrationTest {
 
             assertEquals(DispatchState.Consumed, state)
             assertEquals(0, submits.get())
+            assertEquals(0, dateCalls.get())
         } finally {
             sut.uninstall()
         }
@@ -231,7 +255,10 @@ internal class PostHogReplayIntegrationTest {
     @Test
     fun `touch submits capture work and still dispatches when active`() {
         val submits = AtomicInteger(0)
-        val sut = getSutWithExecutor(configWithSampling(flagActive = true, samplingPasses = true), countingReplayExecutor(submits))
+        val dateCalls = AtomicInteger(0)
+        val config = configWithSampling(flagActive = true, samplingPasses = true)
+        config.dateProvider = CountingDateProvider(dateCalls)
+        val sut = getSutWithExecutor(config, countingReplayExecutor(submits))
         val fake = createPostHogFake()
         fake.sessionReplayActive = false
         sut.install(fake)
@@ -248,6 +275,7 @@ internal class PostHogReplayIntegrationTest {
 
             assertEquals(DispatchState.Consumed, state)
             assertTrue(submits.get() >= 1)
+            assertTrue(dateCalls.get() >= 1)
         } finally {
             sut.uninstall()
         }

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.posthog.android.replay
 import android.app.Activity
 import android.content.Context
 import android.os.Looper
+import android.view.MotionEvent
 import android.view.View
 import android.view.Window
 import androidx.test.core.app.ApplicationProvider
@@ -26,6 +27,7 @@ import com.posthog.internal.PostHogQueue
 import com.posthog.internal.PostHogQueueInterface
 import com.posthog.internal.PostHogRemoteConfig
 import com.posthog.internal.PostHogSessionManager
+import curtains.DispatchState
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -39,11 +41,14 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowPixelCopy
 import java.lang.ref.WeakReference
 import java.util.UUID
+import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -178,6 +183,74 @@ internal class PostHogReplayIntegrationTest {
 
     private fun getSut(config: PostHogAndroidConfig = PostHogAndroidConfig(API_KEY)): PostHogReplayIntegration {
         return PostHogReplayIntegration(context, config, MainHandler())
+    }
+
+    private fun countingReplayExecutor(counter: AtomicInteger): ExecutorService {
+        val delegate = createReplayExecutor()
+        return object : ExecutorService by delegate {
+            override fun submit(task: Runnable): Future<*> {
+                counter.incrementAndGet()
+                return delegate.submit(task)
+            }
+
+            override fun <T> submit(task: Callable<T>): Future<T> {
+                counter.incrementAndGet()
+                return delegate.submit(task)
+            }
+        }
+    }
+
+    private fun getSutWithExecutor(
+        config: PostHogAndroidConfig,
+        executor: ExecutorService,
+    ): PostHogReplayIntegration {
+        return PostHogReplayIntegration(context, config, MainHandler(), executor)
+    }
+
+    @Test
+    fun `touch does not submit capture work to the replay executor when inactive`() {
+        val submits = AtomicInteger(0)
+        val sut = getSutWithExecutor(configWithSampling(flagActive = false, samplingPasses = true), countingReplayExecutor(submits))
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            assertFalse(sut.isActive())
+
+            val event = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 0f, 0f, 0)
+            val state = sut.onTouchEventListener.intercept(event) { DispatchState.Consumed }
+            event.recycle()
+            awaitReplayExecutors()
+
+            assertEquals(DispatchState.Consumed, state)
+            assertEquals(0, submits.get())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `touch submits capture work and still dispatches when active`() {
+        val submits = AtomicInteger(0)
+        val sut = getSutWithExecutor(configWithSampling(flagActive = true, samplingPasses = true), countingReplayExecutor(submits))
+        val fake = createPostHogFake()
+        fake.sessionReplayActive = false
+        sut.install(fake)
+        try {
+            PostHogSessionManager.startSession()
+            sut.onSessionIdChanged()
+            shadowOf(Looper.getMainLooper()).idle()
+            assertTrue(sut.isActive())
+
+            val event = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 0f, 0f, 0)
+            val state = sut.onTouchEventListener.intercept(event) { DispatchState.Consumed }
+            event.recycle()
+            awaitReplayExecutors()
+
+            assertEquals(DispatchState.Consumed, state)
+            assertTrue(submits.get() >= 1)
+        } finally {
+            sut.uninstall()
+        }
     }
 
     @Test


### PR DESCRIPTION
## :bulb: Motivation and Context

Session Replay's touch interceptor runs on the main thread and, on **every** touch, copied the `MotionEvent` (`MotionEvent.obtain`) and submitted a task to the single-threaded replay executor — gating on the recording state (`isActive()`) only *inside* the submitted task. So even when a session is sampled out (the common case, given typical 1–20% sample rates) every touch still allocated and enqueued onto the executor's `DelayedWorkQueue`, which is guarded by a single `ReentrantLock`.

Under load on low-end devices this shows up as an ANR: the main thread parks acquiring that queue lock while the default-priority replay worker holds it and gets descheduled — priority inversion. Play SDK Console ANR cluster `52c22c94` (the `onTouchEventListener` frame parked in `ScheduledThreadPoolExecutor$DelayedWorkQueue.offer → ReentrantLock.lock`) matched this in 10 of 15 sampled variants, on SDK 3.9.3–3.30.

## Changes

- Check `isActive()` at the top of the touch interceptor, before `MotionEvent.obtain` and `executor.submit`. When replay is not recording, the touch is dispatched to the app and nothing else happens — no allocation, no executor submission, no lock traffic. The existing inner `isActive()` check is kept as a cheap guard for recording stopping mid-flight.
- Added an internal executor-injection seam to `PostHogReplayIntegration` (mirrors `PostHogReplayQueue`) so the behavior is unit-testable.

This does not change capture behavior for active sessions.

## :green_heart: How did you test it?

- New unit tests driving the touch interceptor through a counting executor:
  - **Reproduction:** with the fix reverted, `touch does not submit capture work to the replay executor when inactive` fails (`expected:<0> but was:<1>` — an inactive touch still submits).
  - **Fix confirmed:** with the fix, that test passes (0 submits when inactive), and `touch submits capture work and still dispatches when active` verifies active sessions still capture and the touch is still delivered to the app.
- Full `:posthog-android` unit suite (39 `PostHogReplayIntegrationTest` cases) passes; `spotlessCheck` clean.

Note: the priority-inversion → ANR itself is load/device dependent and not deterministically reproducible in a unit test; the wasteful per-touch allocation and executor submission when inactive is the reproducible, fixed core.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) investigated Play SDK Console cluster `52c22c94` with Anna, traced the main-thread lock contention to the unconditional per-touch `executor.submit`, reproduced the wasteful submit with a failing unit test, applied the gate, and confirmed the test passes. A complementary thread-priority change for the replay worker was considered and deliberately deferred to its own discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
