### PR TITLE
fix(replay): handle null bitmap drawables

### DIFF
--- a/.changeset/calm-bitmaps-rest.md
+++ b/.changeset/calm-bitmaps-rest.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Prevent session replay from crashing when an image uses a `BitmapDrawable` with a null bitmap.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,6 @@ pnpm changeset
 
 This will prompt for the affected packages, semver bump type, and a summary of changes. Commit the generated `.changeset/*.md` file with the PR.
 
-When the PR is merged with a `release` label, changesets will automatically bump versions, publish packages, and create GitHub releases.
-
 Use this template when creating PRs:
 
 ```
@@ -83,5 +81,4 @@ Use this template when creating PRs:
 ### If releasing new changes
 
 - [ ] Ran `pnpm changeset` to generate a changeset file
-- [ ] Added the "release" label to the PR to indicate we're publishing new versions for the affected packages
 ```

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -796,11 +796,11 @@ public class PostHogReplayIntegration(
         return false
     }
 
-    private fun Drawable.shouldMaskDrawable(): Boolean {
+    internal fun Drawable.shouldMaskDrawable(): Boolean {
         return when (this) {
             is InsetDrawable, is ColorDrawable, is VectorDrawable, is GradientDrawable, is LayerDrawable -> false
             // otherwise its not accessible anyway
-            is BitmapDrawable -> bitmap.isValid()
+            is BitmapDrawable -> bitmap?.isValid() == true
             else -> true
         }
     }

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -2,6 +2,8 @@ package com.posthog.android.replay
 
 import android.app.Activity
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.os.Looper
 import android.view.MotionEvent
 import android.view.View
@@ -1411,6 +1413,16 @@ internal class PostHogReplayIntegrationTest {
         fx.sut.install(fake)
         fx.sut.start(resumeCurrent = true)
         return fx to fake
+    }
+
+    @Test
+    fun `null bitmap drawable is not masked`() {
+        val resources = ApplicationProvider.getApplicationContext<Context>().resources
+        val drawable = BitmapDrawable(resources, null as Bitmap?)
+
+        with(getSut()) {
+            assertFalse(drawable.shouldMaskDrawable())
+        }
     }
 
     @Test


### PR DESCRIPTION
## :bulb: Motivation and Context

Session replay could crash while traversing an `ImageView` backed by a `BitmapDrawable` whose bitmap is null. Android allows `BitmapDrawable.getBitmap()` to return null, but the masking check called `Bitmap.isValid()` without guarding the platform type.

This change treats a null bitmap as non-maskable, preventing the uncaught `NullPointerException` while preserving existing behavior for valid and recycled bitmaps. It also removes the repository guidance that instructed agents to add a `release` label to release-bound PRs.

## :green_heart: How did you test it?

- `./gradlew :posthog-android:testDebugUnitTest --tests 'com.posthog.android.replay.PostHogReplayIntegrationTest'`
- `make checkFormat`
- Added a Robolectric regression test using a null-backed `BitmapDrawable`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent investigated the crash, implemented the null guard and regression test, updated the repository guidance as directed, and prepared the PR. A read-only reviewer subagent independently checked correctness, test quality, API implications, and scope and reported no actionable findings. The masking helper was changed from private to Kotlin `internal` so the regression test can call the production logic directly without reflection; this does not add a published API.
