### PR TITLE
perf(android): avoid screen and device-type IPC candidates

### DIFF
--- a/.changeset/calm-clocks-rest.md
+++ b/.changeset/calm-clocks-rest.md
@@ -2,4 +2,4 @@
 "posthog-android": patch
 ---
 
-Avoid remaining main-thread IPC candidates in network time, screen autocapture, and device type detection.
+Avoid main-thread IPC candidates in screen autocapture and device type detection.

--- a/.changeset/calm-clocks-rest.md
+++ b/.changeset/calm-clocks-rest.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Avoid remaining main-thread IPC candidates in network time, screen autocapture, and device type detection.

--- a/.changeset/calm-clocks-rest.md
+++ b/.changeset/calm-clocks-rest.md
@@ -2,4 +2,4 @@
 "posthog-android": patch
 ---
 
-Avoid main-thread IPC candidates in screen autocapture and device type detection.
+Avoid main-thread IPC candidates in screen autocapture and device type detection. Screen autocapture now uses the activity's current title, which may produce a different `$screen_name` for `$screen` events when apps set titles dynamically.

--- a/posthog-android/src/main/java/com/posthog/android/internal/DeviceUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/DeviceUtils.kt
@@ -1,6 +1,5 @@
 package com.posthog.android.internal
 
-import android.app.UiModeManager
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
@@ -70,11 +69,9 @@ internal fun getDeviceType(context: Context): String? {
         return "TV"
     }
 
