### PR TITLE
fix(error-tracking): bound the ignoredExceptionTypes cause-chain walk

### DIFF
--- a/.changeset/bound-ignored-exception-walk.md
+++ b/.changeset/bound-ignored-exception-walk.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Bound the `ignoredExceptionTypes` prefilter's cause-chain walk. It previously walked `throwable.cause` with no depth limit and equality-based cycle detection, so a throwable whose `getCause()` returns a fresh object on every call looped forever in the prefilter, and one whose `equals`/`hashCode` misreport identity could stop the walk early and miss an ignored cause. The walk is now identity-based and capped at 50 links; hitting the cap without a match lets the capture proceed rather than dropping the event.

--- a/.changeset/exception-chain-metadata.md
+++ b/.changeset/exception-chain-metadata.md
@@ -4,10 +4,10 @@
 
 Completes the exception-item model in the shared `ThrowableCoercer`:
 
-- Each `$exception_list` item's mechanism now carries `exception_id` (0-based position); cause items get `parent_id` and mechanism `type: "chained"`, the primary item keeps its existing type. A single-item list carries no ids, matching the other SDKs.
+- Each `$exception_list` item's mechanism now carries `exception_id` (0-based position); cause items get `parent_id` and mechanism `type: "chained"`, the primary item keeps its existing type. A single-item list carries no ids, matching the other SDKs. The chain metadata is emitted on the wire; persisting the relationships requires the PostHog-side mechanism-schema change (in flight), which today drops the ids on ingestion.
 - Suppressed exceptions (`Throwable.suppressed`) are serialized with mechanism `type: "suppressed"` and the holder's `parent_id`.
-- Caps: at most 50 items per `$exception_list` (keeps the primary + nearest causes) and 64 frames per stacktrace (keeps the frames nearest the crash).
-- JVM-synthesized frames (lambdas, Spring CGLIB proxies, reflection accessors, dynamic proxies) are flagged with `synthetic: true` rather than dropped.
-- New `PostHogErrorTrackingConfig.inAppExcludes` to force frames out of `in_app` (excludes win over `inAppIncludes`).
+- Caps: at most 50 items per `$exception_list` and 64 frames per stacktrace (keeps the frames nearest the crash). The 50-item cap bounds the traversal itself, so a pathological cause chain cannot be walked without limit.
+- JVM-synthesized frames (lambdas, Spring CGLIB proxies, reflection accessors, dynamic proxies) are flagged with `method_synthetic: true` rather than dropped.
+- New `PostHogErrorTrackingConfig.inAppExcludes` to force frames out of `in_app` (excludes win over `inAppIncludes`). Matching happens against runtime class names before symbolication, so on minified (ProGuard/R8) builds excludes generally will not match and server-side deobfuscation may reclassify frames afterwards; a deobfuscation-aware in-app contract is a follow-up.
 
 All field/key names and `platform: "java"` are unchanged; the additions are backwards compatible on the wire.

--- a/.changeset/exception-chain-metadata.md
+++ b/.changeset/exception-chain-metadata.md
@@ -7,7 +7,7 @@ Completes the exception-item model in the shared `ThrowableCoercer`:
 - Each `$exception_list` item's mechanism now carries `exception_id` (0-based position); cause items get `parent_id` and mechanism `type: "chained"`, the primary item keeps its existing type. A single-item list carries no ids, matching the other SDKs. The chain metadata is emitted on the wire; persisting the relationships requires the PostHog-side mechanism-schema change (in flight), which today drops the ids on ingestion.
 - Suppressed exceptions (`Throwable.suppressed`) are serialized with mechanism `type: "suppressed"` and the holder's `parent_id`.
 - Caps: at most 50 items per `$exception_list` and 64 frames per stacktrace (keeps the frames nearest the crash). The 50-item cap bounds the traversal itself, so a pathological cause chain cannot be walked without limit.
-- JVM-synthesized frames (lambdas, Spring CGLIB proxies, reflection accessors, dynamic proxies) are flagged with `method_synthetic: true` rather than dropped.
+- Compiler-generated frames (JVM and Kotlin lambdas, Android D8/R8 desugared lambdas and outlines, Spring CGLIB proxies, reflection accessors, dynamic proxies) are flagged with `method_synthetic: true` rather than dropped.
 - New `PostHogErrorTrackingConfig.inAppExcludes` to force frames out of `in_app` (excludes win over `inAppIncludes`). Matching happens against runtime class names before symbolication, so on minified (ProGuard/R8) builds excludes generally will not match and server-side deobfuscation may reclassify frames afterwards; a deobfuscation-aware in-app contract is a follow-up.
 
 All field/key names and `platform: "java"` are unchanged; the additions are backwards compatible on the wire.

--- a/.changeset/exception-chain-metadata.md
+++ b/.changeset/exception-chain-metadata.md
@@ -1,0 +1,13 @@
+---
+'posthog': minor
+---
+
+Completes the exception-item model in the shared `ThrowableCoercer`:
+
+- Each `$exception_list` item's mechanism now carries `exception_id` (0-based position); cause items get `parent_id` and mechanism `type: "chained"`, the primary item keeps its existing type. A single-item list carries no ids, matching the other SDKs.
+- Suppressed exceptions (`Throwable.suppressed`) are serialized with mechanism `type: "suppressed"` and the holder's `parent_id`.
+- Caps: at most 50 items per `$exception_list` (keeps the primary + nearest causes) and 64 frames per stacktrace (keeps the frames nearest the crash).
+- JVM-synthesized frames (lambdas, Spring CGLIB proxies, reflection accessors, dynamic proxies) are flagged with `synthetic: true` rather than dropped.
+- New `PostHogErrorTrackingConfig.inAppExcludes` to force frames out of `in_app` (excludes win over `inAppIncludes`).
+
+All field/key names and `platform: "java"` are unchanged; the additions are backwards compatible on the wire.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -540,10 +540,12 @@ public final class com/posthog/errortracking/PostHogErrorTrackingConfig {
 	public fun <init> (ZLjava/util/List;)V
 	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;)V
 	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;)V
-	public synthetic fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoCapture ()Z
 	public final fun getExceptionSteps ()Lcom/posthog/errortracking/PostHogExceptionStepsConfig;
 	public final fun getIgnoredExceptionTypes ()Ljava/util/List;
+	public final fun getInAppExcludes ()Ljava/util/List;
 	public final fun getInAppIncludes ()Ljava/util/List;
 	public final fun setAutoCapture (Z)V
 }
