### PR TITLE
feat(surveys): add opt-in requireDeviceTypeTargeting config

### DIFF
--- a/.changeset/require-device-type-targeting.md
+++ b/.changeset/require-device-type-targeting.md
@@ -1,0 +1,6 @@
+---
+'posthog': minor
+'posthog-android': minor
+---
+
+Add opt-in `PostHogSurveysConfig.requireDeviceTypeTargeting` to exclude surveys without explicit device-type targeting on Android. When enabled, surveys with missing or empty `conditions.deviceTypes` are ineligible; surveys with a non-empty device-type condition continue to use the existing match operators against `Mobile`, `Tablet`, or `TV`.

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -183,8 +183,10 @@ public class PostHogSurveysIntegration(
     }
 
     private fun doesSurveyDeviceTypesMatch(survey: Survey): Boolean {
-        val deviceTypes = survey.conditions?.deviceTypes ?: return true
-        if (deviceTypes.isEmpty()) return true
+        val deviceTypes = survey.conditions?.deviceTypes
+        if (deviceTypes.isNullOrEmpty()) {
+            return !config.surveysConfig.requireDeviceTypeTargeting
+        }
 
         val matchType = defaultMatchType(survey.conditions?.deviceTypesMatchType)
         return surveyValidationMap[matchType]?.invoke(deviceTypes, deviceType) ?: true

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysDeviceTypeTargetingTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysDeviceTypeTargetingTest.kt
@@ -1,0 +1,168 @@
+package com.posthog.android.surveys
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.posthog.PostHogConfig
+import com.posthog.PostHogInterface
+import com.posthog.surveys.Survey
+import com.posthog.surveys.SurveyConditions
+import com.posthog.surveys.SurveyMatchType
+import com.posthog.surveys.SurveyType
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+internal class PostHogSurveysDeviceTypeTargetingTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    private fun createIntegration(requireDeviceTypeTargeting: Boolean): PostHogSurveysIntegration {
+        val config =
+            PostHogConfig("test-api-key").apply {
+                surveys = true
+                surveysConfig.requireDeviceTypeTargeting = requireDeviceTypeTargeting
+            }
+        val integration = PostHogSurveysIntegration(context, config)
+        val fake = mock<PostHogInterface>()
+        whenever(fake.isFeatureEnabled(any(), any(), any())).thenReturn(true)
+        integration.install(fake)
+        return integration
+    }
+
+    private fun createSurvey(
+        id: String,
+        deviceTypes: List<String>?,
+        deviceTypesMatchType: SurveyMatchType? = null,
+    ): Survey {
+        return Survey(
+            id = id,
+            name = "Test Survey $id",
+            type = SurveyType.API,
+            questions = emptyList(),
+            description = null,
+            featureFlagKeys = null,
+            linkedFlagKey = null,
+            targetingFlagKey = null,
+            internalTargetingFlagKey = null,
+            conditions =
+                SurveyConditions(
+                    url = null,
+                    urlMatchType = null,
+                    selector = null,
+                    deviceTypes = deviceTypes,
+                    deviceTypesMatchType = deviceTypesMatchType,
+                    seenSurveyWaitPeriodInDays = null,
+                    events = null,
+                ),
+            appearance = null,
+            currentIteration = null,
+            currentIterationStartDate = null,
+            startDate = java.util.Date(),
+            endDate = null,
+            schedule = null,
+        )
+    }
+
+    private fun isEligible(
+        integration: PostHogSurveysIntegration,
+        surveyId: String,
+    ): Boolean {
+        return integration.getActiveMatchingSurveys().any { it.id == surveyId }
+    }
+
+    @Test
+    fun `default config allows surveys with missing device types`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = false)
+        val survey = createSurvey("s1", deviceTypes = null)
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertTrue(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `default config allows surveys with empty device types`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = false)
+        val survey = createSurvey("s1", deviceTypes = emptyList())
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertTrue(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `requireDeviceTypeTargeting excludes surveys with missing device types`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = true)
+        val survey = createSurvey("s1", deviceTypes = null)
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertFalse(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `requireDeviceTypeTargeting excludes surveys with empty device types`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = true)
+        val survey = createSurvey("s1", deviceTypes = emptyList())
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertFalse(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `requireDeviceTypeTargeting includes surveys with matching device type`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = true)
+        val survey =
+            createSurvey(
+                id = "s1",
+                deviceTypes = listOf("Mobile"),
+                deviceTypesMatchType = SurveyMatchType.EXACT,
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertTrue(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `requireDeviceTypeTargeting excludes surveys with non-matching device type`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = true)
+        val survey =
+            createSurvey(
+                id = "s1",
+                deviceTypes = listOf("Desktop"),
+                deviceTypesMatchType = SurveyMatchType.EXACT,
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertFalse(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `requireDeviceTypeTargeting supports IS_NOT match operator`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = true)
+        val survey =
+            createSurvey(
+                id = "s1",
+                deviceTypes = listOf("Desktop"),
+                deviceTypesMatchType = SurveyMatchType.IS_NOT,
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertTrue(isEligible(integration, "s1"))
+    }
+
+    @Test
+    fun `requireDeviceTypeTargeting supports I_CONTAINS match operator`() {
+        val integration = createIntegration(requireDeviceTypeTargeting = true)
+        val survey =
+            createSurvey(
+                id = "s1",
+                deviceTypes = listOf("mob"),
+                deviceTypesMatchType = SurveyMatchType.I_CONTAINS,
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        assertTrue(isEligible(integration, "s1"))
+    }
+}

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -1826,8 +1826,10 @@ public final class com/posthog/surveys/PostHogSurveyResponse$Text : com/posthog/
 public final class com/posthog/surveys/PostHogSurveysConfig {
 	public fun <init> ()V
 	public final fun getOverrideDisplayLanguage ()Ljava/lang/String;
+	public final fun getRequireDeviceTypeTargeting ()Z
 	public final fun getSurveysDelegate ()Lcom/posthog/surveys/PostHogSurveysDelegate;
 	public final fun setOverrideDisplayLanguage (Ljava/lang/String;)V
+	public final fun setRequireDeviceTypeTargeting (Z)V
 	public final fun setSurveysDelegate (Lcom/posthog/surveys/PostHogSurveysDelegate;)V
 }
 

--- a/posthog/src/main/java/com/posthog/surveys/PostHogSurveysConfig.kt
+++ b/posthog/src/main/java/com/posthog/surveys/PostHogSurveysConfig.kt
@@ -28,4 +28,15 @@ public class PostHogSurveysConfig {
      * Default: `null`.
      */
     public var overrideDisplayLanguage: String? = null
+
+    /**
+     * When enabled, surveys without explicit device-type targeting are excluded.
+     *
+     * If `true`, surveys with missing or empty [SurveyConditions.deviceTypes] are ineligible.
+     * Surveys with a non-empty device-type condition continue to use the existing match
+     * operators against the current device type (`Mobile`, `Tablet`, or `TV`).
+     *
+     * Default: `false` (preserve existing allow-when-unspecified behavior).
+     */
+    public var requireDeviceTypeTargeting: Boolean = false
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

Android currently treats surveys with missing or empty `conditions.deviceTypes` as matching every device. That makes it easy for surveys intended for other platforms (for example web surveys that only set URL/selector conditions) to become eligible on Android, because those web-only conditions are not evaluated by the Android SDK.

This change adds an opt-in `PostHogSurveysConfig.requireDeviceTypeTargeting` flag so apps can require explicit device-type targeting before a survey is eligible.

When `false` (default): preserve existing behavior — missing/empty `deviceTypes` still match.

When `true`:
- Missing `conditions.deviceTypes` does not match
- Empty `conditions.deviceTypes` does not match
- Non-empty conditions continue to use the existing match operators against `Mobile`, `Tablet`, or `TV`

## :green_heart: How did you test it?

- Added `PostHogSurveysDeviceTypeTargetingTest` covering default allow, require-deny for missing/empty, matching and non-matching explicit device types, and existing match operators (`EXACT`, `IS_NOT`, `I_CONTAINS`)
- Ran `:posthog-android:testDebugUnitTest --tests "com.posthog.android.surveys.PostHogSurveysDeviceTypeTargetingTest"`
- Ran `:posthog:test`, `:posthog:apiDump`, and `make checkFormat`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Cursor agent assistance. Approach follows an opt-in SDK config on `PostHogSurveysConfig` rather than a custom survey predicate, so eligibility stays in the existing device-type matching layer and default behavior remains unchanged for other consumers.

Made with [Cursor](https://cursor.com)