### PR TITLE
fix(server): standardize event buffer defaults

### DIFF
--- a/.changeset/standardize-server-event-buffer-defaults.md
+++ b/.changeset/standardize-server-event-buffer-defaults.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Standardize the default event flush threshold and maximum batch size at 100 events.

--- a/.changeset/standardize-server-event-buffer-defaults.md
+++ b/.changeset/standardize-server-event-buffer-defaults.md
@@ -2,4 +2,4 @@
 "posthog-server": patch
 ---
 
-Standardize event buffering defaults at a 10,000-event queue, 100-event flush threshold, and 100-event maximum batch size.
+Standardize event buffering defaults at a 10,000-event queue, 100-event flush threshold, 100-event maximum batch size, and 5-second flush interval.

--- a/.changeset/standardize-server-event-buffer-defaults.md
+++ b/.changeset/standardize-server-event-buffer-defaults.md
@@ -2,4 +2,4 @@
 "posthog-server": patch
 ---
 
-Standardize the default event flush threshold and maximum batch size at 100 events.
+Standardize event buffering defaults at a 10,000-event queue, 100-event flush threshold, and 100-event maximum batch size.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -57,7 +57,7 @@ public open class PostHogConfig constructor(
     public var remoteConfig: Boolean = true,
     /**
      * Number of minimum events before they are sent over the wire
-     * Defaults to 20
+     * Defaults to 100
      */
     public var flushAt: Int = DEFAULT_FLUSH_AT,
     /**
@@ -68,7 +68,7 @@ public open class PostHogConfig constructor(
     public var maxQueueSize: Int = DEFAULT_MAX_QUEUE_SIZE,
     /**
      * Number of maximum events in a batch call
-     * Defaults to 50
+     * Defaults to 100
      */
     public var maxBatchSize: Int = DEFAULT_MAX_BATCH_SIZE,
     /**
@@ -258,9 +258,9 @@ public open class PostHogConfig constructor(
         public const val DEFAULT_EU_HOST: String = "https://eu.i.posthog.com"
         public const val DEFAULT_EU_ASSETS_HOST: String = "https://eu-assets.i.posthog.com"
 
-        public const val DEFAULT_FLUSH_AT: Int = 20
+        public const val DEFAULT_FLUSH_AT: Int = 100
         public const val DEFAULT_MAX_QUEUE_SIZE: Int = 1000
-        public const val DEFAULT_MAX_BATCH_SIZE: Int = 50
+        public const val DEFAULT_MAX_BATCH_SIZE: Int = 100
         public const val DEFAULT_FLUSH_INTERVAL_SECONDS: Int = 30
         public const val DEFAULT_FEATURE_FLAG_CACHE_SIZE: Int = 1000
         public const val DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS: Int = 5 * 60 * 1000 // 5 minutes

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -63,7 +63,7 @@ public open class PostHogConfig constructor(
     /**
      * Number of maximum events in memory and disk, when the maximum is exceed, the oldest
      * event is deleted and the new one takes place
-     * Defaults to 1000
+     * Defaults to 10000
      */
     public var maxQueueSize: Int = DEFAULT_MAX_QUEUE_SIZE,
     /**
@@ -259,7 +259,7 @@ public open class PostHogConfig constructor(
         public const val DEFAULT_EU_ASSETS_HOST: String = "https://eu-assets.i.posthog.com"
 
         public const val DEFAULT_FLUSH_AT: Int = 100
-        public const val DEFAULT_MAX_QUEUE_SIZE: Int = 1000
+        public const val DEFAULT_MAX_QUEUE_SIZE: Int = 10000
         public const val DEFAULT_MAX_BATCH_SIZE: Int = 100
         public const val DEFAULT_FLUSH_INTERVAL_SECONDS: Int = 30
         public const val DEFAULT_FEATURE_FLAG_CACHE_SIZE: Int = 1000

--- a/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogConfig.kt
@@ -74,7 +74,7 @@ public open class PostHogConfig constructor(
     /**
      * Interval in seconds for sending events over the wire
      * The lower the number, most likely more battery is used
-     * Defaults to 30s
+     * Defaults to 5s
      */
     public var flushIntervalSeconds: Int = DEFAULT_FLUSH_INTERVAL_SECONDS,
     /**
@@ -261,7 +261,7 @@ public open class PostHogConfig constructor(
         public const val DEFAULT_FLUSH_AT: Int = 100
         public const val DEFAULT_MAX_QUEUE_SIZE: Int = 10000
         public const val DEFAULT_MAX_BATCH_SIZE: Int = 100
-        public const val DEFAULT_FLUSH_INTERVAL_SECONDS: Int = 30
+        public const val DEFAULT_FLUSH_INTERVAL_SECONDS: Int = 5
         public const val DEFAULT_FEATURE_FLAG_CACHE_SIZE: Int = 1000
         public const val DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS: Int = 5 * 60 * 1000 // 5 minutes
         public const val DEFAULT_FEATURE_FLAG_CALLED_CACHE_SIZE: Int = 1000

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -217,7 +217,7 @@ internal class PostHogConfigTest {
         assertEquals("https://eu.i.posthog.com", PostHogConfig.DEFAULT_EU_HOST)
         assertEquals("https://eu-assets.i.posthog.com", PostHogConfig.DEFAULT_EU_ASSETS_HOST)
         assertEquals(100, PostHogConfig.DEFAULT_FLUSH_AT)
-        assertEquals(1000, PostHogConfig.DEFAULT_MAX_QUEUE_SIZE)
+        assertEquals(10000, PostHogConfig.DEFAULT_MAX_QUEUE_SIZE)
         assertEquals(100, PostHogConfig.DEFAULT_MAX_BATCH_SIZE)
         assertEquals(30, PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS)
         assertEquals(1000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_SIZE)

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -216,9 +216,9 @@ internal class PostHogConfigTest {
         assertEquals("https://us.i.posthog.com", PostHogConfig.DEFAULT_HOST)
         assertEquals("https://eu.i.posthog.com", PostHogConfig.DEFAULT_EU_HOST)
         assertEquals("https://eu-assets.i.posthog.com", PostHogConfig.DEFAULT_EU_ASSETS_HOST)
-        assertEquals(20, PostHogConfig.DEFAULT_FLUSH_AT)
+        assertEquals(100, PostHogConfig.DEFAULT_FLUSH_AT)
         assertEquals(1000, PostHogConfig.DEFAULT_MAX_QUEUE_SIZE)
-        assertEquals(50, PostHogConfig.DEFAULT_MAX_BATCH_SIZE)
+        assertEquals(100, PostHogConfig.DEFAULT_MAX_BATCH_SIZE)
         assertEquals(30, PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS)
         assertEquals(1000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_SIZE)
         assertEquals(300000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS) // 5 minutes

--- a/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogConfigTest.kt
@@ -219,7 +219,7 @@ internal class PostHogConfigTest {
         assertEquals(100, PostHogConfig.DEFAULT_FLUSH_AT)
         assertEquals(10000, PostHogConfig.DEFAULT_MAX_QUEUE_SIZE)
         assertEquals(100, PostHogConfig.DEFAULT_MAX_BATCH_SIZE)
-        assertEquals(30, PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS)
+        assertEquals(5, PostHogConfig.DEFAULT_FLUSH_INTERVAL_SECONDS)
         assertEquals(1000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_SIZE)
         assertEquals(300000, PostHogConfig.DEFAULT_FEATURE_FLAG_CACHE_MAX_AGE_MS) // 5 minutes
     }


### PR DESCRIPTION
## :bulb: Motivation and Context

The server-side Java SDK currently buffers 1,000 events, flushes after 20 events or 30 seconds, and caps batch requests at 50 events. Increase the queue to 10,000 events and standardize the flush threshold, maximum batch size, and flush interval at 100 events, 100 events, and 5 seconds respectively. These defaults align with the Python, Ruby, and Rails server-side SDKs, as summarized in the [server-side SDK event buffer defaults comparison](https://gist.github.com/dustinbyrne/53aae4565ccae67586b9d8d9a1017033).

Related changes: [Node.js SDK](https://github.com/PostHog/posthog-js/pull/4164), [.NET SDK](https://github.com/PostHog/posthog-dotnet/pull/262), and [PHP SDK](https://github.com/PostHog/posthog-php/pull/204).

## :green_heart: How did you test it?

- `./gradlew :posthog-server:test`
- `make checkFormat`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent based on a human-directed SDK standardization request. Updated the server queue, flush threshold, batch size, and flush interval defaults, their KDoc, and the existing constant assertions; included a patch changeset for `posthog-server`.
