### PR TITLE
fix: send the push unregister DELETE even after opt-out (#675)

### DIFF
--- a/.changeset/push-unregister-optout.md
+++ b/.changeset/push-unregister-optout.md
@@ -1,5 +1,6 @@
 ---
 "posthog": patch
+"posthog-android": patch
 ---
 
 Fix: opting out no longer strands an in-flight push unregister. The unregister `DELETE` is data removal, so it now completes even after `setOptOut(true)` instead of leaving the server-side subscription active for the whole opted-out period (#675).

--- a/.changeset/push-unregister-optout.md
+++ b/.changeset/push-unregister-optout.md
@@ -1,5 +1,5 @@
 ---
-"posthog-android": patch
+"posthog": patch
 ---
 
 Fix: opting out no longer strands an in-flight push unregister. The unregister `DELETE` is data removal, so it now completes even after `setOptOut(true)` instead of leaving the server-side subscription active for the whole opted-out period (#675).

--- a/.changeset/push-unregister-optout.md
+++ b/.changeset/push-unregister-optout.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix: opting out no longer strands an in-flight push unregister. The unregister `DELETE` is data removal, so it now completes even after `setOptOut(true)` instead of leaving the server-side subscription active for the whole opted-out period (#675).

--- a/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
@@ -235,7 +235,10 @@ internal class PostHogPushSubscriptionManager(
         pending: PendingUnregister,
         isRetry: Boolean = false,
     ) {
-        if (closed || config.optOut) {
+        // A DELETE removes data rather than collecting it, so opt-out must not block it: gating cleanup
+        // on config.optOut would leave the server-side subscription live for the whole opted-out period.
+        // Opt-out still blocks registration and sends (their own guards keep config.optOut).
+        if (closed) {
             return
         }
         if (pending.distinctId.isBlank() || pending.deviceToken.isBlank() || pending.appId.isBlank()) {
@@ -247,7 +250,7 @@ internal class PostHogPushSubscriptionManager(
             return
         }
         resolveIdentityToken(pending.distinctId, pending.appId) { identityToken ->
-            if (closed || config.optOut) {
+            if (closed) {
                 return@resolveIdentityToken
             }
             // A same-identity same-app registration can queue and even complete while this DELETE's

--- a/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
@@ -12,6 +12,7 @@ import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -359,6 +360,34 @@ internal class PostHogPushSubscriptionManagerTest {
         assertEquals(1, http.requestCount)
     }
 
+    // Reproduction for posthog-android#675: asserts the FIXED behavior, so it fails today.
+    @Test
+    fun `opt-out during an in-flight unregister strands the DELETE (posthog-android#675)`() {
+        val http = mockHttp(total = 2) // register POST, then the unregister DELETE
+        val (sut, config, _) = getSut(http)
+
+        // 1) Register and deliver a token.
+        sut.register("fcm-token", "firebase-project", "android")
+        flush()
+        assertEquals("POST", http.takeRequest().method)
+
+        // 2) The wrapper's opt-out flow: unregister, then opt out. Block the single executor thread so
+        //    opt-out flips config.optOut before the queued unregister task runs (the reported race).
+        val gate = CountDownLatch(1)
+        executor.execute { gate.await() }
+        sut.unregisterCurrent() // queues performUnregister behind the gate
+        config.optOut = true // opt-out lands first
+        gate.countDown() // release: the unregister now runs while opted out
+        flush()
+
+        // A DELETE removes data, so opt-out must not block it. Fails today: the
+        // `if (closed || config.optOut) return` guard strands the DELETE and the server-side
+        // subscription stays active for the whole opted-out period.
+        val delete = http.takeRequest(2, TimeUnit.SECONDS)
+        assertNotNull(delete, "posthog-android#675: opt-out stranded the unregister DELETE; subscription stays active")
+        assertEquals("DELETE", delete.method)
+    }
+
     @Test
     fun `a mint completing after optOut is not cached and opt-in re-mints`() {
         val http = mockHttp(total = 2, response = MockResponse().setBody(""))
@@ -650,7 +679,9 @@ internal class PostHogPushSubscriptionManagerTest {
     }
 
     @Test
-    fun `unregister does not send after optOut`() {
+    fun `unregister still sends the DELETE while opted out`() {
+        // Opt-out blocks registration and sends, but a DELETE is data removal, so it must still go out
+        // (posthog-android#675) — otherwise the server-side subscription outlives the opt-out.
         val http = mockHttp()
         val (sut, config, _) = getSut(http)
         config.optOut = true
@@ -658,7 +689,9 @@ internal class PostHogPushSubscriptionManagerTest {
         sut.unregister("distinct-1", "fcm-token", "firebase-project", "android")
         flush()
 
-        assertEquals(0, http.requestCount)
+        val request = http.takeRequest(2, TimeUnit.SECONDS)
+        assertNotNull(request)
+        assertEquals("DELETE", request.method)
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
@@ -360,7 +360,7 @@ internal class PostHogPushSubscriptionManagerTest {
         assertEquals(1, http.requestCount)
     }
 
-    // Reproduction for posthog-android#675: asserts the FIXED behavior, so it fails today.
+    // Regression test for posthog-android#675: opt-out mid-unregister must still send the DELETE.
     @Test
     fun `opt-out during an in-flight unregister strands the DELETE (posthog-android#675)`() {
         val http = mockHttp(total = 2) // register POST, then the unregister DELETE


### PR DESCRIPTION
## Problem

Opting out did not stop Workflows push. `unregisterPushNotificationToken()` resolves before the DELETE runs, and `performUnregister` began with `if (closed || config.optOut) return`. The normal opt-out flow — `unregisterPushNotificationToken()` then `setOptOut(true)` — let opt-out flip `config.optOut` before the executor ran the unregister, so the DELETE silently parked. The server-side subscription stayed active for the whole opted-out period and Workflows kept delivering to a device that opted out (#675).

## Change

`performUnregister` no longer gates on `config.optOut`, only on `closed`. A DELETE removes data rather than collecting it, so opt-out must block registration and sends but not cleanup. The register and send paths keep their `config.optOut` guards unchanged.

## How did you test this code?

- New unit test `opt-out during an in-flight unregister strands the DELETE (#675)`: registers a token, blocks the manager's single executor thread, queues `unregisterCurrent()` behind it, flips `config.optOut` before it runs, then releases. Asserts a DELETE reaches the mock server. Fails on the pre-fix code (reproduces the bug), passes with the fix.
- Updated the existing opted-out unregister test to assert the DELETE is sent, not skipped.
- Full `PostHogPushSubscriptionManagerTest` suite passes via `./gradlew :posthog:test`.
- Emulator E2E against a local stack (via `adb reverse`). Registered a token, then ran `unregisterPushNotificationToken()` then `optOut()`. The DELETE reached the backend (200). Rebuilt with the pre-fix `config.optOut` guard and the same flow logged the unregister but sent no DELETE.

## Not in this PR

#675 also reports that `optIn()` does not refetch the token or re-register. That half is fixed separately in #689.

> [!NOTE]
> Draft. Directed by @dmarchuk; implemented and verified locally by Claude while @ioannisj is out.
