### PR TITLE
chore: release posthog-android with bootstrap support

### DIFF
--- a/.changeset/brave-pandas-melt.md
+++ b/.changeset/brave-pandas-melt.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": minor
+---
+
+Add a `bootstrap` option to `PostHogConfig` for pre-seeding identity and feature flags before the first `/flags` response. Set `config.bootstrap = PostHogBootstrapConfig(...)` before `setup()` so early events carry a caller-controlled distinct ID and flag reads return your values during cold start. Mirrors the `bootstrap` option in posthog-js.


### PR DESCRIPTION
## :bulb: Motivation and Context

Bootstrap (#618) shipped as core `posthog` 6.26.0, but that changeset only bumped core. The published `posthog-android` 3.54.1 still pins an older core, so consumers can't reach `config.bootstrap` / `PostHogBootstrapConfig` without manually overriding the dependency to `com.posthog:posthog:6.26.0`.

This changeset-only release bumps `posthog-android` so its published POM re-pins core 6.26.0 at release time, which is what actually delivers bootstrap to `posthog-android` consumers. Same pattern as #611.

## :green_heart: How did you test it?

No code change, changeset only. The POM pin comes from `coreVersion` (already 6.26.0 on `main`) at release time.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
