### PR TITLE
fix: support fractional rollout percentages in local evaluation

### DIFF
--- a/.changeset/fractional-rollout-percentages.md
+++ b/.changeset/fractional-rollout-percentages.md
@@ -1,0 +1,6 @@
+---
+"posthog": patch
+"posthog-server": patch
+---
+
+Support fractional rollout percentages when evaluating feature flags locally.

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -899,7 +899,7 @@ internal class FlagEvaluator(
         flagsByKey: Map<String, FlagDefinition>?,
         evaluationCache: MutableMap<String, Any?>?,
     ): Boolean {
-        val rolloutPercentage = condition.rolloutPercentage
+        val rolloutPercentage = condition.rolloutPercentageDecimal
         val conditionProperties = condition.properties ?: emptyList()
 
         // Check all properties match

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -899,7 +899,7 @@ internal class FlagEvaluator(
         flagsByKey: Map<String, FlagDefinition>?,
         evaluationCache: MutableMap<String, Any?>?,
     ): Boolean {
-        val rolloutPercentage = condition.rolloutPercentageDecimal
+        val rolloutPercentage = condition.rolloutPercentage
         val conditionProperties = condition.properties ?: emptyList()
 
         // Check all properties match

--- a/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
@@ -658,6 +658,45 @@ internal class FlagEvaluatorTest {
     }
 
     @Test
+    internal fun testMatchFeatureFlagPropertiesWithFractionalRollout() {
+        val testCases =
+            listOf(
+                Triple(0.1, "user-2912", true),
+                Triple(0.1, "user-212", false),
+                Triple(0.5, "user-212", true),
+                Triple(100.0, "user-2912", true),
+                Triple(0.0, "user-2912", false),
+                Triple(null, "user-2912", true),
+            )
+
+        for ((rolloutPercentage, distinctId, expected) in testCases) {
+            val json =
+                """
+                {
+                  "id": 1,
+                  "name": "Fractional Rollout Flag",
+                  "key": "fractional-rollout",
+                  "active": true,
+                  "filters": {
+                    "groups": [
+                      {
+                        "properties": [],
+                        "rollout_percentage": $rolloutPercentage
+                      }
+                    ]
+                  },
+                  "version": 1
+                }
+                """.trimIndent()
+
+            val flag = config.serializer.gson.fromJson(json, FlagDefinition::class.java)
+            val result = evaluator.matchFeatureFlagProperties(flag, distinctId, emptyMap())
+
+            assertEquals("rollout $rolloutPercentage for $distinctId", expected, result)
+        }
+    }
+
+    @Test
     internal fun testMatchFeatureFlagPropertiesWithVariant() {
         val flag = createMultiVariateFlag()
         val result = evaluator.matchFeatureFlagProperties(flag, "user-123", emptyMap())

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -637,9 +637,9 @@ public final class com/posthog/internal/FeatureFlagMetadata {
 }
 
 public final class com/posthog/internal/FlagConditionGroup {
-	public fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;)V
 	public final fun getProperties ()Ljava/util/List;
-	public final fun getRolloutPercentage ()Ljava/lang/Integer;
+	public final fun getRolloutPercentage ()Ljava/lang/Double;
 	public final fun getVariant ()Ljava/lang/String;
 }
 

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -637,10 +637,9 @@ public final class com/posthog/internal/FeatureFlagMetadata {
 }
 
 public final class com/posthog/internal/FlagConditionGroup {
-	public fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;)V
 	public final fun getProperties ()Ljava/util/List;
-	public final fun getRolloutPercentage ()Ljava/lang/Integer;
-	public final fun getRolloutPercentageDecimal ()Ljava/lang/Double;
+	public final fun getRolloutPercentage ()Ljava/lang/Double;
 	public final fun getVariant ()Ljava/lang/String;
 }
 

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -637,9 +637,10 @@ public final class com/posthog/internal/FeatureFlagMetadata {
 }
 
 public final class com/posthog/internal/FlagConditionGroup {
-	public fun <init> (Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;)V
 	public final fun getProperties ()Ljava/util/List;
-	public final fun getRolloutPercentage ()Ljava/lang/Double;
+	public final fun getRolloutPercentage ()Ljava/lang/Integer;
+	public final fun getRolloutPercentageDecimal ()Ljava/lang/Double;
 	public final fun getVariant ()Ljava/lang/String;
 }
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
@@ -49,15 +49,10 @@ public class FlagFilters(
 @PostHogInternal
 public class FlagConditionGroup(
     public val properties: List<FlagProperty>?,
-    rolloutPercentage: Int?,
-    public val variant: String?,
-) {
     @SerializedName("rollout_percentage")
-    public val rolloutPercentageDecimal: Double? = rolloutPercentage?.toDouble()
-
-    public val rolloutPercentage: Int?
-        get() = rolloutPercentageDecimal?.toInt()
-}
+    public val rolloutPercentage: Double?,
+    public val variant: String?,
+)
 
 /**
  * A property condition for flag evaluation

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
@@ -50,7 +50,7 @@ public class FlagFilters(
 public class FlagConditionGroup(
     public val properties: List<FlagProperty>?,
     @SerializedName("rollout_percentage")
-    public val rolloutPercentage: Int?,
+    public val rolloutPercentage: Double?,
     public val variant: String?,
 )
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogLocalEvaluationModels.kt
@@ -49,10 +49,15 @@ public class FlagFilters(
 @PostHogInternal
 public class FlagConditionGroup(
     public val properties: List<FlagProperty>?,
-    @SerializedName("rollout_percentage")
-    public val rolloutPercentage: Double?,
+    rolloutPercentage: Int?,
     public val variant: String?,
-)
+) {
+    @SerializedName("rollout_percentage")
+    public val rolloutPercentageDecimal: Double? = rolloutPercentage?.toDouble()
+
+    public val rolloutPercentage: Int?
+        get() = rolloutPercentageDecimal?.toInt()
+}
 
 /**
  * A property condition for flag evaluation


### PR DESCRIPTION
## :bulb: Motivation and Context

Local feature flag definitions can contain fractional condition rollout percentages such as `0.1` or `0.5`. The condition model stored this field as an integer, so Gson rejected fractional definitions before they could be evaluated locally.

This changes the internal condition model to store `rolloutPercentage` as a `Double`, allowing Gson and the local evaluator to preserve fractional values.

## :green_heart: How did you test it?

- `./gradlew :posthog:test :posthog-server:test` using JDK 17
- `make checkFormat`
- `make api`
- `pnpm changeset status`
- Added local evaluator coverage for `0.1`, `0.5`, `100.0`, `0.0`, and `null`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to inspect the local-evaluation path, implement the fix, run the test and formatting checks, and perform an isolated autoreview. Autoreview flagged the changed JVM signature, but `FlagConditionGroup` is annotated `@PostHogInternal` and is public only for the SDK's multi-module architecture. The human DRI chose the direct `Double` type instead of adding a compatibility-only integer property to this internal model.