-    val uiManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager?
-    uiManager?.let {
-        if (it.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
-            return "TV"
-        }
+    val uiModeType = context.resources.configuration.uiMode and Configuration.UI_MODE_TYPE_MASK
+    if (uiModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+        return "TV"
     }
 
     val deviceTypeFromResourceConfiguration = getDeviceTypeFromResourceConfiguration(context)

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidContext.kt
@@ -96,6 +96,8 @@ internal class PostHogAndroidContext(
         }
 
         context.telephonyManager()?.let {
+            // TelephonyCallback requires location permission to expose the operator name. Keep this
+            // property read, which primarily uses telephony system properties and cached mapping.
             val networkOperatorName = it.networkOperatorName
             if (!networkOperatorName.isNullOrEmpty()) {
                 dynamicContext["\$network_carrier"] = networkOperatorName

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
@@ -4,17 +4,21 @@ import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.RequiresApi
 import com.posthog.internal.PostHogDateProvider
+import com.posthog.internal.PostHogThreadFactory
 import java.time.Clock
 import java.util.Date
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Provides the current time, corrected to network time when available.
  *
  * [Clock.millis] on the clock returned by [SystemClock.currentNetworkTimeClock] performs a Binder
  * IPC to a system service on every call, so querying it on each timestamp (e.g. on every touch
- * event) blocks the calling thread and can ANR under load. Instead the network time is sampled at
- * most once per [refreshIntervalMs] and subsequent timestamps are derived from the monotonic
- * [android.os.SystemClock.elapsedRealtime] delta since that anchor.
+ * event) blocks the calling thread and can ANR under load. Instead the network time is sampled on
+ * [refreshExecutor] at most once per [refreshIntervalMs], and subsequent timestamps are derived
+ * from the monotonic [android.os.SystemClock.elapsedRealtime] delta since that anchor.
  *
  * Once a sample has succeeded, later sampling failures extend the existing anchor rather than
  * falling back to the system wall clock: the platform's network clock derives time the same way,
@@ -26,6 +30,7 @@ internal class PostHogAndroidDateProvider(
         runCatching { SystemClock.currentNetworkTimeClock() }.getOrNull(),
     private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
     private val refreshIntervalMs: Long = REFRESH_INTERVAL_MS,
+    private val refreshExecutor: Executor = NETWORK_TIME_EXECUTOR,
 ) : PostHogDateProvider {
     // A network-time sample and the elapsedRealtime at which it was taken, published together as a
     // single immutable value so readers never observe a mixed (torn) anchor.
@@ -39,6 +44,8 @@ internal class PostHogAndroidDateProvider(
     // re-run the Binder IPC on every call.
     @Volatile
     private var lastAttemptElapsedMs: Long? = null
+
+    private val refreshInFlight = AtomicBoolean(false)
 
     override fun currentDate(): Date {
         return Date(currentTimeMillis())
@@ -56,17 +63,40 @@ internal class PostHogAndroidDateProvider(
         val lastAttempt = lastAttemptElapsedMs
         val mayAttempt = lastAttempt == null || elapsed - lastAttempt >= refreshIntervalMs
         if (anchorStale && mayAttempt) {
-            lastAttemptElapsedMs = elapsed
-            val networkNow = runCatching { clock.millis() }.getOrNull()
-            if (networkNow != null) {
-                // re-read the monotonic clock: the sample corresponds to the moment millis()
-                // returned, and the IPC itself may have blocked long enough to skew the anchor
-                anchor = Anchor(networkNow, elapsedRealtimeMs())
-                return networkNow
-            }
+            refreshAnchor(clock)
         }
+
         val latest = anchor
-        return if (latest != null) latest.networkMs + (elapsed - latest.elapsedMs) else System.currentTimeMillis()
+        return if (latest != null) {
+            val latestElapsed = if (latest === current) elapsed else elapsedRealtimeMs()
+            latest.networkMs + (latestElapsed - latest.elapsedMs)
+        } else {
+            System.currentTimeMillis()
+        }
+    }
+
+    private fun refreshAnchor(clock: Clock) {
+        if (!refreshInFlight.compareAndSet(false, true)) {
+            return
+        }
+
+        try {
+            refreshExecutor.execute {
+                try {
+                    lastAttemptElapsedMs = elapsedRealtimeMs()
+                    val networkNow = runCatching { clock.millis() }.getOrNull()
+                    if (networkNow != null) {
+                        // Re-read the monotonic clock: the sample corresponds to the moment millis()
+                        // returned, and the IPC itself may have blocked long enough to skew the anchor.
+                        anchor = Anchor(networkNow, elapsedRealtimeMs())
+                    }
+                } finally {
+                    refreshInFlight.set(false)
+                }
+            }
+        } catch (_: Throwable) {
+            refreshInFlight.set(false)
+        }
     }
 
     override fun nanoTime(): Long {
@@ -75,5 +105,7 @@ internal class PostHogAndroidDateProvider(
 
     private companion object {
         private const val REFRESH_INTERVAL_MS = 60_000L
+        private val NETWORK_TIME_EXECUTOR =
+            Executors.newSingleThreadExecutor(PostHogThreadFactory("PostHogNetworkTimeThread"))
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
@@ -4,21 +4,18 @@ import android.os.Build
 import android.os.SystemClock
 import androidx.annotation.RequiresApi
 import com.posthog.internal.PostHogDateProvider
-import com.posthog.internal.PostHogThreadFactory
 import java.time.Clock
 import java.util.Date
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Provides the current time, corrected to network time when available.
  *
- * [Clock.millis] on the clock returned by [SystemClock.currentNetworkTimeClock] performs a Binder
- * IPC to a system service on every call, so querying it on each timestamp (e.g. on every touch
- * event) blocks the calling thread and can ANR under load. Instead the network time is sampled on
- * [refreshExecutor] at most once per [refreshIntervalMs], and subsequent timestamps are derived
- * from the monotonic [android.os.SystemClock.elapsedRealtime] delta since that anchor.
+ * [Clock.millis] on the clock returned by [SystemClock.currentNetworkTimeClock] reads an OS-cached
+ * network-time sample; it does not make an NTP or other network request. Retrieving that cached
+ * sample uses Binder on Android 13-15, while Android 16 can use shared memory with a Binder fallback.
+ * We intentionally accept at most one synchronous IPC per [refreshIntervalMs] to keep this cache
+ * simple. Subsequent timestamps are derived from the monotonic
+ * [android.os.SystemClock.elapsedRealtime] delta since that anchor.
  *
  * Once a sample has succeeded, later sampling failures extend the existing anchor rather than
  * falling back to the system wall clock: the platform's network clock derives time the same way,
@@ -30,7 +27,6 @@ internal class PostHogAndroidDateProvider(
         runCatching { SystemClock.currentNetworkTimeClock() }.getOrNull(),
     private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
     private val refreshIntervalMs: Long = REFRESH_INTERVAL_MS,
-    private val refreshExecutor: Executor = NETWORK_TIME_EXECUTOR,
 ) : PostHogDateProvider {
     // A network-time sample and the elapsedRealtime at which it was taken, published together as a
     // single immutable value so readers never observe a mixed (torn) anchor.
@@ -44,8 +40,6 @@ internal class PostHogAndroidDateProvider(
     // re-run the Binder IPC on every call.
     @Volatile
     private var lastAttemptElapsedMs: Long? = null
-
-    private val refreshInFlight = AtomicBoolean(false)
 
     override fun currentDate(): Date {
         return Date(currentTimeMillis())
@@ -63,40 +57,17 @@ internal class PostHogAndroidDateProvider(
         val lastAttempt = lastAttemptElapsedMs
         val mayAttempt = lastAttempt == null || elapsed - lastAttempt >= refreshIntervalMs
         if (anchorStale && mayAttempt) {
-            refreshAnchor(clock)
-        }
-
-        val latest = anchor
-        return if (latest != null) {
-            val latestElapsed = if (latest === current) elapsed else elapsedRealtimeMs()
-            latest.networkMs + (latestElapsed - latest.elapsedMs)
-        } else {
-            System.currentTimeMillis()
-        }
-    }
-
-    private fun refreshAnchor(clock: Clock) {
-        if (!refreshInFlight.compareAndSet(false, true)) {
-            return
-        }
-
-        try {
-            refreshExecutor.execute {
-                try {
-                    lastAttemptElapsedMs = elapsedRealtimeMs()
-                    val networkNow = runCatching { clock.millis() }.getOrNull()
-                    if (networkNow != null) {
-                        // Re-read the monotonic clock: the sample corresponds to the moment millis()
-                        // returned, and the IPC itself may have blocked long enough to skew the anchor.
-                        anchor = Anchor(networkNow, elapsedRealtimeMs())
-                    }
-                } finally {
-                    refreshInFlight.set(false)
-                }
+            lastAttemptElapsedMs = elapsed
+            val networkNow = runCatching { clock.millis() }.getOrNull()
+            if (networkNow != null) {
+                // re-read the monotonic clock: the sample corresponds to the moment millis()
+                // returned, and the IPC itself may have blocked long enough to skew the anchor
+                anchor = Anchor(networkNow, elapsedRealtimeMs())
+                return networkNow
             }
-        } catch (_: Throwable) {
-            refreshInFlight.set(false)
         }
+        val latest = anchor
+        return if (latest != null) latest.networkMs + (elapsed - latest.elapsedMs) else System.currentTimeMillis()
     }
 
     override fun nanoTime(): Long {
@@ -105,7 +76,5 @@ internal class PostHogAndroidDateProvider(
 
     private companion object {
         private const val REFRESH_INTERVAL_MS = 60_000L
-        private val NETWORK_TIME_EXECUTOR =
-            Executors.newSingleThreadExecutor(PostHogThreadFactory("PostHogNetworkTimeThread"))
     }
 }

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidUtils.kt
@@ -133,21 +133,20 @@ internal fun Context.telephonyManager(): TelephonyManager? {
     return getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
 }
 
-@Suppress("DEPRECATION")
 internal fun Activity.activityLabelOrName(config: PostHogAndroidConfig): String? {
     return try {
-        val activityInfo = packageManager.getActivityInfo(componentName, GET_META_DATA)
-        val activityLabel = activityInfo.loadLabel(packageManager).toString()
+        val activityLabel = title?.toString().orEmpty()
+        val activityName = componentName.className
         val applicationLabel = applicationInfo.loadLabel(packageManager).toString()
 
         if (activityLabel.isNotEmpty() && activityLabel != applicationLabel) {
-            if (activityLabel == activityInfo.name) {
+            if (activityLabel == activityName) {
                 activityLabel.substringAfterLast('.')
             } else {
                 activityLabel
             }
         } else {
-            activityInfo.name.substringAfterLast('.')
+            localClassName.substringAfterLast('.')
         }
     } catch (e: Throwable) {
         config.logger.log("Error getting the Activity's label or name: $e.")

--- a/posthog-android/src/test/java/com/posthog/android/Utils.kt
+++ b/posthog-android/src/test/java/com/posthog/android/Utils.kt
@@ -8,7 +8,6 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.content.pm.ActivityInfo
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
@@ -53,30 +52,19 @@ public fun mockScreenTitle(
 ): Activity {
     val activity = mock<Activity>()
     val pm = mock<PackageManager>()
-    val ac =
-        mock<ActivityInfo>().apply {
-            name = activityName
-        }
     val appInfo = mock<ApplicationInfo>()
 
-    whenever(ac.loadLabel(any())).thenReturn(title)
+    if (throws) {
+        whenever(activity.title).thenThrow(IllegalStateException("title unavailable"))
+    } else {
+        whenever(activity.title).thenReturn(title)
+    }
     whenever(appInfo.loadLabel(any())).thenReturn(applicationLabel)
 
-    if (throws) {
-        whenever(
-            pm.getActivityInfo(
-                any(),
-                any<Int>(),
-            ),
-        ).thenThrow(PackageManager.NameNotFoundException())
-    } else {
-        whenever(pm.getActivityInfo(any(), any<Int>())).thenReturn(ac)
-    }
-
-    whenever(pm.getApplicationInfo(any(), any<Int>())).thenReturn(appInfo)
-
     val component = mock<ComponentName>()
+    whenever(component.className).thenReturn(activityName)
     whenever(activity.componentName).thenReturn(component)
+    whenever(activity.localClassName).thenReturn(activityName)
     whenever(activity.packageManager).thenReturn(pm)
     whenever(activity.applicationInfo).thenReturn(appInfo) // Ensure applicationInfo is not null
 

--- a/posthog-android/src/test/java/com/posthog/android/internal/DeviceUtilsTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/DeviceUtilsTest.kt
@@ -1,0 +1,60 @@
+package com.posthog.android.internal
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.util.DisplayMetrics
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [28])
+internal class DeviceUtilsTest {
+    private fun contextWithConfiguration(configuration: Configuration): Context {
+        val context = mock<Context>()
+        val resources = mock<Resources>()
+        val packageManager = mock<PackageManager>()
+        whenever(context.resources).thenReturn(resources)
+        whenever(context.packageManager).thenReturn(packageManager)
+        whenever(resources.configuration).thenReturn(configuration)
+        whenever(resources.displayMetrics).thenReturn(DisplayMetrics())
+        whenever(packageManager.hasSystemFeature("amazon.hardware.fire_tv")).thenReturn(false)
+        return context
+    }
+
+    @Test
+    fun `returns TV from the local resource configuration`() {
+        val configuration = Configuration()
+        configuration.uiMode = Configuration.UI_MODE_TYPE_TELEVISION or Configuration.UI_MODE_NIGHT_YES
+        val context = contextWithConfiguration(configuration)
+
+        assertEquals("TV", getDeviceType(context))
+        verify(context, never()).getSystemService(Context.UI_MODE_SERVICE)
+    }
+
+    @Test
+    fun `keeps tablet classification for non television UI mode`() {
+        val configuration = Configuration()
+        configuration.uiMode = Configuration.UI_MODE_TYPE_NORMAL
+        configuration.smallestScreenWidthDp = 600
+
+        assertEquals("Tablet", getDeviceType(contextWithConfiguration(configuration)))
+    }
+
+    @Test
+    fun `keeps mobile classification for non television UI mode`() {
+        val configuration = Configuration()
+        configuration.uiMode = Configuration.UI_MODE_TYPE_NORMAL
+        configuration.smallestScreenWidthDp = 599
+
+        assertEquals("Mobile", getDeviceType(contextWithConfiguration(configuration)))
+    }
+}

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
@@ -12,6 +12,7 @@ import com.posthog.android.mockScreenTitle
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -183,7 +184,32 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
     }
 
     @Test
-    fun `onActivityStarted returns activityInfo name if labels are the same`() {
+    fun `onActivityStarted does not query activity info`() {
+        val sut = getSut()
+        val activity = mockScreenTitle(false, "Title", "com.example.MyActivity", "AppLabel")
+        val fake = createPostHogFake()
+
+        sut.install(fake)
+        sut.onActivityStarted(activity)
+        sut.uninstall()
+
+        verify(activity.packageManager, never()).getActivityInfo(any(), any<Int>())
+        assertEquals("Title", fake.screenTitle)
+    }
+
+    @Test
+    fun `onActivityStarted returns activity name when the label is the class name`() {
+        val fake =
+            executeCaptureScreenViewsTest(
+                title = "com.example.MyActivity",
+                activityName = "com.example.MyActivity",
+            )
+
+        assertEquals("MyActivity", fake.screenTitle)
+    }
+
+    @Test
+    fun `onActivityStarted returns activity name if labels are the same`() {
         val fake =
             executeCaptureScreenViewsTest(
                 captureScreenViews = true,

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
@@ -7,6 +7,9 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
+import java.util.ArrayDeque
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,6 +17,23 @@ import kotlin.test.assertEquals
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34]) // PostHogAndroidDateProvider requires API >= TIRAMISU.
 internal class PostHogAndroidDateProviderTest {
+    private val directExecutor = Executor { it.run() }
+
+    private class QueuedExecutor : Executor {
+        private val tasks = ArrayDeque<Runnable>()
+
+        val pendingCount: Int
+            get() = tasks.size
+
+        override fun execute(command: Runnable) {
+            tasks.addLast(command)
+        }
+
+        fun runNext() {
+            tasks.removeFirst().run()
+        }
+    }
+
     private class CountingClock(private val now: Long) : Clock() {
         val millisCalls = AtomicInteger(0)
 
@@ -30,9 +50,65 @@ internal class PostHogAndroidDateProviderTest {
     }
 
     @Test
+    fun `queries the network clock only through the refresh executor`() {
+        val clock = CountingClock(1_000_000L)
+        val executor = QueuedExecutor()
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { 100L },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = executor,
+            )
+
+        repeat(50) { sut.currentTimeMillis() }
+
+        assertEquals(0, clock.millisCalls.get())
+        assertEquals(1, executor.pendingCount)
+
+        executor.runNext()
+
+        assertEquals(1_000_000L, sut.currentTimeMillis())
+        assertEquals(1, clock.millisCalls.get())
+    }
+
+    @Test
+    fun `concurrent callers schedule only one network refresh`() {
+        val clock = CountingClock(1_000_000L)
+        val executor = QueuedExecutor()
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { 100L },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = executor,
+            )
+        val start = CountDownLatch(1)
+        val callers =
+            List(20) {
+                Thread {
+                    start.await()
+                    sut.currentTimeMillis()
+                }.apply { start() }
+            }
+
+        start.countDown()
+        callers.forEach(Thread::join)
+
+        assertEquals(0, clock.millisCalls.get())
+        assertEquals(1, executor.pendingCount)
+    }
+
+    @Test
     fun `does not query the network clock on every call`() {
         val clock = CountingClock(1_000_000L)
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { 100L },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         repeat(50) { sut.currentTimeMillis() }
 
@@ -43,7 +119,13 @@ internal class PostHogAndroidDateProviderTest {
     fun `derives time from the elapsed delta between refreshes`() {
         val clock = CountingClock(1_000_000L)
         var elapsed = 100L
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { elapsed },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         assertEquals(1_000_000L, sut.currentTimeMillis())
         elapsed = 5_100L
@@ -69,7 +151,13 @@ internal class PostHogAndroidDateProviderTest {
     @Test
     fun `does not retry the network clock on every call when sampling fails`() {
         val clock = ThrowingClock()
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { 100L },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         repeat(50) { sut.currentTimeMillis() }
 
@@ -80,7 +168,13 @@ internal class PostHogAndroidDateProviderTest {
     fun `refreshes the anchor after the interval elapses`() {
         val clock = CountingClock(1_000_000L)
         var elapsed = 100L
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { elapsed },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         sut.currentTimeMillis()
         elapsed = 100L + 60_000L
@@ -106,7 +200,13 @@ internal class PostHogAndroidDateProviderTest {
 
                 override fun withZone(zone: ZoneId?): Clock = this
             }
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { elapsed },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         sut.currentTimeMillis()
         elapsed += 1_000L
@@ -118,7 +218,13 @@ internal class PostHogAndroidDateProviderTest {
     fun `retries a failed network sample after the interval elapses`() {
         val clock = ThrowingClock()
         var elapsed = 100L
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { elapsed },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         sut.currentTimeMillis()
         elapsed += 60_000L
@@ -148,7 +254,13 @@ internal class PostHogAndroidDateProviderTest {
     fun `a failed refresh extends the existing anchor instead of falling back to system time`() {
         val clock = SucceedOnceClock(1_000_000L)
         var elapsed = 100L
-        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
+        val sut =
+            PostHogAndroidDateProvider(
+                networkClock = clock,
+                elapsedRealtimeMs = { elapsed },
+                refreshIntervalMs = 60_000L,
+                refreshExecutor = directExecutor,
+            )
 
         assertEquals(1_000_000L, sut.currentTimeMillis())
         elapsed += 65_000L

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
@@ -7,9 +7,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
-import java.util.ArrayDeque
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,23 +14,6 @@ import kotlin.test.assertEquals
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34]) // PostHogAndroidDateProvider requires API >= TIRAMISU.
 internal class PostHogAndroidDateProviderTest {
-    private val directExecutor = Executor { it.run() }
-
-    private class QueuedExecutor : Executor {
-        private val tasks = ArrayDeque<Runnable>()
-
-        val pendingCount: Int
-            get() = tasks.size
-
-        override fun execute(command: Runnable) {
-            tasks.addLast(command)
-        }
-
-        fun runNext() {
-            tasks.removeFirst().run()
-        }
-    }
-
     private class CountingClock(private val now: Long) : Clock() {
         val millisCalls = AtomicInteger(0)
 
@@ -50,65 +30,9 @@ internal class PostHogAndroidDateProviderTest {
     }
 
     @Test
-    fun `queries the network clock only through the refresh executor`() {
-        val clock = CountingClock(1_000_000L)
-        val executor = QueuedExecutor()
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { 100L },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = executor,
-            )
-
-        repeat(50) { sut.currentTimeMillis() }
-
-        assertEquals(0, clock.millisCalls.get())
-        assertEquals(1, executor.pendingCount)
-
-        executor.runNext()
-
-        assertEquals(1_000_000L, sut.currentTimeMillis())
-        assertEquals(1, clock.millisCalls.get())
-    }
-
-    @Test
-    fun `concurrent callers schedule only one network refresh`() {
-        val clock = CountingClock(1_000_000L)
-        val executor = QueuedExecutor()
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { 100L },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = executor,
-            )
-        val start = CountDownLatch(1)
-        val callers =
-            List(20) {
-                Thread {
-                    start.await()
-                    sut.currentTimeMillis()
-                }.apply { start() }
-            }
-
-        start.countDown()
-        callers.forEach(Thread::join)
-
-        assertEquals(0, clock.millisCalls.get())
-        assertEquals(1, executor.pendingCount)
-    }
-
-    @Test
     fun `does not query the network clock on every call`() {
         val clock = CountingClock(1_000_000L)
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { 100L },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)
 
         repeat(50) { sut.currentTimeMillis() }
 
@@ -119,13 +43,7 @@ internal class PostHogAndroidDateProviderTest {
     fun `derives time from the elapsed delta between refreshes`() {
         val clock = CountingClock(1_000_000L)
         var elapsed = 100L
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { elapsed },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
 
         assertEquals(1_000_000L, sut.currentTimeMillis())
         elapsed = 5_100L
@@ -151,13 +69,7 @@ internal class PostHogAndroidDateProviderTest {
     @Test
     fun `does not retry the network clock on every call when sampling fails`() {
         val clock = ThrowingClock()
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { 100L },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)
 
         repeat(50) { sut.currentTimeMillis() }
 
@@ -168,13 +80,7 @@ internal class PostHogAndroidDateProviderTest {
     fun `refreshes the anchor after the interval elapses`() {
         val clock = CountingClock(1_000_000L)
         var elapsed = 100L
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { elapsed },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
 
         sut.currentTimeMillis()
         elapsed = 100L + 60_000L
@@ -200,13 +106,7 @@ internal class PostHogAndroidDateProviderTest {
 
                 override fun withZone(zone: ZoneId?): Clock = this
             }
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { elapsed },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
 
         sut.currentTimeMillis()
         elapsed += 1_000L
@@ -218,13 +118,7 @@ internal class PostHogAndroidDateProviderTest {
     fun `retries a failed network sample after the interval elapses`() {
         val clock = ThrowingClock()
         var elapsed = 100L
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { elapsed },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
 
         sut.currentTimeMillis()
         elapsed += 60_000L
@@ -254,13 +148,7 @@ internal class PostHogAndroidDateProviderTest {
     fun `a failed refresh extends the existing anchor instead of falling back to system time`() {
         val clock = SucceedOnceClock(1_000_000L)
         var elapsed = 100L
-        val sut =
-            PostHogAndroidDateProvider(
-                networkClock = clock,
-                elapsedRealtimeMs = { elapsed },
-                refreshIntervalMs = 60_000L,
-                refreshExecutor = directExecutor,
-            )
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { elapsed }, refreshIntervalMs = 60_000L)
 
         assertEquals(1_000_000L, sut.currentTimeMillis())
         elapsed += 65_000L


### PR DESCRIPTION
## :bulb: Motivation and Context

Screen autocapture queried `ActivityInfo` through `PackageManager` on every `Activity.onStart`, and device-type detection queried `UiModeManager` while building static context. Both paths can run on the main thread and can be served from state already loaded in the process. Screen autocapture now uses the activity's current title, so apps that set titles dynamically may emit a different `$screen_name` for `$screen` events and change report grouping; this is called out in the changeset.

The network-time candidate was also reviewed. Android already caches the synchronized network-time sample, and reading it does not perform an NTP request. This PR therefore keeps the simpler existing once-per-minute synchronous cache and documents that its occasional cached-value IPC is accepted.

## :green_heart: How did you test it?

- `make test`
- `make checkFormat`
- Focused unit tests for screen-name compatibility without `getActivityInfo` and API 28 device-type compatibility

An API 28 Perfetto Binder trace was considered, but no Android device or emulator was connected locally, so this PR does not claim runtime trace verification.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using repository file, shell, Git, Gradle, and GitHub CLI tools. No shareable agent session link was generated. Activity and UI-mode queries use already-loaded local state instead of adding callback/cache complexity. The proposed asynchronous network-time refresh was rolled back after reviewing AOSP: the OS already caches network time, and the existing once-per-minute synchronous read is the simpler accepted tradeoff. `TelephonyManager.networkOperatorName` remains unchanged because the callback alternative would require location permission.
