### PR TITLE
fix(surveys): exclude web-only surveys on Android

### DIFF
--- a/.changeset/exclude-web-only-surveys.md
+++ b/.changeset/exclude-web-only-surveys.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix surveys scoped to web via a CSS selector or URL display condition leaking onto native Android. Surveys with `conditions.url` and/or `conditions.selector` are now excluded from active matching surveys, since those conditions can only be evaluated in a browser DOM. This mirrors the exclusion already shipped in posthog-ios and posthog-react-native.

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -191,6 +191,16 @@ public class PostHogSurveysIntegration(
     }
 
     /**
+     * Returns whether a survey has CSS selector or URL conditions that cannot be
+     * evaluated outside a browser DOM. These surveys are excluded from native
+     * matching even when they also have device-type or event conditions.
+     */
+    private fun hasWebConditions(survey: Survey): Boolean {
+        val conditions = survey.conditions ?: return false
+        return !conditions.url.isNullOrEmpty() || !conditions.selector.isNullOrEmpty()
+    }
+
+    /**
      * Get surveys enabled for the current user.
      * Uses the cached surveys pushed from remote config and filters for active matching surveys.
      *
@@ -232,6 +242,10 @@ public class PostHogSurveysIntegration(
 
             // 2. Filter out surveys that don't match device type
             if (!doesSurveyDeviceTypesMatch(survey)) return@filter false
+
+            // 2.5. Filter out surveys with CSS selector / URL conditions that
+            // cannot be evaluated natively, so they must never display on Android
+            if (hasWebConditions(survey)) return@filter false
 
             // 3. Filter out seen surveys (unless they can activate repeatedly)
             if (getSurveySeen(survey)) return@filter false

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysWebConditionsTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysWebConditionsTest.kt
@@ -1,0 +1,215 @@
+package com.posthog.android.surveys
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.posthog.PostHogConfig
+import com.posthog.PostHogInterface
+import com.posthog.surveys.OnPostHogSurveyClosed
+import com.posthog.surveys.OnPostHogSurveyResponse
+import com.posthog.surveys.OnPostHogSurveyShown
+import com.posthog.surveys.PostHogDisplaySurvey
+import com.posthog.surveys.PostHogSurveysDelegate
+import com.posthog.surveys.Survey
+import com.posthog.surveys.SurveyConditions
+import com.posthog.surveys.SurveyEventCondition
+import com.posthog.surveys.SurveyEventConditions
+import com.posthog.surveys.SurveyMatchType
+import com.posthog.surveys.SurveyType
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests that surveys with web-only display-targeting conditions (a CSS
+ * `selector` and/or `url` match) are excluded from active matching surveys on
+ * Android, since those conditions cannot be evaluated outside a browser DOM.
+ *
+ * This mirrors the exclusion already shipped in posthog-ios and
+ * posthog-react-native, and matches the canonical `surveys` contract in
+ * PostHog/sdk-specs.
+ */
+@RunWith(AndroidJUnit4::class)
+internal class PostHogSurveysWebConditionsTest {
+    private val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    private class RecordingDelegate : PostHogSurveysDelegate {
+        val renderedSurveyIds = mutableListOf<String>()
+
+        override fun renderSurvey(
+            survey: PostHogDisplaySurvey,
+            onSurveyShown: OnPostHogSurveyShown,
+            onSurveyResponse: OnPostHogSurveyResponse,
+            onSurveyClosed: OnPostHogSurveyClosed,
+        ) {
+            renderedSurveyIds.add(survey.id)
+        }
+
+        override fun cleanupSurveys() {}
+    }
+
+    private fun createIntegration(delegate: RecordingDelegate): PostHogSurveysIntegration {
+        val config =
+            PostHogConfig("test-api-key").apply {
+                surveys = true
+                surveysConfig.surveysDelegate = delegate
+            }
+        val integration = PostHogSurveysIntegration(context, config)
+        val fake = mock<PostHogInterface>()
+        whenever(fake.isFeatureEnabled(any(), any(), any())).thenReturn(true)
+        integration.install(fake)
+        return integration
+    }
+
+    private fun createSurvey(
+        id: String,
+        conditions: SurveyConditions?,
+    ): Survey {
+        return Survey(
+            id = id,
+            name = "Test Survey $id",
+            type = SurveyType.POPOVER,
+            questions = emptyList(),
+            description = null,
+            featureFlagKeys = null,
+            linkedFlagKey = null,
+            targetingFlagKey = null,
+            internalTargetingFlagKey = null,
+            conditions = conditions,
+            appearance = null,
+            currentIteration = null,
+            currentIterationStartDate = null,
+            startDate = java.util.Date(),
+            endDate = null,
+            schedule = null,
+        )
+    }
+
+    private fun conditions(
+        url: String? = null,
+        urlMatchType: SurveyMatchType? = null,
+        selector: String? = null,
+        deviceTypes: List<String>? = null,
+        events: SurveyEventConditions? = null,
+    ): SurveyConditions {
+        return SurveyConditions(
+            url = url,
+            urlMatchType = urlMatchType,
+            selector = selector,
+            deviceTypes = deviceTypes,
+            deviceTypesMatchType = null,
+            seenSurveyWaitPeriodInDays = null,
+            events = events,
+        )
+    }
+
+    @Test
+    fun `getActiveMatchingSurveys excludes surveys whose only condition is a url`() {
+        val delegate = RecordingDelegate()
+        val integration = createIntegration(delegate)
+        val webSurvey =
+            createSurvey(
+                "url-only",
+                conditions(url = "https://example.com/pricing", urlMatchType = SurveyMatchType.I_CONTAINS),
+            )
+        integration.onSurveysLoaded(listOf(webSurvey))
+
+        val result = integration.getActiveMatchingSurveys()
+
+        assertFalse(
+            result.any { it.id == "url-only" },
+            "A survey whose only condition is a url should be excluded on Android",
+        )
+    }
+
+    @Test
+    fun `getActiveMatchingSurveys excludes surveys whose only condition is a selector`() {
+        val delegate = RecordingDelegate()
+        val integration = createIntegration(delegate)
+        val webSurvey = createSurvey("selector-only", conditions(selector = "#my-button"))
+        integration.onSurveysLoaded(listOf(webSurvey))
+
+        val result = integration.getActiveMatchingSurveys()
+
+        assertFalse(
+            result.any { it.id == "selector-only" },
+            "A survey whose only condition is a CSS selector should be excluded on Android",
+        )
+    }
+
+    @Test
+    fun `showNextSurvey does not render web-only surveys`() {
+        val delegate = RecordingDelegate()
+        val integration = createIntegration(delegate)
+        val webSurvey = createSurvey("web-only", conditions(url = "https://example.com", selector = "#btn"))
+        integration.onSurveysLoaded(listOf(webSurvey))
+
+        assertFalse(
+            delegate.renderedSurveyIds.contains("web-only"),
+            "Web-only surveys should not be auto-displayed",
+        )
+    }
+
+    @Test
+    fun `getActiveMatchingSurveys excludes surveys with url and native device type targeting`() {
+        val delegate = RecordingDelegate()
+        val integration = createIntegration(delegate)
+        val survey =
+            createSurvey(
+                "url-plus-device",
+                conditions(url = "https://example.com", deviceTypes = listOf("Mobile")),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        val result = integration.getActiveMatchingSurveys()
+
+        assertFalse(
+            result.any { it.id == "url-plus-device" },
+            "A survey with unevaluable URL targeting should be excluded even when its device type matches",
+        )
+    }
+
+    @Test
+    fun `getActiveMatchingSurveys excludes surveys with selector and native event targeting`() {
+        val delegate = RecordingDelegate()
+        val integration = createIntegration(delegate)
+        val survey =
+            createSurvey(
+                "selector-plus-event",
+                conditions(
+                    selector = "#my-button",
+                    events = SurveyEventConditions(repeatedActivation = null, values = listOf(SurveyEventCondition("my_event"))),
+                ),
+            )
+        integration.onSurveysLoaded(listOf(survey))
+
+        // Activate the survey's event so it passes the event-activation filter and
+        // isolates the assertion to the unevaluable web condition.
+        integration.onEvent("my_event", null)
+
+        val result = integration.getActiveMatchingSurveys()
+
+        assertFalse(
+            result.any { it.id == "selector-plus-event" },
+            "A survey with unevaluable selector targeting should be excluded even after its event activates",
+        )
+    }
+
+    @Test
+    fun `getActiveMatchingSurveys keeps surveys with no conditions`() {
+        val delegate = RecordingDelegate()
+        val integration = createIntegration(delegate)
+        val survey = createSurvey("no-conditions", conditions = null)
+        integration.onSurveysLoaded(listOf(survey))
+
+        val result = integration.getActiveMatchingSurveys()
+
+        assertTrue(
+            result.any { it.id == "no-conditions" },
+            "A survey with no display conditions should remain eligible",
+        )
+    }
+}


### PR DESCRIPTION
## :bulb: Motivation and Context

**Why:** Surveys scoped to the web via a CSS `selector` or `url` display condition were leaking onto native Android and rendering as inert prompts with non-functional targeting.

`PostHogSurveysIntegration.getActiveMatchingSurveys()` did not check `conditions.url` or `conditions.selector`. Android cannot evaluate either condition, so matching native device-type or event targeting is not enough to make such a survey eligible.

This brings posthog-android in line with the canonical `surveys` contract in [PostHog/sdk-specs](https://github.com/PostHog/sdk-specs/commit/4623e11a32687e1ee8abe73ca2f051f19ea5662a) and the behavior already shipped in posthog-ios and posthog-react-native.

Analogous of https://github.com/PostHog/posthog-ios/pull/733

### What changed

- Added a filter to exclude surveys with any non-empty `url` or `selector` condition.
- Kept surveys without web conditions eligible for the existing native targeting checks.
- Added regression coverage for URL, selector, device-type, and event-targeting combinations.

## :green_heart: How did you test it?

- `./gradlew :posthog-android:testDebugUnitTest --tests 'com.posthog.android.surveys.PostHogSurveysWebConditionsTest'`
- `make test`
- `make checkFormat`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code. A Changeset entry was added since the repo uses Changesets rather than direct CHANGELOG edits.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
