### PR TITLE
chore: expand Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,33 @@
 version: 2
 updates:
+  - package-ecosystem: "gradle"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      release-tooling:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - "PostHog/team-client-libraries"
     groups:
       codeql-action:
         patterns:


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot currently updates only GitHub Actions. Gradle and npm dependencies at the repository root also need scheduled update coverage.

This adds weekly Gradle and npm updates with a seven-day cooldown. Each ecosystem uses a catch-all group to keep related updates together. The existing GitHub Actions schedule, cooldown, and CodeQL group remain unchanged, while the explicit reviewer assignment is removed.

## :green_heart: How did you test it?

- Parsed `.github/dependabot.yml` as YAML and checked the exact ecosystem order, root directories, weekly schedules, seven-day cooldowns, groups, patterns, and absence of reviewers.
- Verified the root Gradle and npm manifests, GitHub Actions workflow directory, and CODEOWNERS coverage.
- Ran `make checkFormat`.
- Ran autoreview against `origin/main` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A Pi coding agent made the requested repository configuration change and used the Pi autoreview skill for a final review. The scope was limited to `.github/dependabot.yml`; no package, build, or runtime files changed.