@@ -1156,9 +1158,11 @@ public final class com/posthog/internal/VariantDefinition {
 public final class com/posthog/internal/errortracking/ThrowableCoercer {
 	public static final field EXCEPTION_LEVEL_ATTRIBUTE Ljava/lang/String;
 	public static final field EXCEPTION_LEVEL_FATAL Ljava/lang/String;
+	public static final field MAX_EXCEPTION_LIST_SIZE I
+	public static final field MAX_FRAMES_PER_STACKTRACE I
 	public fun <init> ()V
-	public final fun fromThrowableToPostHogProperties (Ljava/lang/Throwable;Ljava/util/List;Ljava/lang/String;)Ljava/util/Map;
-	public static synthetic fun fromThrowableToPostHogProperties$default (Lcom/posthog/internal/errortracking/ThrowableCoercer;Ljava/lang/Throwable;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/Map;
+	public final fun fromThrowableToPostHogProperties (Ljava/lang/Throwable;Ljava/util/List;Ljava/lang/String;Ljava/util/List;)Ljava/util/Map;
+	public static synthetic fun fromThrowableToPostHogProperties$default (Lcom/posthog/internal/errortracking/ThrowableCoercer;Ljava/lang/Throwable;Ljava/util/List;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ljava/util/Map;
 }
 
 public abstract interface class com/posthog/internal/replay/PostHogSessionReplayHandler {

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -540,8 +540,7 @@ public final class com/posthog/errortracking/PostHogErrorTrackingConfig {
 	public fun <init> (ZLjava/util/List;)V
 	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;)V
 	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;)V
-	public fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZLjava/util/List;Lcom/posthog/errortracking/PostHogExceptionStepsConfig;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAutoCapture ()Z
 	public final fun getExceptionSteps ()Lcom/posthog/errortracking/PostHogExceptionStepsConfig;
 	public final fun getIgnoredExceptionTypes ()Ljava/util/List;

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -857,6 +857,7 @@ public class PostHog private constructor(
                 throwableCoercer.fromThrowableToPostHogProperties(
                     throwable,
                     inAppIncludes = config?.errorTrackingConfig?.inAppIncludes ?: listOf(),
+                    inAppExcludes = config?.errorTrackingConfig?.inAppExcludes ?: listOf(),
                     releaseIdentifier = config?.releaseIdentifier,
                 )
 

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -13,10 +13,18 @@ import com.posthog.internal.PostHogPrintLogger
 import com.posthog.internal.PostHogQueueInterface
 import com.posthog.internal.PostHogThreadFactory
 import com.posthog.internal.errortracking.ThrowableCoercer
+import java.util.Collections
 import java.util.Date
+import java.util.IdentityHashMap
 import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+
+// Hard cap on how many cause links the ignoredExceptionTypes prefilter inspects. Every walk over a
+// user-provided exception graph has to terminate on its own budget: getCause() is user code and may
+// return a fresh throwable on every call, in which case no amount of cycle detection ever stops the
+// loop. Mirrors ThrowableCoercer's MAX_EXCEPTION_LIST_SIZE, far beyond any realistic cause chain.
+private const val MAX_IGNORED_CHECK_CHAIN_LENGTH = 50
 
 public open class PostHogStateless protected constructor(
     private val queueExecutor: ExecutorService =
@@ -628,14 +636,20 @@ public open class PostHogStateless protected constructor(
         throwable: Throwable,
         ignored: List<Class<out Throwable>>,
     ): Class<out Throwable>? {
-        // same cycle detection as ThrowableCoercer, so both walks cover the same chain
-        val seen = hashSetOf<Throwable>()
+        // Identity, not equality: a throwable that overrides equals/hashCode would otherwise be able
+        // to make the walk stop early (false positive cycle) on a chain of genuinely distinct links.
+        val seen = Collections.newSetFromMap(IdentityHashMap<Throwable, Boolean>())
         var current: Throwable? = throwable
-        while (current != null && seen.add(current)) {
+        var depth = 0
+        while (current != null && depth < MAX_IGNORED_CHECK_CHAIN_LENGTH && seen.add(current)) {
             val link = current
             ignored.firstOrNull { it.isInstance(link) }?.let { return it }
             current = link.cause
+            depth++
         }
+        // Reaching the bound without a match reports "not ignored" on purpose, so the capture
+        // proceeds and the coercer serializes what it can. Dropping the event at the limit would
+        // silently lose real errors just for having a long chain.
         return null
     }
 

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -657,6 +657,7 @@ public open class PostHogStateless protected constructor(
                 throwableCoercer.fromThrowableToPostHogProperties(
                     throwable,
                     inAppIncludes = config?.errorTrackingConfig?.inAppIncludes ?: listOf(),
+                    inAppExcludes = config?.errorTrackingConfig?.inAppExcludes ?: listOf(),
                     releaseIdentifier = config?.releaseIdentifier,
                 )
 

--- a/posthog/src/main/java/com/posthog/errortracking/PostHogErrorTrackingConfig.kt
+++ b/posthog/src/main/java/com/posthog/errortracking/PostHogErrorTrackingConfig.kt
@@ -7,6 +7,10 @@ import com.posthog.PostHog
  */
 public class PostHogErrorTrackingConfig
     @JvmOverloads
+    // New options are APPENDED as trailing defaulted params so every previously-shipped
+    // @JvmOverloads constructor overload is kept and existing source stays compatible. This mirrors
+    // how `exceptionSteps` was added (a released minor, core-v6.21.0); as there, the generated
+    // Kotlin `$default` descriptor changes, so consumers using default args recompile on upgrade.
     public constructor(
         /**
          * Enable autocapture of exceptions
@@ -45,4 +49,15 @@ public class PostHogErrorTrackingConfig
          * Defaults to empty.
          */
         public val ignoredExceptionTypes: MutableList<Class<out Throwable>> = mutableListOf(),
+        /**
+         * List of package names to be excluded from inApp frames for error tracking
+         *
+         * inApp Example:
+         * inAppExcludes=["com.thirdparty"]
+         * All Exception stacktrace frames that start with com.thirdparty will NOT be considered inApp
+         *
+         * Excludes win over [inAppIncludes]: a frame matching an exclude prefix is never inApp,
+         * even if it also matches an include prefix.
+         */
+        public val inAppExcludes: MutableList<String> = mutableListOf(),
     )

--- a/posthog/src/main/java/com/posthog/errortracking/PostHogErrorTrackingConfig.kt
+++ b/posthog/src/main/java/com/posthog/errortracking/PostHogErrorTrackingConfig.kt
@@ -7,10 +7,9 @@ import com.posthog.PostHog
  */
 public class PostHogErrorTrackingConfig
     @JvmOverloads
-    // New options are APPENDED as trailing defaulted params so every previously-shipped
-    // @JvmOverloads constructor overload is kept and existing source stays compatible. This mirrors
-    // how `exceptionSteps` was added (a released minor, core-v6.21.0); as there, the generated
-    // Kotlin `$default` descriptor changes, so consumers using default args recompile on upgrade.
+    // Do NOT add new options as constructor params: appending even a defaulted param rewrites the
+    // Kotlin `$default` synthetic constructor descriptor, so already-compiled consumers hit a
+    // NoSuchMethodError on `PostHogErrorTrackingConfig()`. New options go in the class body.
     public constructor(
         /**
          * Enable autocapture of exceptions
@@ -32,6 +31,11 @@ public class PostHogErrorTrackingConfig
          * On Android, We add your app's package name to this list automatically (read from applicationId at runtime)
          *
          * If this list of package names is empty, all frames will be considered inApp
+         *
+         * Matched against the RUNTIME class name, before any symbolication. On a minified build
+         * (ProGuard/R8) the runtime names are the obfuscated ones, so prefixes written against your
+         * source packages generally will not match; PostHog also re-derives `in_app` server-side
+         * after deobfuscation, which can override what the SDK sent.
          */
         public val inAppIncludes: MutableList<String> = mutableListOf(),
         /**
@@ -49,6 +53,7 @@ public class PostHogErrorTrackingConfig
          * Defaults to empty.
          */
         public val ignoredExceptionTypes: MutableList<Class<out Throwable>> = mutableListOf(),
+    ) {
         /**
          * List of package names to be excluded from inApp frames for error tracking
          *
@@ -58,6 +63,15 @@ public class PostHogErrorTrackingConfig
          *
          * Excludes win over [inAppIncludes]: a frame matching an exclude prefix is never inApp,
          * even if it also matches an include prefix.
+         *
+         * Same matching caveats as [inAppIncludes]: prefixes are compared against the RUNTIME class
+         * name before any symbolication, so on minified (ProGuard/R8) builds an exclude written
+         * against your source packages generally will not match, and PostHog's server-side
+         * deobfuscation may reclassify frames as `in_app` afterwards regardless of what the SDK
+         * sent. Making excludes survive deobfuscation needs a server-side in-app contract
+         * (follow-up); until then treat this as best-effort on non-minified builds.
+         *
+         * Defaults to empty.
          */
-        public val inAppExcludes: MutableList<String> = mutableListOf(),
-    )
+        public val inAppExcludes: MutableList<String> = mutableListOf()
+    }

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -162,6 +162,10 @@ public class ThrowableCoercer {
      * set for chained/suppressed items to the id of the throwable this one hangs off.
      * [mechanismType] carries "chained"/"suppressed" for derived items, or the primary throwable's
      * own mechanism ("generic" or the [PostHogThrowable] override) for the first item.
+     *
+     * Note: `exception_id`/`parent_id` are emitted on the wire for parity with the other SDKs, but
+     * PostHog's ingestion currently drops them — its mechanism schema does not model the ids yet, so
+     * the chain relationships are not persisted until that server-side change lands.
      */
     private fun buildExceptionItem(
         throwable: Throwable,

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -41,7 +41,11 @@ public class ThrowableCoercer {
     /**
      * Marks JVM-synthesized "noise" frames (lambdas, CGLIB/Spring proxies, reflection accessors,
      * dynamic proxies) so consumers can de-emphasize them. Frames are kept, never dropped; callers
-     * only add the `synthetic` field when this returns true.
+     * only add the `method_synthetic` field when this returns true.
+     *
+     * `method_synthetic` (not the common `synthetic` field) is the java-specific frame flag: on the
+     * server, frame-level `synthetic` means "this frame was constructed by the SDK", which is a
+     * different claim from "the compiler generated this method".
      */
     private fun isSyntheticFrame(
         className: String,
@@ -134,7 +138,7 @@ public class ThrowableCoercer {
 
             // only present when true; false is the implied default
             if (isSyntheticFrame(frame.className, frame.methodName)) {
-                myFrame["synthetic"] = true
+                myFrame["method_synthetic"] = true
             }
 
             frames.add(myFrame)

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -51,9 +51,21 @@ public class ThrowableCoercer {
         className: String,
         methodName: String,
     ): Boolean {
-        // lambdas: synthetic method `lambda$...` or the invokedynamic-generated `$$Lambda` class
-        if (methodName.startsWith(LAMBDA_METHOD_PREFIX) || className.contains(LAMBDA_CLASS_MARKER)) {
+        // lambdas: javac's synthetic `lambda$...` method, Kotlin's indy-generated `foo$lambda$N`,
+        // or the invokedynamic `$$Lambda` class (also the legacy D8 `-$$Lambda$Foo$hash` form)
+        if (methodName.startsWith(LAMBDA_METHOD_PREFIX) ||
+            methodName.contains(LAMBDA_METHOD_MARKER) ||
+            className.contains(LAMBDA_CLASS_MARKER)
+        ) {
             return true
+        }
+
+        // Android D8/R8 desugaring and outlining, which is the common shape on the Android runtime:
+        // `Foo$$ExternalSyntheticLambda0`, `Foo$$InternalSyntheticLambda$..`, `$$ExternalSyntheticOutline0`
+        DESUGARED_CLASS_MARKERS.forEach { marker ->
+            if (className.contains(marker)) {
+                return true
+            }
         }
 
         // Spring CGLIB generated subclasses / fast-class dispatchers
@@ -352,7 +364,13 @@ public class ThrowableCoercer {
 
         // Synthetic-frame heuristics.
         private const val LAMBDA_METHOD_PREFIX = "lambda$"
+        private const val LAMBDA_METHOD_MARKER = "\$lambda\$"
         private const val LAMBDA_CLASS_MARKER = "\$\$Lambda"
+        private val DESUGARED_CLASS_MARKERS =
+            listOf(
+                "\$\$ExternalSynthetic",
+                "\$\$InternalSynthetic",
+            )
         private val CGLIB_CLASS_MARKERS =
             listOf(
                 "\$\$FastClassBySpringCGLIB\$\$",

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -1,13 +1,29 @@
 package com.posthog.internal.errortracking
 
 import com.posthog.PostHogInternal
+import java.util.Collections
+import java.util.IdentityHashMap
 
 @PostHogInternal
 public class ThrowableCoercer {
+    /**
+     * Decides whether a frame belongs to the user's application (`in_app`).
+     *
+     * Excludes win over includes: a class matching any [inAppExcludes] prefix is never in-app.
+     * With no [inAppIncludes] every remaining frame is in-app (preserves existing Android behavior
+     * where the app package is injected automatically).
+     */
     private fun isInApp(
         className: String,
         inAppIncludes: List<String>,
+        inAppExcludes: List<String>,
     ): Boolean {
+        inAppExcludes.forEach { exclude ->
+            if (className.startsWith(exclude)) {
+                return false
+            }
+        }
+
         // if there's nothing, all frames are considered in app
         if (inAppIncludes.isEmpty()) {
             return true
@@ -22,17 +38,192 @@ public class ThrowableCoercer {
         return false
     }
 
+    /**
+     * Marks JVM-synthesized "noise" frames (lambdas, CGLIB/Spring proxies, reflection accessors,
+     * dynamic proxies) so consumers can de-emphasize them. Frames are kept, never dropped; callers
+     * only add the `synthetic` field when this returns true.
+     */
+    private fun isSyntheticFrame(
+        className: String,
+        methodName: String,
+    ): Boolean {
+        // lambdas: synthetic method `lambda$...` or the invokedynamic-generated `$$Lambda` class
+        if (methodName.startsWith(LAMBDA_METHOD_PREFIX) || className.contains(LAMBDA_CLASS_MARKER)) {
+            return true
+        }
+
+        // Spring CGLIB generated subclasses / fast-class dispatchers
+        CGLIB_CLASS_MARKERS.forEach { marker ->
+            if (className.contains(marker)) {
+                return true
+            }
+        }
+
+        // reflection: generated accessor classes under the reflect internals
+        val isReflectPackage =
+            REFLECT_PACKAGE_PREFIXES.any { className.startsWith(it) }
+        if (isReflectPackage &&
+            REFLECT_ACCESSOR_MARKERS.any { className.contains(it) }
+        ) {
+            return true
+        }
+
+        // JDK dynamic proxies: `com.sun.proxy.$ProxyN` or a simple class name matching `$ProxyN`
+        if (className.startsWith(DYNAMIC_PROXY_PACKAGE_PREFIX) ||
+            DYNAMIC_PROXY_SIMPLE_NAME_REGEX.matches(className.substringAfterLast('.'))
+        ) {
+            return true
+        }
+
+        return false
+    }
+
     @Suppress("DEPRECATION")
     private fun getThreadId(thread: Thread): Long = thread.id
 
+    /**
+     * Builds the `stacktrace` map for a single throwable.
+     *
+     * When a trace exceeds [MAX_FRAMES_PER_STACKTRACE] we keep the frames NEAREST THE CRASH — since
+     * frames are emitted bottom-up that is the tail of the list.
+     */
+    private fun buildStackTrace(
+        stackTraces: Array<StackTraceElement>,
+        inAppIncludes: List<String>,
+        inAppExcludes: List<String>,
+        releaseIdentifier: String?,
+    ): Map<String, Any> {
+        if (stackTraces.isEmpty()) {
+            return emptyMap()
+        }
+
+        // Emit frames bottom-up (canonical order): frames[0] is the outermost/entry point,
+        // the last frame is the crash site. Java's native stackTrace is innermost-first, so reverse it.
+        val ordered = stackTraces.reversed()
+        // keep the crash-side frames (the tail) when trimming
+        val trimmed =
+            if (ordered.size > MAX_FRAMES_PER_STACKTRACE) {
+                ordered.subList(ordered.size - MAX_FRAMES_PER_STACKTRACE, ordered.size)
+            } else {
+                ordered
+            }
+
+        val frames = mutableListOf<Map<String, Any>>()
+        trimmed.forEach { frame ->
+            val myFrame = mutableMapOf<String, Any>()
+
+            myFrame["module"] = frame.className
+            myFrame["function"] = frame.methodName
+            myFrame["platform"] = "java"
+
+            // add release identifier for symbolication
+            if (!releaseIdentifier.isNullOrEmpty()) {
+                myFrame["map_id"] = releaseIdentifier
+            }
+
+            if (frame.lineNumber >= 0) {
+                myFrame["lineno"] = frame.lineNumber
+            }
+
+            val fileName = frame.fileName
+            if (fileName?.isNotEmpty() == true) {
+                myFrame["filename"] = fileName
+            }
+
+            myFrame["in_app"] = isInApp(frame.className, inAppIncludes, inAppExcludes)
+
+            // only present when true; false is the implied default
+            if (isSyntheticFrame(frame.className, frame.methodName)) {
+                myFrame["synthetic"] = true
+            }
+
+            frames.add(myFrame)
+        }
+
+        if (frames.isEmpty()) {
+            return emptyMap()
+        }
+
+        return mapOf(
+            "frames" to frames,
+            "type" to "raw",
+        )
+    }
+
+    /**
+     * Serializes one throwable into an `$exception_list` item.
+     *
+     * [exceptionId] is the item's 0-based position in `$exception_list` and is echoed into the
+     * mechanism; it is null for a single-item list, where the ids carry no information. [parentId] is
+     * set for chained/suppressed items to the id of the throwable this one hangs off.
+     * [mechanismType] carries "chained"/"suppressed" for derived items, or the primary throwable's
+     * own mechanism ("generic" or the [PostHogThrowable] override) for the first item.
+     */
+    private fun buildExceptionItem(
+        throwable: Throwable,
+        exceptionId: Int?,
+        parentId: Int?,
+        handled: Boolean,
+        mechanismType: String,
+        threadId: Long,
+        inAppIncludes: List<String>,
+        inAppExcludes: List<String>,
+        releaseIdentifier: String?,
+    ): Map<String, Any> {
+        val thePackage = throwable.javaClass.`package`
+        val theClass = throwable.javaClass.name
+        val className = if (thePackage != null) theClass.replace(thePackage.name + ".", "") else theClass
+        val exceptionPackage = thePackage?.name
+
+        val mechanism =
+            mutableMapOf<String, Any>(
+                "handled" to handled,
+                "synthetic" to false,
+                "type" to mechanismType,
+            )
+        if (exceptionId != null) {
+            mechanism["exception_id"] = exceptionId
+        }
+        if (parentId != null) {
+            mechanism["parent_id"] = parentId
+        }
+
+        val exception =
+            mutableMapOf<String, Any>(
+                "type" to className,
+                "mechanism" to mechanism,
+                "thread_id" to threadId,
+            )
+
+        throwable.message?.let {
+            if (it.isNotEmpty()) {
+                exception["value"] = it
+            }
+        }
+
+        if (exceptionPackage?.isNotEmpty() == true) {
+            exception["module"] = exceptionPackage
+        }
+
+        val stackTrace = buildStackTrace(throwable.stackTrace, inAppIncludes, inAppExcludes, releaseIdentifier)
+        if (stackTrace.isNotEmpty()) {
+            exception["stacktrace"] = stackTrace
+        }
+
+        return exception
+    }
+
+    // `inAppExcludes` is appended after `releaseIdentifier` so existing positional Kotlin calls stay
+    // valid. This is a `@PostHogInternal` entry point, so the JVM descriptor change is fine.
     public fun fromThrowableToPostHogProperties(
         throwable: Throwable,
         inAppIncludes: List<String> = listOf(),
         releaseIdentifier: String? = null,
+        inAppExcludes: List<String> = listOf(),
     ): MutableMap<String, Any> {
-        val exceptions = mutableListOf<Map<String, Any>>()
-        val throwableList = mutableListOf<Throwable>()
-        val circularDetector = hashSetOf<Throwable>()
+        // Identity-based: a Throwable subclass with value equality (e.g. a Kotlin data class) must
+        // not make two distinct instances collide and drop one from the list.
+        val circularDetector: MutableSet<Throwable> = Collections.newSetFromMap(IdentityHashMap())
 
         var handled = true
         var isFatal = false
@@ -51,99 +242,127 @@ public class ThrowableCoercer {
             threadId = getThreadId(Thread.currentThread())
         }
 
+        // Traversal order (deterministic):
+        //   1. the primary cause chain, root-most last: [main, main.cause, main.cause.cause, ...]
+        //   2. then, in that same order, each throwable's directly-suppressed exceptions appended
+        //      after the chain (one level only — suppressed-of-suppressed is NOT recursed, keeping
+        //      the walk bounded).
+        // exception_id is the 0-based index in this final list; parent_id points at the throwable a
+        // cause/suppressed item hangs off. The list is capped to MAX_EXCEPTION_LIST_SIZE keeping the
+        // earliest (primary + nearest-cause) items.
+        val chain = mutableListOf<Throwable>()
         while (currentThrowable != null && circularDetector.add(currentThrowable)) {
-            throwableList.add(currentThrowable)
+            chain.add(currentThrowable)
             currentThrowable = currentThrowable.cause
         }
 
-        throwableList.forEach { theThrowable ->
-            val thePackage = theThrowable.javaClass.`package`
-            val theClass = theThrowable.javaClass.name
-            val className = if (thePackage != null) theClass.replace(thePackage.name + ".", "") else theClass
-            val exceptionPackage = thePackage?.name
+        val items = mutableListOf<ExceptionRef>()
 
-            val stackTraces = theThrowable.stackTrace
-
-            val stackTrace = mutableMapOf<String, Any>()
-            if (stackTraces.isNotEmpty()) {
-                val frames = mutableListOf<Map<String, Any>>()
-
-                // Emit frames bottom-up (canonical order): frames[0] is the outermost/entry point,
-                // the last frame is the crash site. Java's native stackTrace is innermost-first, so reverse it.
-                stackTraces.reversed().forEach { frame ->
-                    val myFrame = mutableMapOf<String, Any>()
-
-                    myFrame["module"] = frame.className
-                    myFrame["function"] = frame.methodName
-                    myFrame["platform"] = "java"
-
-                    // add release identifier for symbolication
-                    if (!releaseIdentifier.isNullOrEmpty()) {
-                        myFrame["map_id"] = releaseIdentifier
-                    }
-
-                    if (frame.lineNumber >= 0) {
-                        myFrame["lineno"] = frame.lineNumber
-                    }
-
-                    val fileName = frame.fileName
-                    if (fileName?.isNotEmpty() == true) {
-                        myFrame["filename"] = fileName
-                    }
-
-                    myFrame["in_app"] = isInApp(frame.className, inAppIncludes)
-
-                    frames.add(myFrame)
-                }
-
-                if (frames.isNotEmpty()) {
-                    stackTrace["frames"] = frames
-                    stackTrace["type"] = "raw"
-                }
-            }
-
-            // TODO: exception_id and parent_id
-            val exception =
-                mutableMapOf(
-                    "type" to className,
-                    "mechanism" to
-                        mapOf(
-                            "handled" to handled,
-                            "synthetic" to false,
-                            "type" to mechanismType,
-                        ),
-                    "thread_id" to threadId,
-                )
-
-            if (theThrowable.message?.isNotEmpty() == true) {
-                exception["value"] = theThrowable.message
-            }
-
-            if (exceptionPackage?.isNotEmpty() == true) {
-                exception["module"] = exceptionPackage
-            }
-
-            if (stackTrace.isNotEmpty()) {
-                exception["stacktrace"] = stackTrace
-            }
-
-            exceptions.add(exception)
+        // primary cause chain: first item keeps the primary mechanism type; the rest are "chained"
+        // with parent_id = the id of the item they are the cause OF (the previous item).
+        chain.forEachIndexed { index, item ->
+            items.add(
+                ExceptionRef(
+                    throwable = item,
+                    parentId = if (index == 0) null else index - 1,
+                    mechanismType = if (index == 0) mechanismType else "chained",
+                ),
+            )
         }
+
+        // suppressed exceptions: appended after the chain, in chain order, each attributed to its
+        // holder via parent_id and marked mechanism type "suppressed".
+        chain.forEachIndexed { holderId, holder ->
+            holder.suppressed.forEach { suppressed ->
+                if (circularDetector.add(suppressed)) {
+                    items.add(
+                        ExceptionRef(
+                            throwable = suppressed,
+                            parentId = holderId,
+                            mechanismType = "suppressed",
+                        ),
+                    )
+                }
+            }
+        }
+
+        // keep the earliest (root-most primary chain) items when over the cap
+        val cappedItems =
+            if (items.size > MAX_EXCEPTION_LIST_SIZE) {
+                items.subList(0, MAX_EXCEPTION_LIST_SIZE)
+            } else {
+                items
+            }
+
+        // A single-item list needs no chain ids at all (parity with the other SDKs, which only link
+        // a chain when there is more than one exception).
+        val linkChain = cappedItems.size > 1
+
+        val cappedExceptions =
+            cappedItems.mapIndexed { index, ref ->
+                buildExceptionItem(
+                    throwable = ref.throwable,
+                    exceptionId = if (linkChain) index else null,
+                    parentId = if (linkChain) ref.parentId else null,
+                    handled = handled,
+                    mechanismType = ref.mechanismType,
+                    threadId = threadId,
+                    inAppIncludes = inAppIncludes,
+                    inAppExcludes = inAppExcludes,
+                    releaseIdentifier = releaseIdentifier,
+                )
+            }
 
         val exceptionProperties =
             mutableMapOf<String, Any>(
                 EXCEPTION_LEVEL_ATTRIBUTE to if (isFatal) EXCEPTION_LEVEL_FATAL else "error",
             )
 
-        if (exceptions.isNotEmpty()) {
-            exceptionProperties["\$exception_list"] = exceptions
+        if (cappedExceptions.isNotEmpty()) {
+            exceptionProperties["\$exception_list"] = cappedExceptions
         }
 
         return exceptionProperties
     }
 
+    /** A throwable collected during the walk, with its place in the chain, before serialization. */
+    private class ExceptionRef(
+        val throwable: Throwable,
+        val parentId: Int?,
+        val mechanismType: String,
+    )
+
     internal companion object {
         const val EXCEPTION_LEVEL_FATAL = "fatal"
         const val EXCEPTION_LEVEL_ATTRIBUTE = "\$exception_level"
+
+        // Max number of items serialized into `$exception_list`; excess is dropped keeping the
+        // earliest (primary + nearest-cause) items.
+        const val MAX_EXCEPTION_LIST_SIZE = 50
+
+        // Max frames per stacktrace; excess is dropped keeping the frames nearest the crash.
+        const val MAX_FRAMES_PER_STACKTRACE = 64
+
+        // Synthetic-frame heuristics.
+        private const val LAMBDA_METHOD_PREFIX = "lambda$"
+        private const val LAMBDA_CLASS_MARKER = "\$\$Lambda"
+        private val CGLIB_CLASS_MARKERS =
+            listOf(
+                "\$\$FastClassBySpringCGLIB\$\$",
+                "\$\$EnhancerBySpringCGLIB\$\$",
+                "\$\$SpringCGLIB\$\$",
+            )
+        private val REFLECT_PACKAGE_PREFIXES =
+            listOf(
+                "jdk.internal.reflect.",
+                "sun.reflect.",
+            )
+        private val REFLECT_ACCESSOR_MARKERS =
+            listOf(
+                "GeneratedMethodAccessor",
+                "GeneratedConstructorAccessor",
+            )
+        private const val DYNAMIC_PROXY_PACKAGE_PREFIX = "com.sun.proxy."
+        private val DYNAMIC_PROXY_SIMPLE_NAME_REGEX = Regex("\\\$Proxy\\d+")
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
+++ b/posthog/src/main/java/com/posthog/internal/errortracking/ThrowableCoercer.kt
@@ -249,35 +249,41 @@ public class ThrowableCoercer {
         // Traversal order (deterministic):
         //   1. the primary cause chain, root-most last: [main, main.cause, main.cause.cause, ...]
         //   2. then, in that same order, each throwable's directly-suppressed exceptions appended
-        //      after the chain (one level only — suppressed-of-suppressed is NOT recursed, keeping
-        //      the walk bounded).
+        //      after the chain (one level only — suppressed-of-suppressed is NOT recursed).
         // exception_id is the 0-based index in this final list; parent_id points at the throwable a
-        // cause/suppressed item hangs off. The list is capped to MAX_EXCEPTION_LIST_SIZE keeping the
-        // earliest (primary + nearest-cause) items.
-        val chain = mutableListOf<Throwable>()
-        while (currentThrowable != null && circularDetector.add(currentThrowable)) {
-            chain.add(currentThrowable)
-            currentThrowable = currentThrowable.cause
-        }
-
+        // cause/suppressed item hangs off.
+        //
+        // MAX_EXCEPTION_LIST_SIZE bounds the WALK, not just the output: we stop following `cause` as
+        // soon as the list is full and never build an unbounded intermediate collection, so a
+        // pathological chain (very deep, or one whose `cause` mints a fresh throwable on every read
+        // and therefore slips past the identity guard) costs at most the cap.
         val items = mutableListOf<ExceptionRef>()
 
         // primary cause chain: first item keeps the primary mechanism type; the rest are "chained"
         // with parent_id = the id of the item they are the cause OF (the previous item).
-        chain.forEachIndexed { index, item ->
+        while (currentThrowable != null &&
+            items.size < MAX_EXCEPTION_LIST_SIZE &&
+            circularDetector.add(currentThrowable)
+        ) {
+            val index = items.size
             items.add(
                 ExceptionRef(
-                    throwable = item,
+                    throwable = currentThrowable,
                     parentId = if (index == 0) null else index - 1,
                     mechanismType = if (index == 0) mechanismType else "chained",
                 ),
             )
+            currentThrowable = currentThrowable.cause
         }
 
-        // suppressed exceptions: appended after the chain, in chain order, each attributed to its
-        // holder via parent_id and marked mechanism type "suppressed".
-        chain.forEachIndexed { holderId, holder ->
-            holder.suppressed.forEach { suppressed ->
+        // suppressed exceptions fill whatever capacity the chain left over, in chain order, each
+        // attributed to its holder via parent_id and marked mechanism type "suppressed".
+        val chainSize = items.size
+        holders@ for (holderId in 0 until chainSize) {
+            for (suppressed in items[holderId].throwable.suppressed) {
+                if (items.size >= MAX_EXCEPTION_LIST_SIZE) {
+                    break@holders
+                }
                 if (circularDetector.add(suppressed)) {
                     items.add(
                         ExceptionRef(
@@ -290,20 +296,12 @@ public class ThrowableCoercer {
             }
         }
 
-        // keep the earliest (root-most primary chain) items when over the cap
-        val cappedItems =
-            if (items.size > MAX_EXCEPTION_LIST_SIZE) {
-                items.subList(0, MAX_EXCEPTION_LIST_SIZE)
-            } else {
-                items
-            }
-
         // A single-item list needs no chain ids at all (parity with the other SDKs, which only link
         // a chain when there is more than one exception).
-        val linkChain = cappedItems.size > 1
+        val linkChain = items.size > 1
 
         val cappedExceptions =
-            cappedItems.mapIndexed { index, ref ->
+            items.mapIndexed { index, ref ->
                 buildExceptionItem(
                     throwable = ref.throwable,
                     exceptionId = if (linkChain) index else null,
@@ -340,8 +338,9 @@ public class ThrowableCoercer {
         const val EXCEPTION_LEVEL_FATAL = "fatal"
         const val EXCEPTION_LEVEL_ATTRIBUTE = "\$exception_level"
 
-        // Max number of items serialized into `$exception_list`; excess is dropped keeping the
-        // earliest (primary + nearest-cause) items.
+        // Max number of items serialized into `$exception_list`. Bounds the traversal itself: the
+        // cause walk stops here, keeping the earliest (primary + nearest-cause) items, and only then
+        // do suppressed exceptions fill any leftover capacity.
         const val MAX_EXCEPTION_LIST_SIZE = 50
 
         // Max frames per stacktrace; excess is dropped keeping the frames nearest the crash.

--- a/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogStatelessTest.kt
@@ -17,6 +17,7 @@ import org.mockito.kotlin.verify
 import java.io.File
 import java.util.Date
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -25,6 +26,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+// mirrors MAX_IGNORED_CHECK_CHAIN_LENGTH in PostHogStateless, which is file-private
+private const val IGNORED_CHAIN_BOUND = 50
 
 internal class PostHogStatelessTest {
     @get:Rule
@@ -421,6 +425,123 @@ internal class PostHogStatelessTest {
     }
 
     private class IgnoredExceptionStub(message: String) : RuntimeException(message)
+
+    // A cause chain we can shape freely, cycles included, which initCause refuses to build.
+    private open class LinkedExceptionStub(message: String) : RuntimeException(message) {
+        var next: Throwable? = null
+
+        override val cause: Throwable?
+            get() = next
+    }
+
+    // Claims equality with every sibling, which is exactly what defeats a hash-set cycle detector.
+    private open class EqualityLiarExceptionStub(message: String) : LinkedExceptionStub(message) {
+        override fun equals(other: Any?): Boolean = other is EqualityLiarExceptionStub
+
+        override fun hashCode(): Int = 1
+    }
+
+    private class IgnoredEqualityLiarExceptionStub(message: String) : EqualityLiarExceptionStub(message)
+
+    // getCause() is user code: this stub hands back a brand-new throwable on every read, so no
+    // amount of cycle detection can ever stop the walk. It gives up after [chainLength] reads
+    // across the whole chain purely so the test itself can never hang the gradle worker.
+    private class RegeneratingCauseExceptionStub(
+        private val chainLength: Int,
+        val causeReads: AtomicInteger = AtomicInteger(),
+    ) : RuntimeException("regenerating") {
+        override val cause: Throwable?
+            get() =
+                if (causeReads.incrementAndGet() >= chainLength) {
+                    null
+                } else {
+                    RegeneratingCauseExceptionStub(chainLength, causeReads)
+                }
+    }
+
+    private fun createIgnoreFilteringInstance(): TestablePostHogStateless {
+        sut = createStatelessInstance()
+        config = createConfig()
+        config.errorTrackingConfig.ignoredExceptionTypes.add(IgnoredExceptionStub::class.java)
+        config.errorTrackingConfig.ignoredExceptionTypes.add(IgnoredEqualityLiarExceptionStub::class.java)
+        sut.setup(config)
+        return sut
+    }
+
+    @Test
+    fun `isIgnoredThrowable bounds a cause chain that regenerates on every read`() {
+        val sut = createIgnoreFilteringInstance()
+
+        // no object ever repeats, so only the hard bound can end this walk
+        val throwable = RegeneratingCauseExceptionStub(chainLength = 5_000)
+
+        assertFalse(sut.isIgnoredThrowable(throwable))
+        val reads = throwable.causeReads.get()
+        assertTrue(reads <= IGNORED_CHAIN_BOUND, "walked $reads cause links, expected at most $IGNORED_CHAIN_BOUND")
+    }
+
+    @Test
+    fun `isIgnoredThrowable terminates on self and mutual cause cycles`() {
+        val sut = createIgnoreFilteringInstance()
+
+        val selfCycle = LinkedExceptionStub("self")
+        selfCycle.next = selfCycle
+        assertFalse(sut.isIgnoredThrowable(selfCycle))
+
+        val first = LinkedExceptionStub("first")
+        val second = LinkedExceptionStub("second")
+        first.next = second
+        second.next = first
+        assertFalse(sut.isIgnoredThrowable(first))
+    }
+
+    @Test
+    fun `isIgnoredThrowable walks distinct links that claim to be equal`() {
+        val sut = createIgnoreFilteringInstance()
+
+        // an equality-based visited set would stop at the root and miss the ignored cause
+        val root = EqualityLiarExceptionStub("root")
+        root.next = IgnoredEqualityLiarExceptionStub("boom")
+
+        assertTrue(sut.isIgnoredThrowable(root))
+    }
+
+    @Test
+    fun `isIgnoredThrowable matches at the root and inside the bound`() {
+        val sut = createIgnoreFilteringInstance()
+
+        assertTrue(sut.isIgnoredThrowable(IgnoredExceptionStub("boom")))
+
+        val root = LinkedExceptionStub("root")
+        val middle = LinkedExceptionStub("middle")
+        root.next = middle
+        middle.next = IgnoredExceptionStub("boom")
+        assertTrue(sut.isIgnoredThrowable(root))
+    }
+
+    @Test
+    fun `captureExceptionStateless captures when the ignored type sits beyond the walk bound`() {
+        val mockQueue = MockQueue()
+        val sut = createIgnoreFilteringInstance()
+        sut.setMockQueue(mockQueue)
+
+        // ignored type parked deeper than the prefilter is allowed to look
+        var chain: Throwable = IgnoredExceptionStub("boom")
+        repeat(IGNORED_CHAIN_BOUND + 10) {
+            chain = LinkedExceptionStub("link").apply { next = chain }
+        }
+
+        assertFalse(sut.isIgnoredThrowable(chain))
+
+        sut.captureExceptionStateless(chain, distinctId = "user123")
+
+        assertEquals(1, mockQueue.events.size)
+        val event = mockQueue.events.first()
+        assertEquals("\$exception", event.event)
+        @Suppress("UNCHECKED_CAST")
+        val exceptions = event.properties!!["\$exception_list"] as List<Map<String, Any>>
+        assertTrue(exceptions.isNotEmpty())
+    }
 
     @Test
     fun `captureExceptionStateless drops throwables matching ignoredExceptionTypes`() {

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -2781,17 +2781,21 @@ internal class PostHogTest {
         assertEquals("Exception", causeExceptionData["type"])
         assertEquals(threadId, (causeExceptionData["thread_id"] as Number).toLong())
 
-        // Verify mechanism structure for main exception
+        // Verify mechanism structure for main exception: item 0, generic, no parent
         val mechanism = mainException["mechanism"] as Map<*, *>
         assertEquals(true, mechanism["handled"])
         assertEquals(false, mechanism["synthetic"])
         assertEquals("generic", mechanism["type"])
+        assertEquals(0, (mechanism["exception_id"] as Number).toInt())
+        assertFalse(mechanism.containsKey("parent_id"))
 
-        // Verify mechanism structure for cause exception
+        // Verify mechanism structure for cause exception: item 1, chained, parent is item 0
         val causeMechanism = causeExceptionData["mechanism"] as Map<*, *>
         assertEquals(true, causeMechanism["handled"])
         assertEquals(false, causeMechanism["synthetic"])
-        assertEquals("generic", causeMechanism["type"])
+        assertEquals("chained", causeMechanism["type"])
+        assertEquals(1, (causeMechanism["exception_id"] as Number).toInt())
+        assertEquals(0, (causeMechanism["parent_id"] as Number).toInt())
 
         // Verify stack trace structure for main exception
         val stackTraceMainException = mainException["stacktrace"] as Map<*, *>
@@ -2894,6 +2898,9 @@ internal class PostHogTest {
         assertEquals(false, mechanism["handled"])
         assertEquals(false, mechanism["synthetic"])
         assertEquals("UncaughtExceptionHandler", mechanism["type"])
+        // A single-item list carries no chain ids at all.
+        assertFalse(mechanism.containsKey("exception_id"))
+        assertFalse(mechanism.containsKey("parent_id"))
 
         // Verify stack trace structure for main exception
         val stackTraceMainException = mainException["stacktrace"] as Map<*, *>

--- a/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
@@ -168,12 +168,15 @@ internal class ThrowableCoercerTest {
             val t = throwableWith("boom", arrayOf(frame(case.className, case.methodName)))
             val emitted = coercer.fromThrowableToPostHogProperties(t).exceptionList()[0].frames().first()
             if (case.synthetic) {
-                assertEquals(true, emitted["synthetic"], "expected synthetic for ${case.label}")
+                assertEquals(true, emitted["method_synthetic"], "expected method_synthetic for ${case.label}")
             } else {
                 // omitted (not false) when not synthetic
-                assertFalse(emitted.containsKey("synthetic"), "expected no synthetic key for ${case.label}")
-                assertNull(emitted["synthetic"])
+                assertFalse(emitted.containsKey("method_synthetic"), "expected no method_synthetic key for ${case.label}")
+                assertNull(emitted["method_synthetic"])
             }
+            // the compiler-generated flag must never be sent as the common frame-level `synthetic`
+            // field, which the server reads as "SDK-constructed frame"
+            assertFalse(emitted.containsKey("synthetic"), "must not emit frame `synthetic` for ${case.label}")
         }
     }
 

--- a/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
@@ -125,6 +125,46 @@ internal class ThrowableCoercerTest {
     }
 
     @Test
+    fun `bounds the cause walk itself on an endless chain`() {
+        // GrowingCauseThrowable mints a brand new cause on every read, so the identity guard can
+        // never stop it: only a bounded walk terminates here at all.
+        val reads = intArrayOf(0)
+        val t = GrowingCauseThrowable(0, reads)
+
+        val list = coercer.fromThrowableToPostHogProperties(t).exceptionList()
+
+        assertEquals(ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE, list.size)
+        // the walk must stop AT the cap rather than collect everything and slice afterwards
+        assertTrue(
+            reads[0] <= ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE + 1,
+            "expected at most ${ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE + 1} cause reads, got ${reads[0]}",
+        )
+    }
+
+    @Test
+    fun `suppressed exceptions only fill the capacity the chain leaves over`() {
+        val root = throwableWith("root", arrayOf(frame("com.app.Root", "root")))
+        val top = throwableWith("top", arrayOf(frame("com.app.Top", "top")), cause = root)
+        repeat(ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE * 2) { i ->
+            top.addSuppressed(throwableWith("sup$i", arrayOf(frame("com.app.Sup$i", "s"))))
+        }
+
+        val list = coercer.fromThrowableToPostHogProperties(top).exceptionList()
+
+        assertEquals(ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE, list.size)
+        // 2 chain items first, then suppressed items attributed to the holder (id 0) fill the rest
+        assertEquals("generic", list[0].mechanism()["type"])
+        assertEquals("chained", list[1].mechanism()["type"])
+        assertEquals("suppressed", list[2].mechanism()["type"])
+        assertEquals(0, (list[2].mechanism()["parent_id"] as Number).toInt())
+        assertEquals("suppressed", list.last().mechanism()["type"])
+        assertEquals(
+            ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE - 1,
+            (list.last().mechanism()["exception_id"] as Number).toInt(),
+        )
+    }
+
+    @Test
     fun `caps frames per stacktrace keeping the crash-side frames`() {
         val total = ThrowableCoercer.MAX_FRAMES_PER_STACKTRACE + 20
         // JVM order: index 0 is the crash site. Name frames by distance from crash.
@@ -208,6 +248,21 @@ internal class ThrowableCoercerTest {
         assertEquals(false, byModule["com.app.feature.internal.Excluded"]!!["in_app"])
         // outside includes => not in app
         assertEquals(false, byModule["org.thirdparty.Lib"]!!["in_app"])
+    }
+
+    /**
+     * A cause chain with no end: every `cause` read returns a fresh instance, which defeats the
+     * identity-based circular guard. Counts reads so a test can assert the walk is bounded.
+     */
+    private class GrowingCauseThrowable(
+        private val depth: Int,
+        private val reads: IntArray,
+    ) : RuntimeException("depth-$depth") {
+        override val cause: Throwable
+            get() {
+                reads[0]++
+                return GrowingCauseThrowable(depth + 1, reads)
+            }
     }
 
     private class ValueEqualThrowable(private val token: String) : RuntimeException(token) {

--- a/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
@@ -1,0 +1,230 @@
+package com.posthog.internal.errortracking
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class ThrowableCoercerTest {
+    private val coercer = ThrowableCoercer()
+
+    private fun frame(
+        className: String,
+        methodName: String,
+        line: Int = 10,
+        file: String? = "Sample.java",
+    ) = StackTraceElement(className, methodName, file, line)
+
+    private fun throwableWith(
+        message: String,
+        frames: Array<StackTraceElement>,
+        cause: Throwable? = null,
+    ): Throwable {
+        val t = if (cause != null) RuntimeException(message, cause) else RuntimeException(message)
+        t.stackTrace = frames
+        return t
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<String, Any>.exceptionList(): List<Map<String, Any>> = this["\$exception_list"] as List<Map<String, Any>>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<String, Any>.mechanism(): Map<String, Any> = this["mechanism"] as Map<String, Any>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<String, Any>.frames(): List<Map<String, Any>> =
+        (this["stacktrace"] as Map<String, Any>)["frames"] as List<Map<String, Any>>
+
+    @Test
+    fun `omits chain ids for a single exception`() {
+        val t = throwableWith("boom", arrayOf(frame("com.app.Only", "only")))
+
+        val list = coercer.fromThrowableToPostHogProperties(t).exceptionList()
+        assertEquals(1, list.size)
+
+        // nothing to link: no exception_id, no parent_id
+        val mechanism = list[0].mechanism()
+        assertFalse(mechanism.containsKey("exception_id"))
+        assertFalse(mechanism.containsKey("parent_id"))
+        assertEquals("generic", mechanism["type"])
+    }
+
+    @Test
+    fun `exception_id parent_id and chained type across a 3-deep cause chain`() {
+        val root = throwableWith("root", arrayOf(frame("com.app.Root", "root")))
+        val middle = throwableWith("middle", arrayOf(frame("com.app.Mid", "mid")), cause = root)
+        val top = throwableWith("top", arrayOf(frame("com.app.Top", "top")), cause = middle)
+
+        val list = coercer.fromThrowableToPostHogProperties(top).exceptionList()
+        assertEquals(3, list.size)
+
+        // item 0: the primary throwable, generic mechanism, no parent
+        assertEquals("top", list[0]["value"])
+        assertEquals(0, (list[0].mechanism()["exception_id"] as Number).toInt())
+        assertEquals("generic", list[0].mechanism()["type"])
+        assertFalse(list[0].mechanism().containsKey("parent_id"))
+
+        // item 1: cause of item 0
+        assertEquals("middle", list[1]["value"])
+        assertEquals(1, (list[1].mechanism()["exception_id"] as Number).toInt())
+        assertEquals("chained", list[1].mechanism()["type"])
+        assertEquals(0, (list[1].mechanism()["parent_id"] as Number).toInt())
+
+        // item 2: cause of item 1
+        assertEquals("root", list[2]["value"])
+        assertEquals(2, (list[2].mechanism()["exception_id"] as Number).toInt())
+        assertEquals("chained", list[2].mechanism()["type"])
+        assertEquals(1, (list[2].mechanism()["parent_id"] as Number).toInt())
+    }
+
+    @Test
+    fun `serializes suppressed exceptions after the chain with suppressed mechanism`() {
+        val top = throwableWith("top", arrayOf(frame("com.app.Top", "top")))
+        val suppressed = throwableWith("suppressed", arrayOf(frame("com.app.Sup", "sup")))
+        top.addSuppressed(suppressed)
+
+        val list = coercer.fromThrowableToPostHogProperties(top).exceptionList()
+        assertEquals(2, list.size)
+
+        // suppressed item is appended after the chain, attributed to its holder (id 0)
+        assertEquals("suppressed", list[1]["value"])
+        assertEquals("suppressed", list[1].mechanism()["type"])
+        assertEquals(1, (list[1].mechanism()["exception_id"] as Number).toInt())
+        assertEquals(0, (list[1].mechanism()["parent_id"] as Number).toInt())
+    }
+
+    @Test
+    fun `keeps distinct suppressed exceptions that are equal by value`() {
+        // The circular-reference guard is identity-based, so a Throwable subclass with value
+        // equality must not make one of two distinct instances vanish from the list.
+        val top = throwableWith("top", arrayOf(frame("com.app.Top", "top")))
+        top.addSuppressed(ValueEqualThrowable("same"))
+        top.addSuppressed(ValueEqualThrowable("same"))
+
+        val list = coercer.fromThrowableToPostHogProperties(top).exceptionList()
+        assertEquals(3, list.size)
+        assertEquals("suppressed", list[1].mechanism()["type"])
+        assertEquals("suppressed", list[2].mechanism()["type"])
+    }
+
+    @Test
+    fun `caps exception list keeping the earliest root-most items`() {
+        // build a chain deeper than the cap
+        val depth = ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE + 10
+        var current: Throwable = throwableWith("e0", arrayOf(frame("com.app.C0", "m")))
+        for (i in 1 until depth) {
+            current = throwableWith("e$i", arrayOf(frame("com.app.C$i", "m")), cause = current)
+        }
+
+        val list = coercer.fromThrowableToPostHogProperties(current).exceptionList()
+        assertEquals(ThrowableCoercer.MAX_EXCEPTION_LIST_SIZE, list.size)
+        // the earliest (primary) item survives; the deepest causes are dropped
+        assertEquals("e${depth - 1}", list.first()["value"])
+        assertEquals(0, (list.first().mechanism()["exception_id"] as Number).toInt())
+    }
+
+    @Test
+    fun `caps frames per stacktrace keeping the crash-side frames`() {
+        val total = ThrowableCoercer.MAX_FRAMES_PER_STACKTRACE + 20
+        // JVM order: index 0 is the crash site. Name frames by distance from crash.
+        val frames = Array(total) { i -> frame("com.app.F$i", "m$i", line = i) }
+        val t = throwableWith("boom", frames)
+
+        val emitted = coercer.fromThrowableToPostHogProperties(t).exceptionList()[0].frames()
+        assertEquals(ThrowableCoercer.MAX_FRAMES_PER_STACKTRACE, emitted.size)
+        // crash frame (F0) is nearest the crash and must survive as the LAST emitted frame
+        assertEquals("com.app.F0", emitted.last()["module"])
+        // the outermost retained frame is the one MAX_FRAMES-1 away from the crash
+        assertEquals("com.app.F${ThrowableCoercer.MAX_FRAMES_PER_STACKTRACE - 1}", emitted.first()["module"])
+    }
+
+    @Test
+    fun `marks synthetic frames via each heuristic`() {
+        data class Case(val className: String, val methodName: String, val synthetic: Boolean, val label: String)
+
+        val cases =
+            listOf(
+                // lambdas
+                Case("com.app.Service", "lambda\$doWork\$0", true, "lambda method"),
+                Case("com.app.Service\$\$Lambda\$14", "run", true, "lambda class"),
+                // Spring CGLIB
+                Case("com.app.Bean\$\$FastClassBySpringCGLIB\$\$abc", "invoke", true, "spring fastclass"),
+                Case("com.app.Bean\$\$EnhancerBySpringCGLIB\$\$abc", "doStuff", true, "spring enhancer"),
+                Case("com.app.Bean\$\$SpringCGLIB\$\$0", "doStuff", true, "spring cglib"),
+                // reflection accessors
+                Case("jdk.internal.reflect.GeneratedMethodAccessor42", "invoke", true, "jdk generated method accessor"),
+                Case("sun.reflect.GeneratedConstructorAccessor7", "newInstance", true, "sun generated ctor accessor"),
+                // dynamic proxies
+                Case("com.sun.proxy.\$Proxy23", "handle", true, "com.sun.proxy"),
+                Case("com.app.\$Proxy99", "handle", true, "simple-name proxy"),
+                // negatives
+                Case("com.app.RealService", "doWork", false, "ordinary frame"),
+                Case("jdk.internal.reflect.DirectMethodHandleAccessor", "invoke", false, "plain reflect frame (not an accessor)"),
+                Case("com.app.ProxyHelper", "handle", false, "class merely containing Proxy"),
+            )
+
+        cases.forEach { case ->
+            val t = throwableWith("boom", arrayOf(frame(case.className, case.methodName)))
+            val emitted = coercer.fromThrowableToPostHogProperties(t).exceptionList()[0].frames().first()
+            if (case.synthetic) {
+                assertEquals(true, emitted["synthetic"], "expected synthetic for ${case.label}")
+            } else {
+                // omitted (not false) when not synthetic
+                assertFalse(emitted.containsKey("synthetic"), "expected no synthetic key for ${case.label}")
+                assertNull(emitted["synthetic"])
+            }
+        }
+    }
+
+    @Test
+    fun `in_app excludes beat includes`() {
+        val t =
+            throwableWith(
+                "boom",
+                arrayOf(
+                    frame("com.app.feature.Included", "a"),
+                    frame("com.app.feature.internal.Excluded", "b"),
+                    frame("org.thirdparty.Lib", "c"),
+                ),
+            )
+
+        val frames =
+            coercer
+                .fromThrowableToPostHogProperties(
+                    t,
+                    inAppIncludes = listOf("com.app"),
+                    inAppExcludes = listOf("com.app.feature.internal"),
+                ).exceptionList()[0]
+                .frames()
+
+        // frames are reversed; index by module for clarity
+        val byModule = frames.associateBy { it["module"] as String }
+        assertEquals(true, byModule["com.app.feature.Included"]!!["in_app"])
+        // exclude wins even though it also matches the include prefix
+        assertEquals(false, byModule["com.app.feature.internal.Excluded"]!!["in_app"])
+        // outside includes => not in app
+        assertEquals(false, byModule["org.thirdparty.Lib"]!!["in_app"])
+    }
+
+    private class ValueEqualThrowable(private val token: String) : RuntimeException(token) {
+        override fun equals(other: Any?): Boolean = other is ValueEqualThrowable && other.token == token
+
+        override fun hashCode(): Int = token.hashCode()
+    }
+
+    @Test
+    fun `empty includes marks everything in_app by default`() {
+        val t =
+            throwableWith(
+                "boom",
+                arrayOf(
+                    frame("com.app.A", "a"),
+                    frame("org.thirdparty.B", "b"),
+                ),
+            )
+
+        val frames = coercer.fromThrowableToPostHogProperties(t).exceptionList()[0].frames()
+        assertTrue(frames.all { it["in_app"] == true })
+    }
+}

--- a/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/errortracking/ThrowableCoercerTest.kt
@@ -188,6 +188,12 @@ internal class ThrowableCoercerTest {
                 // lambdas
                 Case("com.app.Service", "lambda\$doWork\$0", true, "lambda method"),
                 Case("com.app.Service\$\$Lambda\$14", "run", true, "lambda class"),
+                Case("com.app.MainActivity", "onCreate\$lambda\$3", true, "kotlin indy lambda method"),
+                // Android D8/R8 desugaring: the common shape on the Android runtime
+                Case("com.app.MainActivity\$\$ExternalSyntheticLambda0", "onClick", true, "d8 desugared lambda"),
+                Case("com.app.MainActivity\$\$InternalSyntheticLambda\$1\$abc\$0", "run", true, "d8 internal lambda"),
+                Case("com.app.Repo\$\$ExternalSyntheticOutline0", "m", true, "d8 outlined method"),
+                Case("com.app.-\$\$Lambda\$MainActivity\$abc123", "run", true, "legacy d8 lambda class"),
                 // Spring CGLIB
                 Case("com.app.Bean\$\$FastClassBySpringCGLIB\$\$abc", "invoke", true, "spring fastclass"),
                 Case("com.app.Bean\$\$EnhancerBySpringCGLIB\$\$abc", "doStuff", true, "spring enhancer"),
@@ -202,6 +208,7 @@ internal class ThrowableCoercerTest {
                 Case("com.app.RealService", "doWork", false, "ordinary frame"),
                 Case("jdk.internal.reflect.DirectMethodHandleAccessor", "invoke", false, "plain reflect frame (not an accessor)"),
                 Case("com.app.ProxyHelper", "handle", false, "class merely containing Proxy"),
+                Case("com.app.SyntheticEventBuilder", "build", false, "class merely containing Synthetic"),
             )
 
         cases.forEach { case ->


### PR DESCRIPTION
## :bulb: Motivation and Context

The `ignoredExceptionTypes` prefilter (`findIgnoredTypeInCauseChain`, consulted by both `PostHog.captureException` and `captureExceptionStateless` before coercion) walked `throwable.cause` with equality-based cycle detection and no depth bound. Two ways that hangs the capture caller:

- a throwable whose `getCause()` returns a fresh throwable on every call defeats *any* visited-set cycle detection — the walk loops forever and allocates unboundedly, worst on synchronous crash paths;
- a throwable overriding `equals`/`hashCode` can make the hash-set report a false cycle on genuinely distinct links (early stop, wrong answer) or fail to detect a real one.

(Shipped in #608, spotted during review of #669.)

## Fix semantics

- **Identity-based cycle detection**: `Collections.newSetFromMap(IdentityHashMap())` instead of `hashSetOf`, so user-defined `equals`/`hashCode` can't confuse the walk.
- **Hard bound of 50 links** (`MAX_IGNORED_CHECK_CHAIN_LENGTH`): every traversal of a user-provided exception graph must be bounded independently, since `getCause()` is user code.
- **Proceed on limit**: hitting the bound without a match returns "not ignored", so the capture proceeds rather than dropping the event.

**Stacked on #669** (base `cat/java-et-coercer`; will restack onto `main` after it merges). On that base the coercer's own walk is already identity-based and bounded by `MAX_EXCEPTION_LIST_SIZE = 50`, so this closes the last unbounded traversal of user-provided exception graphs on the capture path. The bound here mirrors that cap; unifying both walks into one shared bounded helper is left as a follow-up so this stays a surgical fix.

## :green_heart: How did you test it?

New unit tests in `PostHogStatelessTest`:

- regenerating-cause throwable (fresh object per `getCause()` read) with an invocation counter — cause reads stay ≤ the bound;
- self-cycle and two-object mutual cycle terminate;
- `equals`/`hashCode`-colliding throwables are still walked by identity — a distinct-but-equal second link matching an ignored type is found;
- match at the root and mid-chain still short-circuits;
- ignored type parked beyond the bound → prefilter returns no match AND `captureExceptionStateless` still enqueues the `$exception` event (truncated chain);
- existing test: a matching ignored type still skips capture.

`make checkFormat`, `make testJava`, and `apiDump` (no public API diff) all pass.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
