### PR TITLE
fix(android): avoid connectivity Binder IPC during capture

### DIFF
--- a/.changeset/quiet-pandas-cache.md
+++ b/.changeset/quiet-pandas-cache.md
@@ -1,0 +1,5 @@
+---
+'posthog-android': patch
+---
+
+Stop querying Android connectivity services synchronously while capturing events.

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -92,19 +92,13 @@ public class PostHogAndroid private constructor() {
                 config.errorTrackingConfig.inAppIncludes.add(packageName)
             }
 
-            val needsAndroidContext = config.context == null
-            val androidNetworkStatus =
-                (config.networkStatus as? PostHogAndroidNetworkStatus)
-                    ?: if (needsAndroidContext || config.networkStatus == null) {
-                        PostHogAndroidNetworkStatus(context)
-                    } else {
-                        null
-                    }
-            if (config.networkStatus == null) {
-                config.networkStatus = androidNetworkStatus
-            }
-            if (needsAndroidContext) {
-                val contextNetworkStatus = requireNotNull(androidNetworkStatus)
+            if (config.context == null) {
+                val contextNetworkStatus =
+                    (config.networkStatus as? PostHogAndroidNetworkStatus)
+                        ?: PostHogAndroidNetworkStatus(context)
+                if (config.networkStatus == null) {
+                    config.networkStatus = contextNetworkStatus
+                }
                 config.context =
                     PostHogAndroidContext(
                         context,
@@ -114,6 +108,8 @@ public class PostHogAndroid private constructor() {
                 if (config.networkStatus !== contextNetworkStatus) {
                     config.addIntegration(PostHogAndroidNetworkStatusIntegration(contextNetworkStatus))
                 }
+            } else if (config.networkStatus == null) {
+                config.networkStatus = PostHogAndroidNetworkStatus(context)
             }
 
             val legacyPath = context.getDir("app_posthog-disk-queue", Context.MODE_PRIVATE)

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -11,6 +11,7 @@ import com.posthog.android.internal.PostHogAndroidContext
 import com.posthog.android.internal.PostHogAndroidDateProvider
 import com.posthog.android.internal.PostHogAndroidLogger
 import com.posthog.android.internal.PostHogAndroidNetworkStatus
+import com.posthog.android.internal.PostHogAndroidNetworkStatusIntegration
 import com.posthog.android.internal.PostHogAppInstallIntegration
 import com.posthog.android.internal.PostHogLifecycleObserverIntegration
 import com.posthog.android.internal.PostHogMetaPropertiesApplier
@@ -91,8 +92,29 @@ public class PostHogAndroid private constructor() {
                 config.errorTrackingConfig.inAppIncludes.add(packageName)
             }
 
-            val androidContext = config.context ?: PostHogAndroidContext(context, config)
-            config.context = androidContext
+            val needsAndroidContext = config.context == null
+            val androidNetworkStatus =
+                (config.networkStatus as? PostHogAndroidNetworkStatus)
+                    ?: if (needsAndroidContext || config.networkStatus == null) {
+                        PostHogAndroidNetworkStatus(context)
+                    } else {
+                        null
+                    }
+            if (config.networkStatus == null) {
+                config.networkStatus = androidNetworkStatus
+            }
+            if (needsAndroidContext) {
+                val contextNetworkStatus = requireNotNull(androidNetworkStatus)
+                config.context =
+                    PostHogAndroidContext(
+                        context,
+                        config,
+                        contextNetworkStatus::getNetworkProperties,
+                    )
+                if (config.networkStatus !== contextNetworkStatus) {
+                    config.addIntegration(PostHogAndroidNetworkStatusIntegration(contextNetworkStatus))
+                }
+            }
 
             val legacyPath = context.getDir("app_posthog-disk-queue", Context.MODE_PRIVATE)
             val path = File(context.cacheDir, "posthog-disk-queue")
@@ -116,7 +138,6 @@ public class PostHogAndroid private constructor() {
                     PostHogSessionManager.setDateProvider(config.dateProvider)
                 }
             }
-            config.networkStatus = config.networkStatus ?: PostHogAndroidNetworkStatus(context)
             // Flutter, RN, and KMP SDKs set the sdkName and sdkVersion, so this guard is not to allow
             // the values to be overwritten again
             if (config.sdkName != "posthog-flutter" &&

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -1,11 +1,6 @@
 package com.posthog.android.internal
 
-import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
-import android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
-import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
-import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.os.Build
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.internal.PostHogContext
@@ -21,6 +16,7 @@ import java.util.TimeZone
 internal class PostHogAndroidContext(
     private val context: Context,
     private val config: PostHogAndroidConfig,
+    private val networkPropertiesProvider: () -> Map<String, Any>,
 ) : PostHogContext {
     private val cacheSdkInfo by lazy {
         val sdkInfo = mutableMapOf<String, Any>()
@@ -67,8 +63,6 @@ internal class PostHogAndroidContext(
         return cacheStaticContext
     }
 
-    @Suppress("DEPRECATION")
-    @SuppressLint("MissingPermission")
     override fun getDynamicContext(): Map<String, Any> {
         val dynamicContext = mutableMapOf<String, Any>()
         dynamicContext["\$locale"] = "${Locale.getDefault().language}-${Locale.getDefault().country}"
@@ -80,20 +74,7 @@ internal class PostHogAndroidContext(
         }
         dynamicContext["\$timezone"] = TimeZone.getDefault().id
 
-        // TODO: use ConnectivityManager.NetworkCallback instead
-        context.connectivityManager()?.let { connectivityManager ->
-            if (context.hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
-                connectivityManager.activeNetwork?.let {
-                    val networkCapabilities = connectivityManager.getNetworkCapabilities(it)
-
-                    networkCapabilities?.let { capabilities ->
-                        dynamicContext["\$network_wifi"] = capabilities.hasTransport(TRANSPORT_WIFI)
-                        dynamicContext["\$network_bluetooth"] = capabilities.hasTransport(TRANSPORT_BLUETOOTH)
-                        dynamicContext["\$network_cellular"] = capabilities.hasTransport(TRANSPORT_CELLULAR)
-                    }
-                }
-            }
-        }
+        dynamicContext.putAll(networkPropertiesProvider())
 
         context.telephonyManager()?.let {
             val networkOperatorName = it.networkOperatorName

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
@@ -10,40 +10,22 @@ import android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
 import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.os.Build
-import android.os.SystemClock
 import com.posthog.internal.PostHogNetworkStatus
-import java.util.concurrent.Executor
-import kotlin.concurrent.thread
 
 /**
  * Checks if there's an active network enabled and observes network availability changes.
  *
  * Network state is maintained from [ConnectivityManager.NetworkCallback] so event capture only
  * reads an in-memory snapshot. API 23 and callback registration failures refresh that snapshot
- * asynchronously with synchronous platform queries.
+ * when [isConnected] runs on an SDK worker.
  *
  * @property context the App Context
  */
-internal class PostHogAndroidNetworkStatus(
-    private val context: Context,
-    private val backgroundExecutor: Executor =
-        Executor { command ->
-            thread(start = true, isDaemon = true, name = "PostHogNetworkStatusThread") {
-                command.run()
-            }
-        },
-    private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
-) : PostHogNetworkStatus {
+internal class PostHogAndroidNetworkStatus(private val context: Context) : PostHogNetworkStatus {
     private data class Snapshot(
         val network: Network?,
         val connected: Boolean,
         val properties: Map<String, Any>,
-    )
-
-    private data class Refresh(
-        val manager: ConnectivityManager,
-        val generation: Int,
-        val networkGeneration: Int,
     )
 
     private val lock = Any()
@@ -53,11 +35,8 @@ internal class PostHogAndroidNetworkStatus(
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     private var activeNetwork: Network? = null
     private var started = false
-    private var usesPollingFallback = false
-    private var refreshInFlight = false
-    private var lastRefreshElapsedMs: Long? = null
+    private var usesSynchronousFallback = true
     private var generation = 0
-    private var networkGeneration = 0
 
     @Volatile
     private var connected: Boolean? = null
@@ -66,18 +45,21 @@ internal class PostHogAndroidNetworkStatus(
     private var networkProperties: Map<String, Any> = emptyMap()
 
     override fun isConnected(): Boolean {
-        connected?.let { return it }
-
         if (!context.hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
             return true
         }
-        val manager = context.connectivityManager() ?: return true
-        val currentNetworkGeneration = synchronized(lock) { networkGeneration }
+
+        val queryGeneration = synchronized(lock) { generation }
+        val shouldQuery = synchronized(lock) { !started || usesSynchronousFallback }
+        if (!shouldQuery) {
+            return connected ?: true
+        }
+
+        val manager = synchronized(lock) { connectivityManager } ?: context.connectivityManager() ?: return true
         val snapshot = querySnapshot(manager) ?: return true
         synchronized(lock) {
-            if (canApplySnapshotLocked(snapshot, currentNetworkGeneration)) {
+            if (queryGeneration == generation && (!started || usesSynchronousFallback)) {
                 applySnapshotLocked(snapshot)
-                lastRefreshElapsedMs = elapsedRealtimeMs()
             }
         }
         return snapshot.connected
@@ -109,49 +91,39 @@ internal class PostHogAndroidNetworkStatus(
                 try {
                     manager.registerDefaultNetworkCallback(callback)
                     networkCallback = callback
+                    usesSynchronousFallback = false
                 } catch (ignored: Throwable) {
-                    // SecurityException, callback limit, or another platform error.
-                    usesPollingFallback = true
+                    // SecurityException, callback limit, or another platform error. Connectivity
+                    // will be refreshed by isConnected() on an SDK worker instead.
+                    usesSynchronousFallback = true
                 }
             } else {
-                // API 23 cannot observe the default network, so refresh the snapshot off-thread.
-                usesPollingFallback = true
+                // API 23 cannot observe the default network.
+                usesSynchronousFallback = true
             }
         }
-
-        scheduleSnapshotRefresh(force = true)
     }
 
     internal fun getNetworkProperties(): Map<String, Any> {
-        val shouldRefresh =
-            synchronized(lock) {
-                usesPollingFallback || connected == null || (connected == true && networkProperties.isEmpty())
-            }
-        if (shouldRefresh) {
-            scheduleSnapshotRefresh()
-        }
         return networkProperties
     }
 
     private fun createNetworkCallback(): ConnectivityManager.NetworkCallback {
         return object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                val (networkChanged, callbacks) =
+                val callbacks =
                     synchronized(lock) {
-                        val changed = activeNetwork != network
-                        activeNetwork = network
-                        connected = true
-                        if (changed) {
-                            networkGeneration++
-                            networkProperties = emptyMap()
-                            lastRefreshElapsedMs = null
+                        if (networkCallback !== this) {
+                            return
                         }
-                        changed to availableCallbacks.toList()
+                        if (activeNetwork != network) {
+                            activeNetwork = network
+                            networkProperties = emptyMap()
+                        }
+                        connected = true
+                        availableCallbacks.toList()
                     }
                 callbacks.forEach { it() }
-                if (networkChanged) {
-                    scheduleSnapshotRefresh(force = true)
-                }
             }
 
             override fun onCapabilitiesChanged(
@@ -159,6 +131,9 @@ internal class PostHogAndroidNetworkStatus(
                 capabilities: NetworkCapabilities,
             ) {
                 synchronized(lock) {
+                    if (networkCallback !== this) {
+                        return
+                    }
                     if (network == activeNetwork) {
                         connected = true
                         networkProperties = capabilities.toNetworkProperties()
@@ -168,51 +143,14 @@ internal class PostHogAndroidNetworkStatus(
 
             override fun onLost(network: Network) {
                 synchronized(lock) {
+                    if (networkCallback !== this) {
+                        return
+                    }
                     if (network == activeNetwork) {
-                        networkGeneration++
                         activeNetwork = null
                         connected = false
                         networkProperties = emptyMap()
                     }
-                }
-            }
-        }
-    }
-
-    private fun scheduleSnapshotRefresh(force: Boolean = false) {
-        val refresh: Refresh =
-            synchronized(lock) {
-                val manager = connectivityManager ?: return
-                if (!started || refreshInFlight) {
-                    return
-                }
-                val now = elapsedRealtimeMs()
-                val lastRefresh = lastRefreshElapsedMs
-                if (!force && lastRefresh != null && now - lastRefresh < REFRESH_INTERVAL_MS) {
-                    return
-                }
-                refreshInFlight = true
-                Refresh(manager, generation, networkGeneration)
-            }
-
-        try {
-            backgroundExecutor.execute {
-                val snapshot = querySnapshot(refresh.manager)
-                synchronized(lock) {
-                    if (refresh.generation == generation) {
-                        if (snapshot != null && canApplySnapshotLocked(snapshot, refresh.networkGeneration)) {
-                            applySnapshotLocked(snapshot)
-                        }
-                        lastRefreshElapsedMs = elapsedRealtimeMs()
-                        refreshInFlight = false
-                    }
-                }
-            }
-        } catch (ignored: Throwable) {
-            synchronized(lock) {
-                if (refresh.generation == generation) {
-                    lastRefreshElapsedMs = elapsedRealtimeMs()
-                    refreshInFlight = false
                 }
             }
         }
@@ -237,14 +175,6 @@ internal class PostHogAndroidNetworkStatus(
         }
     }
 
-    private fun canApplySnapshotLocked(
-        snapshot: Snapshot,
-        expectedNetworkGeneration: Int,
-    ): Boolean {
-        return expectedNetworkGeneration == networkGeneration &&
-            (usesPollingFallback || activeNetwork == null || snapshot.network == activeNetwork)
-    }
-
     private fun applySnapshotLocked(snapshot: Snapshot) {
         activeNetwork = snapshot.network
         connected = snapshot.connected
@@ -265,15 +195,12 @@ internal class PostHogAndroidNetworkStatus(
                 val currentManager = connectivityManager
                 val currentCallback = networkCallback
                 generation++
-                networkGeneration++
                 connectivityManager = null
                 networkCallback = null
                 activeNetwork = null
                 availableCallbacks.clear()
                 started = false
-                usesPollingFallback = false
-                refreshInFlight = false
-                lastRefreshElapsedMs = null
+                usesSynchronousFallback = true
                 connected = null
                 networkProperties = emptyMap()
                 if (currentManager != null && currentCallback != null) {
@@ -288,9 +215,5 @@ internal class PostHogAndroidNetworkStatus(
         } catch (ignored: Throwable) {
             // IllegalArgumentException if the callback was not registered.
         }
-    }
-
-    private companion object {
-        private const val REFRESH_INTERVAL_MS = 60_000L
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
@@ -4,60 +4,150 @@ import android.Manifest
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
+import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
+import android.net.NetworkCapabilities.TRANSPORT_WIFI
+import android.net.NetworkRequest
 import android.os.Build
 import com.posthog.internal.PostHogNetworkStatus
 
 /**
- * Checks if there's an active network enabled and observes network availability changes
+ * Checks if there's an active network enabled and observes network availability changes.
+ *
+ * Network state is maintained from [ConnectivityManager.NetworkCallback] so callers never need to
+ * query the connectivity service synchronously while capturing an event.
+ *
  * @property context the App Context
  */
 internal class PostHogAndroidNetworkStatus(private val context: Context) : PostHogNetworkStatus {
+    private val lock = Any()
+    private val connectedNetworks = linkedSetOf<Network>()
+    private val networkPropertiesByNetwork = linkedMapOf<Network, Map<String, Any>>()
+    private val availableCallbacks = mutableListOf<() -> Unit>()
+
+    private var connectivityManager: ConnectivityManager? = null
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
+    @Volatile
+    private var connected: Boolean? = null
+
+    @Volatile
+    private var networkProperties: Map<String, Any> = emptyMap()
+
     override fun isConnected(): Boolean {
-        return context.isConnected()
+        // Unknown connectivity should not prevent requests, matching the previous behavior when
+        // ACCESS_NETWORK_STATE or ConnectivityManager was unavailable.
+        return connected ?: true
     }
 
     override fun register(callback: () -> Unit) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            return
+        synchronized(lock) {
+            availableCallbacks.add(callback)
         }
+        start()
+    }
 
+    internal fun start() {
         if (!context.hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
             return
         }
 
-        val connectivityManager = context.connectivityManager() ?: return
+        val manager = context.connectivityManager() ?: return
 
-        val cb =
-            object : ConnectivityManager.NetworkCallback() {
-                override fun onAvailable(network: Network) {
-                    callback()
+        synchronized(lock) {
+            if (networkCallback != null) {
+                return
+            }
+
+            val callback = createNetworkCallback()
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    manager.registerDefaultNetworkCallback(callback)
+                } else {
+                    val request =
+                        NetworkRequest.Builder()
+                            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                            .build()
+                    manager.registerNetworkCallback(request, callback)
+                }
+                connectivityManager = manager
+                networkCallback = callback
+            } catch (ignored: Throwable) {
+                // SecurityException or other platform errors. Connectivity remains unknown so the
+                // SDK attempts requests rather than incorrectly treating the device as offline.
+            }
+        }
+    }
+
+    internal fun getNetworkProperties(): Map<String, Any> {
+        return networkProperties
+    }
+
+    private fun createNetworkCallback(): ConnectivityManager.NetworkCallback {
+        return object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                val callbacks =
+                    synchronized(lock) {
+                        connectedNetworks.add(network)
+                        connected = true
+                        availableCallbacks.toList()
+                    }
+                callbacks.forEach { it() }
+            }
+
+            override fun onCapabilitiesChanged(
+                network: Network,
+                capabilities: NetworkCapabilities,
+            ) {
+                val properties =
+                    mapOf(
+                        "\$network_wifi" to capabilities.hasTransport(TRANSPORT_WIFI),
+                        "\$network_bluetooth" to capabilities.hasTransport(TRANSPORT_BLUETOOTH),
+                        "\$network_cellular" to capabilities.hasTransport(TRANSPORT_CELLULAR),
+                    )
+                synchronized(lock) {
+                    connectedNetworks.add(network)
+                    connected = true
+                    networkPropertiesByNetwork[network] = properties
+                    networkProperties = properties
                 }
             }
 
-        try {
-            connectivityManager.registerDefaultNetworkCallback(cb)
-            networkCallback = cb
-        } catch (ignored: Throwable) {
-            // SecurityException or other errors
+            override fun onLost(network: Network) {
+                synchronized(lock) {
+                    connectedNetworks.remove(network)
+                    networkPropertiesByNetwork.remove(network)
+                    connected = connectedNetworks.isNotEmpty()
+                    networkProperties = networkPropertiesByNetwork.values.lastOrNull() ?: emptyMap()
+                }
+            }
         }
     }
 
     override fun unregister() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            return
-        }
-
-        val cb = networkCallback ?: return
-        networkCallback = null
-
-        val connectivityManager = context.connectivityManager() ?: return
+        val registration =
+            synchronized(lock) {
+                val currentManager = connectivityManager
+                val currentCallback = networkCallback
+                connectivityManager = null
+                networkCallback = null
+                availableCallbacks.clear()
+                connectedNetworks.clear()
+                networkPropertiesByNetwork.clear()
+                connected = null
+                networkProperties = emptyMap()
+                if (currentManager != null && currentCallback != null) {
+                    currentManager to currentCallback
+                } else {
+                    null
+                }
+            } ?: return
 
         try {
-            connectivityManager.unregisterNetworkCallback(cb)
+            registration.first.unregisterNetworkCallback(registration.second)
         } catch (ignored: Throwable) {
-            // IllegalArgumentException if not registered
+            // IllegalArgumentException if the callback was not registered.
         }
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
@@ -1,6 +1,7 @@
 package com.posthog.android.internal
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
@@ -9,24 +10,54 @@ import android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
 import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
 import android.os.Build
+import android.os.SystemClock
 import com.posthog.internal.PostHogNetworkStatus
+import java.util.concurrent.Executor
+import kotlin.concurrent.thread
 
 /**
  * Checks if there's an active network enabled and observes network availability changes.
  *
- * Network state is maintained from [ConnectivityManager.NetworkCallback] so callers never need to
- * query the connectivity service synchronously while capturing an event.
+ * Network state is maintained from [ConnectivityManager.NetworkCallback] so event capture only
+ * reads an in-memory snapshot. API 23 and callback registration failures refresh that snapshot
+ * asynchronously with synchronous platform queries.
  *
  * @property context the App Context
  */
-internal class PostHogAndroidNetworkStatus(private val context: Context) : PostHogNetworkStatus {
+internal class PostHogAndroidNetworkStatus(
+    private val context: Context,
+    private val backgroundExecutor: Executor =
+        Executor { command ->
+            thread(start = true, isDaemon = true, name = "PostHogNetworkStatusThread") {
+                command.run()
+            }
+        },
+    private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
+) : PostHogNetworkStatus {
+    private data class Snapshot(
+        val network: Network?,
+        val connected: Boolean,
+        val properties: Map<String, Any>,
+    )
+
+    private data class Refresh(
+        val manager: ConnectivityManager,
+        val generation: Int,
+        val networkGeneration: Int,
+    )
+
     private val lock = Any()
-    private val connectedNetworks = linkedSetOf<Network>()
-    private val networkPropertiesByNetwork = linkedMapOf<Network, Map<String, Any>>()
     private val availableCallbacks = mutableListOf<() -> Unit>()
 
     private var connectivityManager: ConnectivityManager? = null
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private var activeNetwork: Network? = null
+    private var started = false
+    private var usesPollingFallback = false
+    private var refreshInFlight = false
+    private var lastRefreshElapsedMs: Long? = null
+    private var generation = 0
+    private var networkGeneration = 0
 
     @Volatile
     private var connected: Boolean? = null
@@ -35,9 +66,23 @@ internal class PostHogAndroidNetworkStatus(private val context: Context) : PostH
     private var networkProperties: Map<String, Any> = emptyMap()
 
     override fun isConnected(): Boolean {
-        // Unknown connectivity should not prevent requests, matching the previous behavior when
-        // ACCESS_NETWORK_STATE or ConnectivityManager was unavailable.
-        return connected ?: true
+        connected?.let { return it }
+
+        if (!context.hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
+            return true
+        }
+        val manager = context.connectivityManager() ?: return true
+        val currentNetworkGeneration = synchronized(lock) { networkGeneration }
+        val snapshot = querySnapshot(manager) ?: return true
+        synchronized(lock) {
+            if (currentNetworkGeneration == networkGeneration &&
+                (usesPollingFallback || activeNetwork == null || snapshot.network == activeNetwork)
+            ) {
+                applySnapshotLocked(snapshot)
+                lastRefreshElapsedMs = elapsedRealtimeMs()
+            }
+        }
+        return snapshot.connected
     }
 
     override fun register(callback: () -> Unit) {
@@ -48,78 +93,168 @@ internal class PostHogAndroidNetworkStatus(private val context: Context) : PostH
     }
 
     internal fun start() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            // API 23 can observe matching networks, but not the default network. Leave the
-            // snapshot empty rather than report a non-active transport or query synchronously.
-            return
-        }
-
         if (!context.hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
             return
         }
 
         val manager = context.connectivityManager() ?: return
-
         synchronized(lock) {
-            if (networkCallback != null) {
+            if (started) {
                 return
             }
+            started = true
+            generation++
+            connectivityManager = manager
 
-            val callback = createNetworkCallback()
-            try {
-                manager.registerDefaultNetworkCallback(callback)
-                connectivityManager = manager
-                networkCallback = callback
-            } catch (ignored: Throwable) {
-                // SecurityException or other platform errors. Connectivity remains unknown so the
-                // SDK attempts requests rather than incorrectly treating the device as offline.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                val callback = createNetworkCallback()
+                try {
+                    manager.registerDefaultNetworkCallback(callback)
+                    networkCallback = callback
+                } catch (ignored: Throwable) {
+                    // SecurityException, callback limit, or another platform error.
+                    usesPollingFallback = true
+                }
+            } else {
+                // API 23 cannot observe the default network, so refresh the snapshot off-thread.
+                usesPollingFallback = true
             }
         }
+
+        scheduleSnapshotRefresh(force = true)
     }
 
     internal fun getNetworkProperties(): Map<String, Any> {
+        val shouldRefresh =
+            synchronized(lock) {
+                usesPollingFallback || connected == null || (connected == true && networkProperties.isEmpty())
+            }
+        if (shouldRefresh) {
+            scheduleSnapshotRefresh()
+        }
         return networkProperties
     }
 
     private fun createNetworkCallback(): ConnectivityManager.NetworkCallback {
         return object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                val callbacks =
+                val (networkChanged, callbacks) =
                     synchronized(lock) {
-                        connectedNetworks.add(network)
+                        val changed = activeNetwork != network
+                        activeNetwork = network
                         connected = true
-                        availableCallbacks.toList()
+                        if (changed) {
+                            networkGeneration++
+                            networkProperties = emptyMap()
+                            lastRefreshElapsedMs = null
+                        }
+                        changed to availableCallbacks.toList()
                     }
                 callbacks.forEach { it() }
+                if (networkChanged) {
+                    scheduleSnapshotRefresh(force = true)
+                }
             }
 
             override fun onCapabilitiesChanged(
                 network: Network,
                 capabilities: NetworkCapabilities,
             ) {
-                val properties =
-                    mapOf(
-                        "\$network_wifi" to capabilities.hasTransport(TRANSPORT_WIFI),
-                        "\$network_bluetooth" to capabilities.hasTransport(TRANSPORT_BLUETOOTH),
-                        "\$network_cellular" to capabilities.hasTransport(TRANSPORT_CELLULAR),
-                    )
                 synchronized(lock) {
-                    connectedNetworks.add(network)
-                    connected = true
-                    networkPropertiesByNetwork[network] = properties
-                    networkProperties = properties
+                    if (network == activeNetwork) {
+                        connected = true
+                        networkProperties = capabilities.toNetworkProperties()
+                    }
                 }
             }
 
             override fun onLost(network: Network) {
                 synchronized(lock) {
-                    connectedNetworks.remove(network)
-                    networkPropertiesByNetwork.remove(network)
-                    connected = connectedNetworks.isNotEmpty()
-                    networkProperties = networkPropertiesByNetwork.values.lastOrNull() ?: emptyMap()
+                    if (network == activeNetwork) {
+                        networkGeneration++
+                        activeNetwork = null
+                        connected = false
+                        networkProperties = emptyMap()
+                    }
                 }
             }
         }
+    }
+
+    private fun scheduleSnapshotRefresh(force: Boolean = false) {
+        val refresh: Refresh =
+            synchronized(lock) {
+                val manager = connectivityManager ?: return
+                if (!started || refreshInFlight) {
+                    return
+                }
+                val now = elapsedRealtimeMs()
+                val lastRefresh = lastRefreshElapsedMs
+                if (!force && lastRefresh != null && now - lastRefresh < REFRESH_INTERVAL_MS) {
+                    return
+                }
+                refreshInFlight = true
+                Refresh(manager, generation, networkGeneration)
+            }
+
+        try {
+            backgroundExecutor.execute {
+                val snapshot = querySnapshot(refresh.manager)
+                synchronized(lock) {
+                    if (refresh.generation == generation) {
+                        val canApply =
+                            refresh.networkGeneration == networkGeneration &&
+                                snapshot != null &&
+                                (usesPollingFallback || activeNetwork == null || snapshot.network == activeNetwork)
+                        if (canApply) {
+                            applySnapshotLocked(snapshot)
+                        }
+                        lastRefreshElapsedMs = elapsedRealtimeMs()
+                        refreshInFlight = false
+                    }
+                }
+            }
+        } catch (ignored: Throwable) {
+            synchronized(lock) {
+                if (refresh.generation == generation) {
+                    lastRefreshElapsedMs = elapsedRealtimeMs()
+                    refreshInFlight = false
+                }
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun querySnapshot(manager: ConnectivityManager): Snapshot? {
+        return try {
+            val network = manager.activeNetwork
+            if (network == null) {
+                Snapshot(null, connected = false, properties = emptyMap())
+            } else {
+                val capabilities = manager.getNetworkCapabilities(network)
+                Snapshot(
+                    network,
+                    connected = true,
+                    properties = capabilities?.toNetworkProperties() ?: emptyMap(),
+                )
+            }
+        } catch (ignored: Throwable) {
+            null
+        }
+    }
+
+    private fun applySnapshotLocked(snapshot: Snapshot) {
+        activeNetwork = snapshot.network
+        connected = snapshot.connected
+        networkProperties = snapshot.properties
+    }
+
+    private fun NetworkCapabilities.toNetworkProperties(): Map<String, Any> {
+        return mapOf(
+            "\$network_wifi" to hasTransport(TRANSPORT_WIFI),
+            "\$network_bluetooth" to hasTransport(TRANSPORT_BLUETOOTH),
+            "\$network_cellular" to hasTransport(TRANSPORT_CELLULAR),
+        )
     }
 
     override fun unregister() {
@@ -127,11 +262,16 @@ internal class PostHogAndroidNetworkStatus(private val context: Context) : PostH
             synchronized(lock) {
                 val currentManager = connectivityManager
                 val currentCallback = networkCallback
+                generation++
+                networkGeneration++
                 connectivityManager = null
                 networkCallback = null
+                activeNetwork = null
                 availableCallbacks.clear()
-                connectedNetworks.clear()
-                networkPropertiesByNetwork.clear()
+                started = false
+                usesPollingFallback = false
+                refreshInFlight = false
+                lastRefreshElapsedMs = null
                 connected = null
                 networkProperties = emptyMap()
                 if (currentManager != null && currentCallback != null) {
@@ -146,5 +286,9 @@ internal class PostHogAndroidNetworkStatus(private val context: Context) : PostH
         } catch (ignored: Throwable) {
             // IllegalArgumentException if the callback was not registered.
         }
+    }
+
+    private companion object {
+        private const val REFRESH_INTERVAL_MS = 60_000L
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
@@ -75,9 +75,7 @@ internal class PostHogAndroidNetworkStatus(
         val currentNetworkGeneration = synchronized(lock) { networkGeneration }
         val snapshot = querySnapshot(manager) ?: return true
         synchronized(lock) {
-            if (currentNetworkGeneration == networkGeneration &&
-                (usesPollingFallback || activeNetwork == null || snapshot.network == activeNetwork)
-            ) {
+            if (canApplySnapshotLocked(snapshot, currentNetworkGeneration)) {
                 applySnapshotLocked(snapshot)
                 lastRefreshElapsedMs = elapsedRealtimeMs()
             }
@@ -202,11 +200,7 @@ internal class PostHogAndroidNetworkStatus(
                 val snapshot = querySnapshot(refresh.manager)
                 synchronized(lock) {
                     if (refresh.generation == generation) {
-                        val canApply =
-                            refresh.networkGeneration == networkGeneration &&
-                                snapshot != null &&
-                                (usesPollingFallback || activeNetwork == null || snapshot.network == activeNetwork)
-                        if (canApply) {
+                        if (snapshot != null && canApplySnapshotLocked(snapshot, refresh.networkGeneration)) {
                             applySnapshotLocked(snapshot)
                         }
                         lastRefreshElapsedMs = elapsedRealtimeMs()
@@ -241,6 +235,14 @@ internal class PostHogAndroidNetworkStatus(
         } catch (ignored: Throwable) {
             null
         }
+    }
+
+    private fun canApplySnapshotLocked(
+        snapshot: Snapshot,
+        expectedNetworkGeneration: Int,
+    ): Boolean {
+        return expectedNetworkGeneration == networkGeneration &&
+            (usesPollingFallback || activeNetwork == null || snapshot.network == activeNetwork)
     }
 
     private fun applySnapshotLocked(snapshot: Snapshot) {

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatus.kt
@@ -8,7 +8,6 @@ import android.net.NetworkCapabilities
 import android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
 import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
 import android.net.NetworkCapabilities.TRANSPORT_WIFI
-import android.net.NetworkRequest
 import android.os.Build
 import com.posthog.internal.PostHogNetworkStatus
 
@@ -49,6 +48,12 @@ internal class PostHogAndroidNetworkStatus(private val context: Context) : PostH
     }
 
     internal fun start() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            // API 23 can observe matching networks, but not the default network. Leave the
+            // snapshot empty rather than report a non-active transport or query synchronously.
+            return
+        }
+
         if (!context.hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
             return
         }
@@ -62,15 +67,7 @@ internal class PostHogAndroidNetworkStatus(private val context: Context) : PostH
 
             val callback = createNetworkCallback()
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    manager.registerDefaultNetworkCallback(callback)
-                } else {
-                    val request =
-                        NetworkRequest.Builder()
-                            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                            .build()
-                    manager.registerNetworkCallback(request, callback)
-                }
+                manager.registerDefaultNetworkCallback(callback)
                 connectivityManager = manager
                 networkCallback = callback
             } catch (ignored: Throwable) {

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatusIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidNetworkStatusIntegration.kt
@@ -1,0 +1,17 @@
+package com.posthog.android.internal
+
+import com.posthog.PostHogIntegration
+import com.posthog.PostHogInterface
+
+/** Starts the connectivity monitor when a custom queue network status is configured. */
+internal class PostHogAndroidNetworkStatusIntegration(
+    private val networkStatus: PostHogAndroidNetworkStatus,
+) : PostHogIntegration {
+    override fun install(postHog: PostHogInterface) {
+        networkStatus.start()
+    }
+
+    override fun uninstall() {
+        networkStatus.unregister()
+    }
+}

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -1,7 +1,5 @@
 package com.posthog.android.internal
 
-import android.Manifest
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -111,18 +109,6 @@ internal fun Context.hasPermission(permission: String): Boolean {
         Process.myPid(),
         Process.myUid(),
     ) == PackageManager.PERMISSION_GRANTED
-}
-
-@Suppress("DEPRECATION")
-@SuppressLint("MissingPermission")
-internal fun Context.isConnected(): Boolean {
-    val connectivityManager = connectivityManager() ?: return true
-
-    if (!hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)) {
-        return true
-    }
-    val networkInfo = connectivityManager.activeNetworkInfo ?: return false
-    return networkInfo.isConnected
 }
 
 internal fun Context.connectivityManager(): ConnectivityManager? {

--- a/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
@@ -7,10 +7,12 @@ import com.posthog.android.internal.PostHogActivityLifecycleCallbackIntegration
 import com.posthog.android.internal.PostHogAndroidContext
 import com.posthog.android.internal.PostHogAndroidLogger
 import com.posthog.android.internal.PostHogAndroidNetworkStatus
+import com.posthog.android.internal.PostHogAndroidNetworkStatusIntegration
 import com.posthog.android.internal.PostHogAppInstallIntegration
 import com.posthog.android.internal.PostHogLifecycleObserverIntegration
 import com.posthog.android.internal.PostHogSharedPreferences
 import com.posthog.internal.PostHogLogger
+import com.posthog.internal.PostHogNetworkStatus
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -118,6 +120,22 @@ internal class PostHogAndroidTest {
         PostHogAndroid.setup(context, config)
 
         assertTrue(config.networkStatus is PostHogAndroidNetworkStatus)
+    }
+
+    @Test
+    fun `adds connectivity monitor when custom network status is configured`() {
+        val config = PostHogAndroidConfig(API_KEY)
+        config.networkStatus =
+            object : PostHogNetworkStatus {
+                override fun isConnected(): Boolean = true
+            }
+
+        mockContextAppStart(context, tmpDir)
+
+        PostHogAndroid.setup(context, config)
+
+        assertTrue(config.context is PostHogAndroidContext)
+        assertNotNull(config.integrations.find { it is PostHogAndroidNetworkStatusIntegration })
     }
 
     @Test

--- a/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
@@ -125,15 +126,17 @@ internal class PostHogAndroidTest {
     @Test
     fun `adds connectivity monitor when custom network status is configured`() {
         val config = PostHogAndroidConfig(API_KEY)
-        config.networkStatus =
+        val customNetworkStatus =
             object : PostHogNetworkStatus {
                 override fun isConnected(): Boolean = true
             }
+        config.networkStatus = customNetworkStatus
 
         mockContextAppStart(context, tmpDir)
 
         PostHogAndroid.setup(context, config)
 
+        assertSame(customNetworkStatus, config.networkStatus)
         assertTrue(config.context is PostHogAndroidContext)
         assertNotNull(config.integrations.find { it is PostHogAndroidNetworkStatusIntegration })
     }

--- a/posthog-android/src/test/java/com/posthog/android/Utils.kt
+++ b/posthog-android/src/test/java/com/posthog/android/Utils.kt
@@ -15,7 +15,6 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.net.ConnectivityManager
-import android.net.NetworkInfo
 import android.net.Uri
 import android.telephony.TelephonyManager
 import android.util.DisplayMetrics
@@ -140,45 +139,10 @@ public fun mockPermission(
     return cm
 }
 
-public fun mockNetworkInfo(
-    connectivityManager: ConnectivityManager,
-    hasNetwork: Boolean = true,
-    isConnected: Boolean = true,
-) {
-    if (hasNetwork) {
-        val ni = mock<NetworkInfo>()
-        whenever(connectivityManager.activeNetworkInfo).thenReturn(ni)
-        whenever(ni.isConnected).thenReturn(isConnected)
-    }
-}
-
 public fun Context.mockTelephone() {
     val tm = mock<TelephonyManager>()
     whenever(getSystemService(any())).thenReturn(tm)
     whenever(tm.networkOperatorName).thenReturn("name")
-}
-
-public fun mockGetNetworkInfo(
-    connectivityManager: ConnectivityManager,
-    networkType: Int,
-    isConnected: Boolean = true,
-) {
-    val network = mock<android.net.Network>()
-    whenever(connectivityManager.activeNetwork).thenReturn(if (isConnected) network else null)
-
-    if (isConnected) {
-        val capabilities = mock<android.net.NetworkCapabilities>()
-        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
-
-        val transport =
-            when (networkType) {
-                ConnectivityManager.TYPE_WIFI -> android.net.NetworkCapabilities.TRANSPORT_WIFI
-                ConnectivityManager.TYPE_BLUETOOTH -> android.net.NetworkCapabilities.TRANSPORT_BLUETOOTH
-                ConnectivityManager.TYPE_MOBILE -> android.net.NetworkCapabilities.TRANSPORT_CELLULAR
-                else -> -1
-            }
-        whenever(capabilities.hasTransport(transport)).thenReturn(true)
-    }
 }
 
 public fun createPostHogFake(): PostHogFake {

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidContextTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package com.posthog.android.internal
 
 import android.content.Context
@@ -9,27 +7,26 @@ import com.posthog.android.API_KEY
 import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.mockAppInfo
 import com.posthog.android.mockDisplayMetrics
-import com.posthog.android.mockGetNetworkInfo
 import com.posthog.android.mockPackageInfo
-import com.posthog.android.mockPermission
 import com.posthog.android.mockTelephone
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 internal class PostHogAndroidContextTest {
     private val context = mock<Context>()
     private lateinit var config: PostHogAndroidConfig
 
-    private fun getSut(): PostHogAndroidContext {
+    private fun getSut(networkProperties: Map<String, Any> = emptyMap()): PostHogAndroidContext {
         config = PostHogAndroidConfig(API_KEY)
-        return PostHogAndroidContext(context, config)
+        return PostHogAndroidContext(context, config) { networkProperties }
     }
 
     @BeforeTest
@@ -69,6 +66,7 @@ internal class PostHogAndroidContextTest {
         assertNotNull(staticContext["\$is_emulator"])
     }
 
+    @Test
     fun `returns sdk info`() {
         val sut = getSut()
         val sdkInfo = sut.getSdkInfo()
@@ -81,8 +79,6 @@ internal class PostHogAndroidContextTest {
     fun `returns dynamic context`() {
         val sut = getSut()
 
-        val cm = mockPermission(context)
-        mockGetNetworkInfo(cm, ConnectivityManager.TYPE_WIFI)
         context.mockTelephone()
         val dynamicContext = sut.getDynamicContext()
 
@@ -95,58 +91,41 @@ internal class PostHogAndroidContextTest {
         assertEquals("name", dynamicContext["\$network_carrier"])
     }
 
-    private fun executeNetworkTest(
-        networkType: Int = ConnectivityManager.TYPE_WIFI,
-        isConnected: Boolean = true,
-    ): Map<String, Any> {
-        val sut = getSut()
-        val cm = mockPermission(context)
-        mockGetNetworkInfo(cm, networkType, isConnected = isConnected)
-        return sut.getDynamicContext()
+    @Test
+    fun `returns network properties from snapshot`() {
+        val sut =
+            getSut(
+                mapOf(
+                    "\$network_wifi" to true,
+                    "\$network_bluetooth" to false,
+                    "\$network_cellular" to false,
+                ),
+            )
+
+        val dynamicContext = sut.getDynamicContext()
+
+        assertEquals(true, dynamicContext["\$network_wifi"])
+        assertEquals(false, dynamicContext["\$network_bluetooth"])
+        assertEquals(false, dynamicContext["\$network_cellular"])
     }
 
     @Test
-    fun `sets network wifi connected`() {
-        val dynamicContext = executeNetworkTest()
+    fun `omits network properties when snapshot is empty`() {
+        val dynamicContext = getSut().getDynamicContext()
 
-        assertTrue(dynamicContext["\$network_wifi"] as Boolean)
-    }
-
-    @Test
-    fun `sets network wifi not connected`() {
-        val dynamicContext = executeNetworkTest(isConnected = false)
-
-        // When not connected, activeNetwork is null so network keys are absent
         assertFalse(dynamicContext.containsKey("\$network_wifi"))
-    }
-
-    @Test
-    fun `sets network bluetooth connected`() {
-        val dynamicContext = executeNetworkTest(networkType = ConnectivityManager.TYPE_BLUETOOTH)
-
-        assertTrue(dynamicContext["\$network_bluetooth"] as Boolean)
-    }
-
-    @Test
-    fun `sets network bluetooth not connected`() {
-        val dynamicContext = executeNetworkTest(isConnected = false, networkType = ConnectivityManager.TYPE_BLUETOOTH)
-
-        // When not connected, activeNetwork is null so network keys are absent
         assertFalse(dynamicContext.containsKey("\$network_bluetooth"))
-    }
-
-    @Test
-    fun `sets network cellular connected`() {
-        val dynamicContext = executeNetworkTest(networkType = ConnectivityManager.TYPE_MOBILE)
-
-        assertTrue(dynamicContext["\$network_cellular"] as Boolean)
-    }
-
-    @Test
-    fun `sets network cellular not connected`() {
-        val dynamicContext = executeNetworkTest(isConnected = false, networkType = ConnectivityManager.TYPE_MOBILE)
-
-        // When not connected, activeNetwork is null so network keys are absent
         assertFalse(dynamicContext.containsKey("\$network_cellular"))
+    }
+
+    @Test
+    fun `does not query ConnectivityManager`() {
+        val connectivityManager = mock<ConnectivityManager>()
+        whenever(context.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(connectivityManager)
+
+        val sut = getSut()
+        repeat(10) { sut.getDynamicContext() }
+
+        verifyNoInteractions(connectivityManager)
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
@@ -5,11 +5,9 @@ import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.posthog.android.mockPermission
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -105,13 +103,14 @@ internal class PostHogAndroidNetworkStatusTest {
 
     @Test
     @Config(sdk = [23])
-    fun `uses network request callback on API 23`() {
+    fun `does not register callback on API 23`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
 
         sut.register {}
 
-        verify(connectivityManager).registerNetworkCallback(any<NetworkRequest>(), any<ConnectivityManager.NetworkCallback>())
+        verifyNoInteractions(connectivityManager)
+        assertTrue(sut.getNetworkProperties().isEmpty())
     }
 
     @Test

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
@@ -11,12 +11,12 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
-import java.util.concurrent.Executor
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -25,14 +25,9 @@ import kotlin.test.assertTrue
 @RunWith(AndroidJUnit4::class)
 internal class PostHogAndroidNetworkStatusTest {
     private val context = mock<Context>()
-    private var elapsedRealtimeMs = 0L
 
-    private fun getSut(backgroundExecutor: Executor = Executor { it.run() }): PostHogAndroidNetworkStatus {
-        return PostHogAndroidNetworkStatus(
-            context,
-            backgroundExecutor = backgroundExecutor,
-            elapsedRealtimeMs = { elapsedRealtimeMs },
-        )
+    private fun getSut(): PostHogAndroidNetworkStatus {
+        return PostHogAndroidNetworkStatus(context)
     }
 
     private fun mockCapabilities(
@@ -75,17 +70,15 @@ internal class PostHogAndroidNetworkStatusTest {
 
     @Test
     @Config(sdk = [34])
-    fun `primes properties off thread before callback delivery`() {
+    fun `relies on callback without querying connectivity service`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
-        val network = mock<Network>()
-        val capabilities = mockCapabilities(wifi = true)
-        whenever(connectivityManager.activeNetwork).thenReturn(network)
-        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
 
         sut.register {}
 
-        assertEquals(true, sut.getNetworkProperties()["\$network_wifi"])
+        assertTrue(sut.isConnected())
+        assertTrue(sut.getNetworkProperties().isEmpty())
+        verify(connectivityManager, never()).activeNetwork
     }
 
     @Test
@@ -150,29 +143,6 @@ internal class PostHogAndroidNetworkStatusTest {
 
     @Test
     @Config(sdk = [34])
-    fun `stale background refresh does not restore a lost network`() {
-        val pendingTasks = mutableListOf<Runnable>()
-        val sut = getSut(Executor { pendingTasks.add(it) })
-        val connectivityManager = mockPermission(context)
-        val callbackCaptor = argumentCaptor<ConnectivityManager.NetworkCallback>()
-        val network = mock<Network>()
-        val capabilities = mockCapabilities(wifi = true)
-        whenever(connectivityManager.activeNetwork).thenReturn(network)
-        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
-
-        sut.register {}
-        verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
-        callbackCaptor.firstValue.onAvailable(network)
-        callbackCaptor.firstValue.onLost(network)
-
-        pendingTasks.single().run()
-
-        assertFalse(sut.isConnected())
-        assertTrue(sut.getNetworkProperties().isEmpty())
-    }
-
-    @Test
-    @Config(sdk = [34])
     fun `registers one system callback and notifies every listener`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
@@ -193,7 +163,7 @@ internal class PostHogAndroidNetworkStatusTest {
 
     @Test
     @Config(sdk = [23])
-    fun `uses background snapshot fallback on API 23`() {
+    fun `refreshes snapshot from isConnected on API 23`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
         val network = mock<Network>()
@@ -202,13 +172,16 @@ internal class PostHogAndroidNetworkStatusTest {
         whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
 
         sut.register {}
+        assertTrue(sut.getNetworkProperties().isEmpty())
+
+        assertTrue(sut.isConnected())
 
         assertEquals(true, sut.getNetworkProperties()["\$network_bluetooth"])
     }
 
     @Test
     @Config(sdk = [34])
-    fun `uses background snapshot fallback when callback registration fails`() {
+    fun `refreshes snapshot from isConnected when callback registration fails`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
         val network = mock<Network>()
@@ -218,27 +191,16 @@ internal class PostHogAndroidNetworkStatusTest {
         whenever(connectivityManager.registerDefaultNetworkCallback(any())).thenThrow(IllegalStateException("limit"))
 
         sut.register {}
+        assertTrue(sut.getNetworkProperties().isEmpty())
+
+        assertTrue(sut.isConnected())
 
         assertEquals(true, sut.getNetworkProperties()["\$network_cellular"])
     }
 
     @Test
     @Config(sdk = [34])
-    fun `throttles failed background refreshes`() {
-        val sut = getSut()
-        val connectivityManager = mockPermission(context)
-        whenever(connectivityManager.activeNetwork).thenThrow(IllegalStateException("service unavailable"))
-
-        sut.register {}
-        sut.getNetworkProperties()
-        sut.getNetworkProperties()
-
-        verify(connectivityManager, times(1)).activeNetwork
-    }
-
-    @Test
-    @Config(sdk = [34])
-    fun `polling fallback refreshes stale properties`() {
+    fun `synchronous fallback refreshes changed properties`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
         val wifiNetwork = mock<Network>()
@@ -249,13 +211,30 @@ internal class PostHogAndroidNetworkStatusTest {
         whenever(connectivityManager.activeNetwork).thenReturn(wifiNetwork)
         whenever(connectivityManager.getNetworkCapabilities(wifiNetwork)).thenReturn(wifiCapabilities)
         sut.register {}
+
+        assertTrue(sut.isConnected())
         assertEquals(true, sut.getNetworkProperties()["\$network_wifi"])
 
         whenever(connectivityManager.activeNetwork).thenReturn(cellularNetwork)
         whenever(connectivityManager.getNetworkCapabilities(cellularNetwork)).thenReturn(cellularCapabilities)
-        elapsedRealtimeMs = 60_000L
 
+        assertTrue(sut.isConnected())
         assertEquals(true, sut.getNetworkProperties()["\$network_cellular"])
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `synchronous fallback fails open and retries`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        whenever(connectivityManager.registerDefaultNetworkCallback(any())).thenThrow(IllegalStateException("limit"))
+        whenever(connectivityManager.activeNetwork).thenThrow(IllegalStateException("service unavailable"))
+        sut.register {}
+
+        assertTrue(sut.isConnected())
+        assertTrue(sut.isConnected())
+
+        verify(connectivityManager, times(2)).activeNetwork
     }
 
     @Test
@@ -272,9 +251,10 @@ internal class PostHogAndroidNetworkStatusTest {
         callbackCaptor.firstValue.onCapabilitiesChanged(network, mockCapabilities(wifi = true))
 
         sut.unregister()
+        callbackCaptor.firstValue.onAvailable(network)
+        callbackCaptor.firstValue.onCapabilitiesChanged(network, mockCapabilities(wifi = true))
 
         verify(connectivityManager).unregisterNetworkCallback(callbackCaptor.firstValue)
-        assertFalse(sut.isConnected())
         assertTrue(sut.getNetworkProperties().isEmpty())
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
@@ -2,12 +2,23 @@ package com.posthog.android.internal
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.posthog.android.mockNetworkInfo
 import com.posthog.android.mockPermission
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -20,43 +31,106 @@ internal class PostHogAndroidNetworkStatusTest {
     }
 
     @Test
-    fun `returns connected if no activity manager`() {
-        val sut = getSut()
-
-        assertTrue(sut.isConnected())
+    fun `returns connected if no connectivity manager`() {
+        assertTrue(getSut().isConnected())
     }
 
     @Test
-    fun `returns connected if no permission`() {
+    fun `returns connected and does not register if no permission`() {
         val sut = getSut()
-        mockPermission(context, PackageManager.PERMISSION_DENIED)
+        val connectivityManager = mockPermission(context, PackageManager.PERMISSION_DENIED)
+
+        sut.register {}
 
         assertTrue(sut.isConnected())
+        verifyNoInteractions(connectivityManager)
     }
 
     @Test
-    fun `returns not connected if no active connection`() {
+    @Config(sdk = [34])
+    fun `updates connectivity and properties from callback`() {
         val sut = getSut()
-        mockPermission(context)
+        val connectivityManager = mockPermission(context)
+        val callbackCaptor = argumentCaptor<ConnectivityManager.NetworkCallback>()
+        var availableCalls = 0
+
+        sut.register { availableCalls++ }
+        verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
+
+        val network = mock<Network>()
+        val capabilities = mock<NetworkCapabilities>()
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(true)
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)).thenReturn(false)
+        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(false)
+
+        callbackCaptor.firstValue.onAvailable(network)
+        callbackCaptor.firstValue.onCapabilitiesChanged(network, capabilities)
+
+        assertTrue(sut.isConnected())
+        assertEquals(1, availableCalls)
+        assertEquals(
+            mapOf(
+                "\$network_wifi" to true,
+                "\$network_bluetooth" to false,
+                "\$network_cellular" to false,
+            ),
+            sut.getNetworkProperties(),
+        )
+
+        callbackCaptor.firstValue.onLost(network)
 
         assertFalse(sut.isConnected())
+        assertTrue(sut.getNetworkProperties().isEmpty())
     }
 
     @Test
-    fun `returns connected if active connection`() {
+    @Config(sdk = [34])
+    fun `registers one system callback and notifies every listener`() {
         val sut = getSut()
-        val cm = mockPermission(context)
-        mockNetworkInfo(cm)
+        val connectivityManager = mockPermission(context)
+        val callbackCaptor = argumentCaptor<ConnectivityManager.NetworkCallback>()
+        var firstCalls = 0
+        var secondCalls = 0
 
+        sut.register { firstCalls++ }
+        sut.register { secondCalls++ }
+
+        verify(connectivityManager, times(1)).registerDefaultNetworkCallback(callbackCaptor.capture())
+
+        callbackCaptor.firstValue.onAvailable(mock())
+
+        assertEquals(1, firstCalls)
+        assertEquals(1, secondCalls)
+    }
+
+    @Test
+    @Config(sdk = [23])
+    fun `uses network request callback on API 23`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+
+        sut.register {}
+
+        verify(connectivityManager).registerNetworkCallback(any<NetworkRequest>(), any<ConnectivityManager.NetworkCallback>())
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `unregisters callback and clears snapshot`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        val callbackCaptor = argumentCaptor<ConnectivityManager.NetworkCallback>()
+        sut.register {}
+        verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
+
+        val network = mock<Network>()
+        val capabilities = mock<NetworkCapabilities>()
+        callbackCaptor.firstValue.onCapabilitiesChanged(network, capabilities)
+
+        sut.unregister()
+
+        verify(connectivityManager).unregisterNetworkCallback(callbackCaptor.firstValue)
         assertTrue(sut.isConnected())
-    }
-
-    @Test
-    fun `returns not connected if active connection but not connected`() {
-        val sut = getSut()
-        val cm = mockPermission(context)
-        mockNetworkInfo(cm, isConnected = false)
-
-        assertFalse(sut.isConnected())
+        assertTrue(sut.getNetworkProperties().isEmpty())
     }
 }

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidNetworkStatusTest.kt
@@ -8,6 +8,7 @@ import android.net.NetworkCapabilities
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.posthog.android.mockPermission
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -15,6 +16,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
+import java.util.concurrent.Executor
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -23,9 +25,26 @@ import kotlin.test.assertTrue
 @RunWith(AndroidJUnit4::class)
 internal class PostHogAndroidNetworkStatusTest {
     private val context = mock<Context>()
+    private var elapsedRealtimeMs = 0L
 
-    private fun getSut(): PostHogAndroidNetworkStatus {
-        return PostHogAndroidNetworkStatus(context)
+    private fun getSut(backgroundExecutor: Executor = Executor { it.run() }): PostHogAndroidNetworkStatus {
+        return PostHogAndroidNetworkStatus(
+            context,
+            backgroundExecutor = backgroundExecutor,
+            elapsedRealtimeMs = { elapsedRealtimeMs },
+        )
+    }
+
+    private fun mockCapabilities(
+        wifi: Boolean = false,
+        bluetooth: Boolean = false,
+        cellular: Boolean = false,
+    ): NetworkCapabilities {
+        return mock<NetworkCapabilities>().also {
+            whenever(it.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(wifi)
+            whenever(it.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)).thenReturn(bluetooth)
+            whenever(it.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(cellular)
+        }
     }
 
     @Test
@@ -45,6 +64,31 @@ internal class PostHogAndroidNetworkStatusTest {
     }
 
     @Test
+    fun `isConnected synchronously resolves unknown state`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+
+        assertFalse(sut.isConnected())
+
+        verify(connectivityManager).activeNetwork
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `primes properties off thread before callback delivery`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        val network = mock<Network>()
+        val capabilities = mockCapabilities(wifi = true)
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
+
+        sut.register {}
+
+        assertEquals(true, sut.getNetworkProperties()["\$network_wifi"])
+    }
+
+    @Test
     @Config(sdk = [34])
     fun `updates connectivity and properties from callback`() {
         val sut = getSut()
@@ -56,10 +100,7 @@ internal class PostHogAndroidNetworkStatusTest {
         verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
 
         val network = mock<Network>()
-        val capabilities = mock<NetworkCapabilities>()
-        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(true)
-        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)).thenReturn(false)
-        whenever(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(false)
+        val capabilities = mockCapabilities(wifi = true)
 
         callbackCaptor.firstValue.onAvailable(network)
         callbackCaptor.firstValue.onCapabilitiesChanged(network, capabilities)
@@ -76,6 +117,55 @@ internal class PostHogAndroidNetworkStatusTest {
         )
 
         callbackCaptor.firstValue.onLost(network)
+
+        assertFalse(sut.isConnected())
+        assertTrue(sut.getNetworkProperties().isEmpty())
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `does not restore a previous default network after handover`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        val callbackCaptor = argumentCaptor<ConnectivityManager.NetworkCallback>()
+        sut.register {}
+        verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
+
+        val wifiNetwork = mock<Network>()
+        val cellularNetwork = mock<Network>()
+        callbackCaptor.firstValue.onAvailable(wifiNetwork)
+        callbackCaptor.firstValue.onCapabilitiesChanged(wifiNetwork, mockCapabilities(wifi = true))
+        callbackCaptor.firstValue.onAvailable(cellularNetwork)
+        callbackCaptor.firstValue.onCapabilitiesChanged(cellularNetwork, mockCapabilities(cellular = true))
+
+        // A late callback from the previously-default network must not replace the snapshot.
+        callbackCaptor.firstValue.onCapabilitiesChanged(wifiNetwork, mockCapabilities(wifi = true))
+        assertEquals(true, sut.getNetworkProperties()["\$network_cellular"])
+
+        callbackCaptor.firstValue.onLost(cellularNetwork)
+
+        assertFalse(sut.isConnected())
+        assertTrue(sut.getNetworkProperties().isEmpty())
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `stale background refresh does not restore a lost network`() {
+        val pendingTasks = mutableListOf<Runnable>()
+        val sut = getSut(Executor { pendingTasks.add(it) })
+        val connectivityManager = mockPermission(context)
+        val callbackCaptor = argumentCaptor<ConnectivityManager.NetworkCallback>()
+        val network = mock<Network>()
+        val capabilities = mockCapabilities(wifi = true)
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
+
+        sut.register {}
+        verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
+        callbackCaptor.firstValue.onAvailable(network)
+        callbackCaptor.firstValue.onLost(network)
+
+        pendingTasks.single().run()
 
         assertFalse(sut.isConnected())
         assertTrue(sut.getNetworkProperties().isEmpty())
@@ -103,14 +193,69 @@ internal class PostHogAndroidNetworkStatusTest {
 
     @Test
     @Config(sdk = [23])
-    fun `does not register callback on API 23`() {
+    fun `uses background snapshot fallback on API 23`() {
         val sut = getSut()
         val connectivityManager = mockPermission(context)
+        val network = mock<Network>()
+        val capabilities = mockCapabilities(bluetooth = true)
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
 
         sut.register {}
 
-        verifyNoInteractions(connectivityManager)
-        assertTrue(sut.getNetworkProperties().isEmpty())
+        assertEquals(true, sut.getNetworkProperties()["\$network_bluetooth"])
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `uses background snapshot fallback when callback registration fails`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        val network = mock<Network>()
+        val capabilities = mockCapabilities(cellular = true)
+        whenever(connectivityManager.activeNetwork).thenReturn(network)
+        whenever(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities)
+        whenever(connectivityManager.registerDefaultNetworkCallback(any())).thenThrow(IllegalStateException("limit"))
+
+        sut.register {}
+
+        assertEquals(true, sut.getNetworkProperties()["\$network_cellular"])
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `throttles failed background refreshes`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        whenever(connectivityManager.activeNetwork).thenThrow(IllegalStateException("service unavailable"))
+
+        sut.register {}
+        sut.getNetworkProperties()
+        sut.getNetworkProperties()
+
+        verify(connectivityManager, times(1)).activeNetwork
+    }
+
+    @Test
+    @Config(sdk = [34])
+    fun `polling fallback refreshes stale properties`() {
+        val sut = getSut()
+        val connectivityManager = mockPermission(context)
+        val wifiNetwork = mock<Network>()
+        val cellularNetwork = mock<Network>()
+        val wifiCapabilities = mockCapabilities(wifi = true)
+        val cellularCapabilities = mockCapabilities(cellular = true)
+        whenever(connectivityManager.registerDefaultNetworkCallback(any())).thenThrow(IllegalStateException("limit"))
+        whenever(connectivityManager.activeNetwork).thenReturn(wifiNetwork)
+        whenever(connectivityManager.getNetworkCapabilities(wifiNetwork)).thenReturn(wifiCapabilities)
+        sut.register {}
+        assertEquals(true, sut.getNetworkProperties()["\$network_wifi"])
+
+        whenever(connectivityManager.activeNetwork).thenReturn(cellularNetwork)
+        whenever(connectivityManager.getNetworkCapabilities(cellularNetwork)).thenReturn(cellularCapabilities)
+        elapsedRealtimeMs = 60_000L
+
+        assertEquals(true, sut.getNetworkProperties()["\$network_cellular"])
     }
 
     @Test
@@ -123,13 +268,13 @@ internal class PostHogAndroidNetworkStatusTest {
         verify(connectivityManager).registerDefaultNetworkCallback(callbackCaptor.capture())
 
         val network = mock<Network>()
-        val capabilities = mock<NetworkCapabilities>()
-        callbackCaptor.firstValue.onCapabilitiesChanged(network, capabilities)
+        callbackCaptor.firstValue.onAvailable(network)
+        callbackCaptor.firstValue.onCapabilitiesChanged(network, mockCapabilities(wifi = true))
 
         sut.unregister()
 
         verify(connectivityManager).unregisterNetworkCallback(callbackCaptor.firstValue)
-        assertTrue(sut.isConnected())
+        assertFalse(sut.isConnected())
         assertTrue(sut.getNetworkProperties().isEmpty())
     }
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

Fixes https://github.com/PostHog/posthog-android/issues/653.

`PostHogAndroidContext.getDynamicContext()` synchronously queried `ConnectivityManager.activeNetwork` and `getNetworkCapabilities()` while building every captured event. These calls cross Binder to `system_server`, so captures made from the main thread could block the UI and cause ANRs.

This change maintains connectivity and transport state from `ConnectivityManager.NetworkCallback` instead. Dynamic context now reads an in-memory snapshot, while the existing network-available callback continues flushing queued events. On API 24+, the monitor shares one default-network callback across queue listeners and relies entirely on callback state. API 23 and callback registration failures refresh the snapshot only when `isConnected()` runs on existing SDK worker call sites, because Android cannot observe the default network there via callback. Failed or unavailable connectivity checks degrade gracefully. The monitor also remains lifecycle-managed when consumers provide a custom `PostHogNetworkStatus`.

## :green_heart: How did you test it?

- `make test`
- `make checkFormat`
- Added tests for callback-driven connectivity/property updates without synchronous queries, API 23 and registration-failure worker fallbacks, default-network handovers, listener sharing, late-callback cleanup, custom network status lifecycle, graceful query failures, and repeated dynamic-context reads without querying `ConnectivityManager`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using the `investigate-github-issue` and `pr` workflows. The implementation reuses the existing Android default-network callback and publishes immutable snapshots for lock-free capture-time reads. Where a default-network callback is unavailable, existing worker-thread connectivity checks refresh the snapshot without adding a scheduler or capture-time query. A small lifecycle integration is added only when a consumer-supplied network status prevents the queue from owning the Android monitor.
