### PR TITLE
fix: identify anonymous user when id already matches persisted distinct id

### DIFF
--- a/.changeset/eager-maps-leave.md
+++ b/.changeset/eager-maps-leave.md
@@ -1,4 +1,5 @@
 ---
+"posthog": patch
 "posthog-android": patch
 ---
 

--- a/.changeset/eager-maps-leave.md
+++ b/.changeset/eager-maps-leave.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix `identify()` leaving a user anonymous when the supplied ID already matches the persisted distinct ID (for example after a non-identified bootstrap seeded the same ID). The SDK now marks the user identified and captures a person-processed `$set` event.

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1274,14 +1274,23 @@ public class PostHog private constructor(
         }
 
         val hasDifferentDistinctId = previousDistinctId != distinctId
-        val shouldTransitionToIdentified = !hasDifferentDistinctId && !isIdentified
-        if (hasDifferentDistinctId && !isIdentified) {
-            // this has to be set before capture since this flag will be read during the event
-            // capture
-            synchronized(identifiedLock) {
+
+        // Read isIdentified, decide the transition, and persist it atomically so two concurrent
+        // identify() calls on an anonymous user can't both observe isIdentified == false and each
+        // emit a person-processed event for the same identity transition. isIdentified must also be
+        // set before capture() below, which reads it during event enrichment.
+        val shouldIdentify: Boolean
+        val shouldTransitionToIdentified: Boolean
+        synchronized(identifiedLock) {
+            val alreadyIdentified = isIdentified
+            shouldIdentify = hasDifferentDistinctId && !alreadyIdentified
+            shouldTransitionToIdentified = !hasDifferentDistinctId && !alreadyIdentified
+            if (shouldIdentify || shouldTransitionToIdentified) {
                 isIdentified = true
             }
+        }
 
+        if (shouldIdentify) {
             capture(
                 PostHogEventName.IDENTIFY.event,
                 distinctId = distinctId,
@@ -1313,9 +1322,7 @@ public class PostHog private constructor(
             // Matching id while still anonymous (e.g. a non-identified bootstrap seeded the same
             // id): upgrade to identified and emit one person-processed $set — there is no
             // anonymous id to merge, so no $identify (matches posthog-js).
-            synchronized(identifiedLock) {
-                isIdentified = true
-            }
+            // isIdentified was already set above under identifiedLock.
             this.distinctId = distinctId
 
             setPersonPropertiesForFlagsIfNeeded(userProperties, userPropertiesSetOnce)

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -1274,6 +1274,7 @@ public class PostHog private constructor(
         }
 
         val hasDifferentDistinctId = previousDistinctId != distinctId
+        val shouldTransitionToIdentified = !hasDifferentDistinctId && !isIdentified
         if (hasDifferentDistinctId && !isIdentified) {
             // this has to be set before capture since this flag will be read during the event
             // capture
@@ -1308,6 +1309,35 @@ public class PostHog private constructor(
             }
             // we need to make sure the user props update is for the same user
             // otherwise they have to reset and identify again
+        } else if (shouldTransitionToIdentified) {
+            // Matching id while still anonymous (e.g. a non-identified bootstrap seeded the same
+            // id): upgrade to identified and emit one person-processed $set — there is no
+            // anonymous id to merge, so no $identify (matches posthog-js).
+            synchronized(identifiedLock) {
+                isIdentified = true
+            }
+            this.distinctId = distinctId
+
+            setPersonPropertiesForFlagsIfNeeded(userProperties, userPropertiesSetOnce)
+
+            capture(
+                PostHogEventName.SET.event,
+                distinctId = distinctId,
+                userProperties = userProperties ?: emptyMap(),
+                userPropertiesSetOnce = userPropertiesSetOnce ?: emptyMap(),
+            )
+
+            // The transition event must fire even when an identical property call was cached
+            // earlier; cache only after capture so deduplication cannot suppress it.
+            synchronized(cachedPersonPropertiesLock) {
+                cachedPersonPropertiesHash = getPersonPropertiesHash(distinctId, userProperties, userPropertiesSetOnce)
+            }
+
+            // The identified state itself is not part of the flags request; reload only when the
+            // caller supplied properties that can affect flag evaluation.
+            if ((userProperties?.isNotEmpty() == true || userPropertiesSetOnce?.isNotEmpty() == true) && reloadFeatureFlags) {
+                reloadFeatureFlags(config?.onFeatureFlags)
+            }
         } else if (!hasDifferentDistinctId && (userProperties?.isNotEmpty() == true || userPropertiesSetOnce?.isNotEmpty() == true)) {
             if (shouldCapturePersonPropertiesEvent(
                     distinctId,

--- a/posthog/src/test/java/com/posthog/PostHogBootstrapTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogBootstrapTest.kt
@@ -226,6 +226,62 @@ internal class PostHogBootstrapTest {
     }
 
     @Test
+    fun `identify upgrades a non-identified bootstrap whose id matches the identify id`() {
+        val http = mockHttp()
+        val prefs = PostHogMemoryPreferences()
+        // Non-identified bootstrap seeds the id as the anonymous id, so distinct id already
+        // equals the id we later identify with while the user is still anonymous.
+        val sut =
+            getSut(
+                host = http.url("/").toString(),
+                bootstrap = PostHogBootstrapConfig(distinctId = "user-123"),
+                cachePreferences = prefs,
+                reloadFeatureFlags = false,
+            )
+
+        sut.identify("user-123")
+
+        queueExecutor.shutdownAndAwaitTermination()
+
+        // No $identify (nothing to merge); a single person-processed $set marks the transition.
+        val event = firstEvent(http, "\$set")
+        assertEquals("user-123", event.distinctId)
+        assertEquals(true, event.properties?.get("\$process_person_profile"))
+        assertEquals(true, prefs.getValue(IS_IDENTIFIED))
+
+        sut.close()
+        http.shutdown()
+    }
+
+    @Test
+    fun `a repeated matching-id identify does not emit a second set event`() {
+        val http = mockHttp()
+        val prefs = PostHogMemoryPreferences()
+        val sut =
+            getSut(
+                host = http.url("/").toString(),
+                bootstrap = PostHogBootstrapConfig(distinctId = "user-123"),
+                cachePreferences = prefs,
+                reloadFeatureFlags = false,
+                flushAt = 2,
+            )
+
+        sut.identify("user-123") // transition: one $set
+        sut.identify("user-123") // already identified: no event
+        sut.capture("event") // flushes the batch (flushAt = 2)
+
+        queueExecutor.shutdownAndAwaitTermination()
+
+        val batch = serializer.deserialize<PostHogBatchEvent>(http.takeRequest().body.unGzip().reader())!!
+        assertEquals(2, batch.batch.size)
+        assertEquals("\$set", batch.batch[0].event)
+        assertEquals("event", batch.batch[1].event)
+
+        sut.close()
+        http.shutdown()
+    }
+
+    @Test
     fun `blank bootstrap distinct id is a no-op`() {
         val sut = getSut(bootstrap = PostHogBootstrapConfig(distinctId = "   "))
 


### PR DESCRIPTION
## :bulb: Motivation and Context

Calling `identify(id)` where `id` already equals the persisted distinct ID left the user anonymous: no transition fired, no person-processed event was sent, and `$is_identified` stayed false. It's easy to hit after a non-identified bootstrap seeds the same ID.

The SDK now upgrades the user to identified and captures one person-processed `$set` (no `$identify`, since there's no anonymous ID to merge). The transition is decided and persisted atomically under `identifiedLock`, so two concurrent `identify()` calls can't both emit a person event for the same transition. Ports PostHog/posthog-js#4328.

## :green_heart: How did you test it?

Added a regression test for the matching-ID-while-anonymous path in `PostHogBootstrapTest`: the user ends up identified, one `$set` is captured (no `$identify`), and flags reload only when the caller supplies properties that affect evaluation. Ran the unit suite.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
