### PR TITLE
feat(gradle-plugin): read CLI credentials from a dotenv file via posthog.dotenvFile

### DIFF
--- a/.changeset/gradle-plugin-dotenv-file.md
+++ b/.changeset/gradle-plugin-dotenv-file.md
@@ -1,0 +1,5 @@
+---
+'posthog-android-gradle-plugin': minor
+---
+
+Read PostHog CLI credentials from a dotenv file via the `posthog.dotenvFile` gradle property. Relative paths resolve against the root project, and the file reaches `posthog-cli` (>= 0.8.4) as `POSTHOG_CLI_DOTENV_FILE` on the upload tasks — no more exporting `POSTHOG_CLI_*` into the Gradle daemon's environment. Process env still wins inside the CLI, and a missing file is a warning there, not a build failure. Also settable per task via the new `postHogDotenvFile` property.

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogCliExecTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogCliExecTask.kt
@@ -29,6 +29,10 @@ public abstract class PostHogCliExecTask : Exec() {
     @get:Optional
     public abstract val postHogApiKey: Property<String>
 
+    @get:Input
+    @get:Optional
+    public abstract val postHogDotenvFile: Property<String>
+
     init {
         postHogExecutable.convention(POSTHOG_CLI_DEFAULT_EXECUTABLE)
     }
@@ -63,6 +67,9 @@ public abstract class PostHogCliExecTask : Exec() {
         }
         postHogApiKey.orNull?.let {
             environment("POSTHOG_CLI_API_KEY", it)
+        }
+        postHogDotenvFile.orNull?.let {
+            environment("POSTHOG_CLI_DOTENV_FILE", it)
         }
 
         super.exec()

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
@@ -118,6 +118,7 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
                     releaseName?.let { this.releaseName.set(it) }
                     releaseVersion?.let { this.releaseVersion.set(it) }
                     build?.let { this.build.set(it) }
+                    resolvePostHogDotenvFile(project)?.let { this.postHogDotenvFile.set(it) }
                 }
             return uploadPostHogProguardMappingsTask
         }

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/Utils.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/Utils.kt
@@ -6,6 +6,7 @@ package com.posthog.android
 
 import com.posthog.android.PostHogGenerateMapIdTask.Companion.POSTHOG_PROGUARD_MAPPING_MAP_ID_PROPERTY
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logger
@@ -96,6 +97,24 @@ internal fun DirectoryProperty.getAndDelete(): File {
 }
 
 internal const val POSTHOG_CLI_DEFAULT_EXECUTABLE = "posthog-cli"
+
+internal const val POSTHOG_DOTENV_FILE_PROPERTY = "posthog.dotenvFile"
+
+/**
+ * Value of the posthog.dotenvFile gradle property as an absolute path, or null
+ * when unset/blank. Relative values resolve against the root project so a
+ * single gradle.properties entry works from any module. The path reaches
+ * posthog-cli (>= 0.8.4) as POSTHOG_CLI_DOTENV_FILE — process env still wins
+ * inside the CLI, and a missing file is a warning there, not a failure.
+ */
+internal fun resolvePostHogDotenvFile(project: Project): String? {
+    val value = project.findProperty(POSTHOG_DOTENV_FILE_PROPERTY)?.toString()?.trim()
+    if (value.isNullOrEmpty()) {
+        return null
+    }
+    val file = File(value)
+    return if (file.isAbsolute) file.path else File(project.rootDir, value).path
+}
 
 /**
  * Locates posthog-cli for builds whose environment lacks the shell PATH —


### PR DESCRIPTION
Adds a `posthog.dotenvFile` gradle property (and a `postHogDotenvFile` task property). The resolved path reaches `posthog-cli` (>= 0.8.4) as `POSTHOG_CLI_DOTENV_FILE` on the upload tasks, so credentials no longer have to live in the Gradle daemon's environment. No test infra exists in the plugin module — verified via `./gradlew -p posthog-android-gradle-plugin build`.

Better explanation here - https://github.com/PostHog/posthog-js/pull/4219.

Tested locally. Works great!

🤖 Generated with [Claude Code](https://claude.com/claude-code)