### PR TITLE
fix(replay): stop doing a network-time Binder IPC on every timestamp

### DIFF
--- a/.changeset/dateprovider-network-time-ipc.md
+++ b/.changeset/dateprovider-network-time-ipc.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Stop querying network time on every timestamp. `PostHogAndroidDateProvider.currentTimeMillis()` called `SystemClock.currentNetworkTimeClock().millis()` on each invocation, which performs a Binder IPC to a system service — so hot paths like the session-replay touch interceptor did an IPC on the main thread for every touch and could ANR under load. Network time is now sampled at most once per minute and intermediate timestamps are derived from the monotonic `elapsedRealtime` delta, preserving network-time correction without the per-call IPC.

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
@@ -15,6 +15,10 @@ import java.util.Date
  * event) blocks the calling thread and can ANR under load. Instead the network time is sampled at
  * most once per [refreshIntervalMs] and subsequent timestamps are derived from the monotonic
  * [android.os.SystemClock.elapsedRealtime] delta since that anchor.
+ *
+ * Once a sample has succeeded, later sampling failures extend the existing anchor rather than
+ * falling back to the system wall clock: the platform's network clock derives time the same way,
+ * and the anchor stays immune to user changes of the device clock.
  */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 internal class PostHogAndroidDateProvider(
@@ -55,7 +59,9 @@ internal class PostHogAndroidDateProvider(
             lastAttemptElapsedMs = elapsed
             val networkNow = runCatching { clock.millis() }.getOrNull()
             if (networkNow != null) {
-                anchor = Anchor(networkNow, elapsed)
+                // re-read the monotonic clock: the sample corresponds to the moment millis()
+                // returned, and the IPC itself may have blocked long enough to skew the anchor
+                anchor = Anchor(networkNow, elapsedRealtimeMs())
                 return networkNow
             }
         }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
@@ -4,14 +4,33 @@ import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.RequiresApi
 import com.posthog.internal.PostHogDateProvider
+import java.time.Clock
 import java.util.Date
 
+/**
+ * Provides the current time, corrected to network time when available.
+ *
+ * [Clock.millis] on the clock returned by [SystemClock.currentNetworkTimeClock] performs a Binder
+ * IPC to a system service on every call, so querying it on each timestamp (e.g. on every touch
+ * event) blocks the calling thread and can ANR under load. Instead the network time is sampled at
+ * most once per [refreshIntervalMs] and subsequent timestamps are derived from the monotonic
+ * [android.os.SystemClock.elapsedRealtime] delta since that anchor.
+ */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-internal class PostHogAndroidDateProvider : PostHogDateProvider {
-    private val networkTimeClock =
-        runCatching {
-            SystemClock.currentNetworkTimeClock()
-        }
+internal class PostHogAndroidDateProvider(
+    private val networkClock: Clock? =
+        runCatching { SystemClock.currentNetworkTimeClock() }.getOrNull(),
+    private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
+    private val refreshIntervalMs: Long = REFRESH_INTERVAL_MS,
+) : PostHogDateProvider {
+    @Volatile
+    private var anchorNetworkMs = 0L
+
+    @Volatile
+    private var anchorElapsedMs = 0L
+
+    @Volatile
+    private var hasAnchor = false
 
     override fun currentDate(): Date {
         return Date(currentTimeMillis())
@@ -22,12 +41,25 @@ internal class PostHogAndroidDateProvider : PostHogDateProvider {
     }
 
     override fun currentTimeMillis(): Long {
-        return networkTimeClock
-            .mapCatching { it.millis() }
-            .getOrDefault(System.currentTimeMillis())
+        val clock = networkClock ?: return System.currentTimeMillis()
+        val elapsed = elapsedRealtimeMs()
+        if (!hasAnchor || elapsed - anchorElapsedMs >= refreshIntervalMs) {
+            val networkNow = runCatching { clock.millis() }.getOrNull()
+            if (networkNow != null) {
+                anchorNetworkMs = networkNow
+                anchorElapsedMs = elapsed
+                hasAnchor = true
+                return networkNow
+            }
+        }
+        return if (hasAnchor) anchorNetworkMs + (elapsed - anchorElapsedMs) else System.currentTimeMillis()
     }
 
     override fun nanoTime(): Long {
         return System.nanoTime()
+    }
+
+    private companion object {
+        private const val REFRESH_INTERVAL_MS = 60_000L
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
@@ -23,14 +23,18 @@ internal class PostHogAndroidDateProvider(
     private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
     private val refreshIntervalMs: Long = REFRESH_INTERVAL_MS,
 ) : PostHogDateProvider {
-    @Volatile
-    private var anchorNetworkMs = 0L
+    // A network-time sample and the elapsedRealtime at which it was taken, published together as a
+    // single immutable value so readers never observe a mixed (torn) anchor.
+    private class Anchor(val networkMs: Long, val elapsedMs: Long)
 
     @Volatile
-    private var anchorElapsedMs = 0L
+    private var anchor: Anchor? = null
 
+    // elapsedRealtime of the last IPC attempt (success or failure), throttling attempts to at most
+    // one per refreshIntervalMs even when network time is unavailable, so a failing clock does not
+    // re-run the Binder IPC on every call.
     @Volatile
-    private var hasAnchor = false
+    private var lastAttemptElapsedMs: Long? = null
 
     override fun currentDate(): Date {
         return Date(currentTimeMillis())
@@ -43,16 +47,20 @@ internal class PostHogAndroidDateProvider(
     override fun currentTimeMillis(): Long {
         val clock = networkClock ?: return System.currentTimeMillis()
         val elapsed = elapsedRealtimeMs()
-        if (!hasAnchor || elapsed - anchorElapsedMs >= refreshIntervalMs) {
+        val current = anchor
+        val anchorStale = current == null || elapsed - current.elapsedMs >= refreshIntervalMs
+        val lastAttempt = lastAttemptElapsedMs
+        val mayAttempt = lastAttempt == null || elapsed - lastAttempt >= refreshIntervalMs
+        if (anchorStale && mayAttempt) {
+            lastAttemptElapsedMs = elapsed
             val networkNow = runCatching { clock.millis() }.getOrNull()
             if (networkNow != null) {
-                anchorNetworkMs = networkNow
-                anchorElapsedMs = elapsed
-                hasAnchor = true
+                anchor = Anchor(networkNow, elapsed)
                 return networkNow
             }
         }
-        return if (hasAnchor) anchorNetworkMs + (elapsed - anchorElapsedMs) else System.currentTimeMillis()
+        val latest = anchor
+        return if (latest != null) latest.networkMs + (elapsed - latest.elapsedMs) else System.currentTimeMillis()
     }
 
     override fun nanoTime(): Long {

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
@@ -1,0 +1,66 @@
+package com.posthog.android.internal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34]) // PostHogAndroidDateProvider requires API >= TIRAMISU.
+internal class PostHogAndroidDateProviderTest {
+    private class CountingClock(private val now: Long) : Clock() {
+        val millisCalls = AtomicInteger(0)
+
+        override fun millis(): Long {
+            millisCalls.incrementAndGet()
+            return now
+        }
+
+        override fun instant(): Instant = Instant.ofEpochMilli(now)
+
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+
+    @Test
+    fun `does not query the network clock on every call`() {
+        val clock = CountingClock(1_000_000L)
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)
+
+        repeat(50) { sut.currentTimeMillis() }
+
+        assertEquals(1, clock.millisCalls.get())
+    }
+
+    @Test
+    fun `derives time from the elapsed delta between refreshes`() {
+        val clock = CountingClock(1_000_000L)
+        var elapsed = 100L
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+
+        assertEquals(1_000_000L, sut.currentTimeMillis())
+        elapsed = 5_100L
+        assertEquals(1_005_000L, sut.currentTimeMillis())
+        assertEquals(1, clock.millisCalls.get())
+    }
+
+    @Test
+    fun `refreshes the anchor after the interval elapses`() {
+        val clock = CountingClock(1_000_000L)
+        var elapsed = 100L
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+
+        sut.currentTimeMillis()
+        elapsed = 100L + 60_000L
+        sut.currentTimeMillis()
+
+        assertEquals(2, clock.millisCalls.get())
+    }
+}

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
@@ -51,6 +51,31 @@ internal class PostHogAndroidDateProviderTest {
         assertEquals(1, clock.millisCalls.get())
     }
 
+    private class ThrowingClock : Clock() {
+        val millisCalls = AtomicInteger(0)
+
+        override fun millis(): Long {
+            millisCalls.incrementAndGet()
+            throw java.time.DateTimeException("network time unavailable")
+        }
+
+        override fun instant(): Instant = throw java.time.DateTimeException("network time unavailable")
+
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+
+    @Test
+    fun `does not retry the network clock on every call when sampling fails`() {
+        val clock = ThrowingClock()
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)
+
+        repeat(50) { sut.currentTimeMillis() }
+
+        assertEquals(1, clock.millisCalls.get())
+    }
+
     @Test
     fun `refreshes the anchor after the interval elapses`() {
         val clock = CountingClock(1_000_000L)

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
@@ -88,4 +88,72 @@ internal class PostHogAndroidDateProviderTest {
 
         assertEquals(2, clock.millisCalls.get())
     }
+
+    @Test
+    fun `does not bake a slow sample's own latency into the anchor`() {
+        var elapsed = 100L
+        // network time is defined as base + elapsedRealtime; millis() blocks for 5s before returning
+        val clock =
+            object : Clock() {
+                override fun millis(): Long {
+                    elapsed += 5_000L
+                    return 1_000_000L + elapsed
+                }
+
+                override fun instant(): Instant = Instant.ofEpochMilli(millis())
+
+                override fun getZone(): ZoneId = ZoneOffset.UTC
+
+                override fun withZone(zone: ZoneId?): Clock = this
+            }
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+
+        sut.currentTimeMillis()
+        elapsed += 1_000L
+
+        assertEquals(1_000_000L + elapsed, sut.currentTimeMillis())
+    }
+
+    @Test
+    fun `retries a failed network sample after the interval elapses`() {
+        val clock = ThrowingClock()
+        var elapsed = 100L
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+
+        sut.currentTimeMillis()
+        elapsed += 60_000L
+        sut.currentTimeMillis()
+
+        assertEquals(2, clock.millisCalls.get())
+    }
+
+    private class SucceedOnceClock(private val now: Long) : Clock() {
+        val millisCalls = AtomicInteger(0)
+
+        override fun millis(): Long {
+            if (millisCalls.incrementAndGet() > 1) {
+                throw java.time.DateTimeException("network time unavailable")
+            }
+            return now
+        }
+
+        override fun instant(): Instant = Instant.ofEpochMilli(now)
+
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+
+    @Test
+    fun `a failed refresh extends the existing anchor instead of falling back to system time`() {
+        val clock = SucceedOnceClock(1_000_000L)
+        var elapsed = 100L
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+
+        assertEquals(1_000_000L, sut.currentTimeMillis())
+        elapsed += 65_000L
+
+        assertEquals(1_065_000L, sut.currentTimeMillis())
+        assertEquals(2, clock.millisCalls.get())
+    }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogAndroidDateProvider.currentTimeMillis()` called `SystemClock.currentNetworkTimeClock().millis()` on **every** invocation. That `Clock.millis()` performs a Binder IPC to a system service:

```
BinderProxy.transactNative
ServiceManager.getService
SystemClock.currentNetworkTimeMillis
PostHogAndroidDateProvider.currentTimeMillis (kt:26)
onTouchEventListener$lambda$17 (kt:309)   ← timestamps every touch, on the main thread
```

The session-replay touch interceptor timestamps every touch, so each touch paid that IPC on the main thread and could ANR under load. Play SDK Console shows four ANR clusters with this exact stack (`8d2cb8cf`, `04272432`, `b034e447`, `c443396a`). Because `currentTimeMillis()` is the SDK-wide date source, the IPC also hit every captured event's timestamp.

## Changes

Sample network time at most once per minute; between refreshes, derive the timestamp from the monotonic `SystemClock.elapsedRealtime()` delta since the last network anchor. This keeps the network-time correction introduced in #235 while removing the per-call IPC. Network clock and elapsed-time source are injectable for testing.

Companion to PostHog/posthog-android#622, which stops the touch interceptor from timestamping at all when replay is inactive; this PR fixes the cost for active sessions and every other timestamp consumer.

## :green_heart: How did you test it?

- New unit tests injecting a counting `Clock`:
  - **Reproduction:** with the old per-call query, `does not query the network clock on every call` and `derives time from the elapsed delta between refreshes` fail (the clock is queried on every call).
  - **Fix confirmed:** the network clock is queried once across 50 calls; intermediate timestamps advance by the elapsed delta; the anchor refreshes after the interval.
- Full `:posthog-android` unit suite passes; `spotlessCheck` clean.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) found this while investigating the second tier of Play SDK Console ANR clusters with Anna. The four `currentTimeMillis` clusters' stacks showed a per-call Binder IPC via the network-time clock. Chose to preserve network-time accuracy (re-anchor every minute) rather than drop it, to avoid regressing #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
