### PR TITLE
feat: skip push registration when the project has no integration for the app_id

### DIFF
--- a/.changeset/push-app-ids-gate.md
+++ b/.changeset/push-app-ids-gate.md
@@ -1,0 +1,5 @@
+---
+"posthog": patch
+---
+
+Skip push token registration when the project has no push integration for the app_id, using the `push.appIds` list published in remote config. A device whose project configures push later re-registers on the next config load rather than staying unreachable.

--- a/.changeset/push-app-ids-gate.md
+++ b/.changeset/push-app-ids-gate.md
@@ -1,5 +1,6 @@
 ---
 "posthog": patch
+"posthog-android": patch
 ---
 
 Skip push token registration when the project has no push integration for the app_id, using the `push.appIds` list published in remote config. A device whose project configures push later re-registers on the next config load rather than staying unreachable.

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -962,6 +962,7 @@ public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/intern
 	public fun <init> (Lcom/posthog/PostHogConfig;Lcom/posthog/internal/PostHogApi;Ljava/util/concurrent/ExecutorService;Lcom/posthog/internal/PostHogDefaultPersonPropertiesProvider;Lcom/posthog/internal/PostHogFeatureFlagCalledProvider;Lcom/posthog/internal/PostHogOnRemoteConfigLoaded;)V
 	public synthetic fun <init> (Lcom/posthog/PostHogConfig;Lcom/posthog/internal/PostHogApi;Ljava/util/concurrent/ExecutorService;Lcom/posthog/internal/PostHogDefaultPersonPropertiesProvider;Lcom/posthog/internal/PostHogFeatureFlagCalledProvider;Lcom/posthog/internal/PostHogOnRemoteConfigLoaded;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clear ()V
+	public final fun consumeNewlyRegisterablePushAppIds ()Ljava/util/Set;
 	public final fun getActiveFeatureFlagKeys ()Ljava/util/List;
 	public fun getEvaluatedAt (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/Long;
 	public final fun getEventTriggers ()Ljava/util/Set;
@@ -975,6 +976,7 @@ public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/intern
 	public fun getFeatureFlags (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
 	public final fun getFlagDetails (Ljava/lang/String;)Lcom/posthog/internal/FeatureFlag;
 	public final fun getPersonPropertiesForFlags ()Ljava/util/Map;
+	public final fun getPushAppIds ()Ljava/util/List;
 	public final fun getRecordingMinimumDurationMs ()Ljava/lang/Long;
 	public fun getRequestId (Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/lang/String;
 	public final fun getSessionRecordingSampleRate ()Ljava/lang/Double;
@@ -1001,11 +1003,12 @@ public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/intern
 
 public class com/posthog/internal/PostHogRemoteConfigResponse {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;Ljava/lang/Object;Ljava/lang/Object;)V
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;Ljava/lang/Object;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Boolean;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCapturePerformance ()Ljava/lang/Object;
 	public final fun getErrorTracking ()Ljava/lang/Object;
 	public final fun getHasFeatureFlags ()Ljava/lang/Boolean;
+	public final fun getPush ()Ljava/lang/Object;
 	public final fun getSessionRecording ()Ljava/lang/Object;
 	public final fun getSurveys ()Ljava/lang/Object;
 }

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -994,6 +994,7 @@ public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/intern
 	public final fun loadRemoteConfig (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;)V
 	public static synthetic fun loadRemoteConfig$default (Lcom/posthog/internal/PostHogRemoteConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/posthog/PostHogOnFeatureFlags;Lcom/posthog/PostHogOnFeatureFlags;ILjava/lang/Object;)V
 	public final fun makeSamplingDecision (Ljava/lang/String;)Z
+	public final fun persistPushConfigCache ()V
 	public final fun resetGroupPropertiesForFlags (Ljava/lang/String;)V
 	public static synthetic fun resetGroupPropertiesForFlags$default (Lcom/posthog/internal/PostHogRemoteConfig;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun resetPersonPropertiesForFlags ()V

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -211,7 +211,15 @@ public class PostHog private constructor(
                                 // stopped asking. This is the only signal that reaches it.
                                 remoteConfig?.consumeNewlyRegisterablePushAppIds()?.let { newlyRegisterable ->
                                     if (newlyRegisterable.isNotEmpty()) {
-                                        pushSubscriptionManager?.onPushAppIdsChanged(newlyRegisterable)
+                                        val manager = pushSubscriptionManager
+                                        if (manager != null) {
+                                            // Advance the cached list only after the marker clear is durable.
+                                            manager.onPushAppIdsChanged(newlyRegisterable) {
+                                                remoteConfig?.persistPushConfigCache()
+                                            }
+                                        } else {
+                                            remoteConfig?.persistPushConfigCache()
+                                        }
                                     }
                                 }
                             } catch (e: Throwable) {

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -206,6 +206,18 @@ public class PostHog private constructor(
                                 config.logger.log("Failed to notify surveys loaded: $e.")
                             }
 
+                            try {
+                                // A device whose project had no push integration was answered 200 and
+                                // stopped asking. This is the only signal that reaches it.
+                                remoteConfig?.consumeNewlyRegisterablePushAppIds()?.let { newlyRegisterable ->
+                                    if (newlyRegisterable.isNotEmpty()) {
+                                        pushSubscriptionManager?.onPushAppIdsChanged(newlyRegisterable)
+                                    }
+                                }
+                            } catch (e: Throwable) {
+                                config.logger.log("Failed to re-register push subscription: $e.")
+                            }
+
                             // Notify all integrations about remote config changes
                             notifyIntegrationsRemoteConfig(config, loaded = true)
                         } else {
@@ -242,7 +254,14 @@ public class PostHog private constructor(
                 this.queue = queue
                 this.replayQueue = replayQueue
                 this.logsQueue = logsQueue
-                this.pushSubscriptionManager = PostHogPushSubscriptionManager(config, api, pushExecutor) { distinctId }
+                this.pushSubscriptionManager =
+                    PostHogPushSubscriptionManager(
+                        config,
+                        api,
+                        pushExecutor,
+                        { distinctId },
+                        { remoteConfig?.getPushAppIds() },
+                    )
 
                 if (config.errorTrackingConfig.exceptionSteps.enabled) {
                     val maxBytes = config.errorTrackingConfig.exceptionSteps.maxBytes

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -51,6 +51,7 @@ public interface PostHogPreferences {
         internal const val SURVEYS = "surveys"
         internal const val ERROR_TRACKING = "errorTracking"
         internal const val CAPTURE_PERFORMANCE = "capturePerformance"
+        internal const val PUSH = "push"
         internal const val PERSON_PROPERTIES_FOR_FLAGS = "personPropertiesForFlags"
         internal const val GROUP_PROPERTIES_FOR_FLAGS = "groupPropertiesForFlags"
         public const val SURVEY_SEEN: String = "surveySeen"
@@ -86,6 +87,7 @@ public interface PostHogPreferences {
                 GROUP_PROPERTIES_FOR_FLAGS,
                 ERROR_TRACKING,
                 CAPTURE_PERFORMANCE,
+                PUSH,
             )
     }
 }

--- a/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
@@ -179,26 +179,36 @@ internal class PostHogPushSubscriptionManager(
      * token discarded, but still recorded the send as delivered and stopped asking. Clearing that
      * marker for an app_id that just became registerable is the only thing that reaches it.
      */
-    fun onPushAppIdsChanged(newlyRegisterable: Set<String>) {
+    fun onPushAppIdsChanged(
+        newlyRegisterable: Set<String>,
+        onDurable: () -> Unit = {},
+    ) {
         executor.executeSafely {
-            val record = currentRecord() ?: return@executeSafely
-            if (record.appId !in newlyRegisterable) {
-                // Either nothing changed for this device, or the app_id was already registerable and
-                // the existing delivered marker is honest. Re-sending here would put the request back
-                // on every launch, which is what the marker exists to prevent.
-                return@executeSafely
+            // onDurable advances the cached app_id list. It must run only after any delivered-marker
+            // clear below is durably persisted, and on every path (including the early returns, where
+            // there is no marker to clear), so the cache always eventually advances.
+            try {
+                val record = currentRecord() ?: return@executeSafely
+                if (record.appId !in newlyRegisterable) {
+                    // Either nothing changed for this device, or the app_id was already registerable and
+                    // the existing delivered marker is honest. Re-sending here would put the request back
+                    // on every launch, which is what the marker exists to prevent.
+                    return@executeSafely
+                }
+                if (record.deliveredForDistinctId != null) {
+                    val cleared = record.copy(deliveredForDistinctId = null)
+                    pendingRecord = cleared
+                    pendingFile?.let { writePending(it, cleared, "Failed to persist push subscription") }
+                }
+                retryCount = 0
+                nextAttemptAtMs = 0L
+                halted = false
+                didAuthRetry = false
+                config.logger.log("Push app_id ${record.appId} became registerable; re-registering.")
+                attempt(resetStateOnFold = true)
+            } finally {
+                onDurable()
             }
-            if (record.deliveredForDistinctId != null) {
-                val cleared = record.copy(deliveredForDistinctId = null)
-                pendingRecord = cleared
-                pendingFile?.let { writePending(it, cleared, "Failed to persist push subscription") }
-            }
-            retryCount = 0
-            nextAttemptAtMs = 0L
-            halted = false
-            didAuthRetry = false
-            config.logger.log("Push app_id ${record.appId} became registerable; re-registering.")
-            attempt(resetStateOnFold = true)
         }
     }
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
@@ -499,6 +499,15 @@ internal class PostHogPushSubscriptionManager(
                 config.logger.log("Push subscription send skipped: distinctId changed during identity token mint.")
                 return
             }
+            // Eligibility can also flip during the async mint: remote config may resolve and drop this
+            // app_id. Re-check here so a config that arrived mid-mint isn't ignored, which would POST a
+            // token the server discards and then record it as delivered, suppressing retries.
+            if (!isRegisterable(record.appId)) {
+                config.logger.log(
+                    "Push subscription send skipped: app_id ${record.appId} is not configured for this project.",
+                )
+                return
+            }
             api.pushSubscription(
                 distinctId = distinctId,
                 deviceToken = record.deviceToken,

--- a/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPushSubscriptionManager.kt
@@ -40,6 +40,9 @@ internal class PostHogPushSubscriptionManager(
     private val api: PostHogApi,
     private val executor: ExecutorService,
     private val distinctIdProvider: () -> String,
+    // The app_ids the project accepts registrations for, or null when no server has said.
+    // Null means attempt: a server older than the key must not stop a device registering.
+    private val pushAppIdsProvider: () -> List<String>? = { null },
 ) {
     private val isSending = AtomicBoolean(false)
 
@@ -156,7 +159,47 @@ internal class PostHogPushSubscriptionManager(
             halted = false
             didAuthRetry = false
         }
+        // The record is persisted above whether or not the send is gated, so when the project does
+        // configure push, [onPushAppIdsChanged] has a token to register and does not have to wait for
+        // the app to hand us one again.
         attempt(resetStateOnFold = !isIdenticalUndelivered)
+    }
+
+    // Null means no server has published the list, so we cannot rule the app_id out and must try.
+    private fun isRegisterable(appId: String): Boolean {
+        val appIds = pushAppIdsProvider() ?: return true
+        return appIds.contains(appId)
+    }
+
+    /**
+     * Called when remote config resolves. [newlyRegisterable] are the app_ids that were not
+     * registerable the last time we looked and are now.
+     *
+     * A device that registered while its project had no push integration was answered 200 and had its
+     * token discarded, but still recorded the send as delivered and stopped asking. Clearing that
+     * marker for an app_id that just became registerable is the only thing that reaches it.
+     */
+    fun onPushAppIdsChanged(newlyRegisterable: Set<String>) {
+        executor.executeSafely {
+            val record = currentRecord() ?: return@executeSafely
+            if (record.appId !in newlyRegisterable) {
+                // Either nothing changed for this device, or the app_id was already registerable and
+                // the existing delivered marker is honest. Re-sending here would put the request back
+                // on every launch, which is what the marker exists to prevent.
+                return@executeSafely
+            }
+            if (record.deliveredForDistinctId != null) {
+                val cleared = record.copy(deliveredForDistinctId = null)
+                pendingRecord = cleared
+                pendingFile?.let { writePending(it, cleared, "Failed to persist push subscription") }
+            }
+            retryCount = 0
+            nextAttemptAtMs = 0L
+            halted = false
+            didAuthRetry = false
+            config.logger.log("Push app_id ${record.appId} became registerable; re-registering.")
+            attempt(resetStateOnFold = true)
+        }
     }
 
     fun retryPending() {
@@ -393,6 +436,14 @@ internal class PostHogPushSubscriptionManager(
         // Read the record here, not from the caller: an already-queued executor task can run after
         // unregisterCurrent() cleared it, so a null means "don't send".
         val record = currentRecord() ?: return
+        if (!isRegisterable(record.appId)) {
+            // The project publishes no push integration for this app_id, so the server would accept
+            // the request and throw the token away. Skipping it here is the whole point of the gate.
+            config.logger.log(
+                "Push subscription skipped: app_id ${record.appId} is not configured for this project.",
+            )
+            return
+        }
         if (config.networkStatus?.isConnected() == false) {
             config.logger.log("Push subscription deferred: no network.")
             // Deferral burns no retry attempt and schedules no timer; recovery is driven by

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -13,6 +13,7 @@ import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAG_EVALUATED_
 import com.posthog.internal.PostHogPreferences.Companion.FEATURE_FLAG_REQUEST_ID
 import com.posthog.internal.PostHogPreferences.Companion.FLAGS
 import com.posthog.internal.PostHogPreferences.Companion.MINIMAL_FLAG_CALLED_EVENTS
+import com.posthog.internal.PostHogPreferences.Companion.PUSH
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
 import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.surveys.Survey
@@ -130,6 +131,14 @@ public class PostHogRemoteConfig(
     @Volatile
     private var autoCaptureExceptions = false
 
+    // The app_ids this project accepts push registrations for, or null when we have never heard
+    // from a server that sends the key. Null means "attempt the registration" — an SDK cannot tell an
+    // unconfigured project from a server older than the key, so absent has to stay permissive.
+    @Volatile private var pushAppIds: List<String>? = null
+
+    // app_ids that became registerable on the last /config read, drained by the push manager.
+    @Volatile private var newlyRegisterablePushAppIds: Set<String> = emptySet()
+
     // Set by preloadErrorTrackingConfig when a disk-cached error-tracking config exists at startup.
     // Survives clear()/reset(): it's project-level config, not user data, like the cached config.
     @Volatile
@@ -170,6 +179,7 @@ public class PostHogRemoteConfig(
         preloadSurveys()
         preloadErrorTrackingConfig()
         preloadCapturePerformanceConfig()
+        preloadPushConfig()
         loadCachedPropertiesForFlags()
         // Apply the bootstrap snapshot before any network load so reads serve it immediately.
         synchronized(featureFlagsLock) {
@@ -293,6 +303,7 @@ public class PostHogRemoteConfig(
                         processSurveys(it.surveys)
                         processErrorTrackingConfig(it.errorTracking)
                         processCapturePerformanceConfig(it.capturePerformance)
+                        newlyRegisterablePushAppIds = processPushConfig(it.push)
 
                         val hasFlags = it.hasFeatureFlags ?: false
 
@@ -631,6 +642,70 @@ public class PostHogRemoteConfig(
     // Restores capture performance config from cache (survives reset); re-armed on a /flags reload.
     // capturePerformance is read from the cache by the caller (off featureFlagsLock, since that read
     // can hit disk); this only re-evaluates it in memory.
+    /**
+     * Parses the `push` slice and returns the app_ids that became registerable since the last time
+     * we looked, so the push manager can re-register a device that was stuck.
+     *
+     * A missing key clears the cache rather than keeping it: a server that stops sending the key is
+     * treated as one that never sent it, which means "attempt the registration" and never silently
+     * withholds a device from a project that has push.
+     */
+    private fun processPushConfig(
+        push: Any?,
+        persist: Boolean = true,
+    ): Set<String> {
+        // Absent for the comparison means the empty set, not unknown. The first launch that ever sees
+        // the key therefore treats every configured app_id as new, which re-registers a device that
+        // recorded a success while its project had no integration. That costs one request per device,
+        // once, and it is the only way to reach a device whose project was configured before it
+        // updated to an SDK that reads this key.
+        val previous = pushAppIds?.toSet() ?: emptySet()
+
+        val appIds =
+            when (push) {
+                is Map<*, *> -> (push["appIds"] as? List<*>)?.mapNotNull { it as? String }
+                else -> null
+            }
+
+        pushAppIds = appIds
+        if (persist) {
+            if (appIds != null) {
+                config.cachePreferences?.setValue(PUSH, mapOf("appIds" to appIds))
+            } else {
+                config.cachePreferences?.remove(PUSH)
+            }
+        }
+
+        return appIds?.toSet().orEmpty() - previous
+    }
+
+    private fun preloadPushConfig() {
+        synchronized(remoteConfigLock) {
+            config.cachePreferences?.let { preferences ->
+                val push = preferences.getValue(PUSH) as? Map<*, *>
+                if (push != null) {
+                    pushAppIds = (push["appIds"] as? List<*>)?.mapNotNull { it as? String }
+                }
+            }
+        }
+    }
+
+    /**
+     * The app_ids this project accepts push registrations for, or null when no server has told us.
+     * Null is not the empty list: it means attempt the registration.
+     */
+    public fun getPushAppIds(): List<String>? = pushAppIds
+
+    /**
+     * app_ids that became registerable on the most recent /config read, cleared by reading them.
+     * Draining rather than peeking keeps a device from re-registering on every subsequent load.
+     */
+    public fun consumeNewlyRegisterablePushAppIds(): Set<String> {
+        val newlyRegisterable = newlyRegisterablePushAppIds
+        newlyRegisterablePushAppIds = emptySet()
+        return newlyRegisterable
+    }
+
     private fun reevaluateCapturePerformanceFromCachedConfig(capturePerformance: Any?) {
         if (capturePerformance == null) {
             config.logger.log("No cached capture performance config to re-evaluate; network timing stays disabled.")

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -642,6 +642,14 @@ public class PostHogRemoteConfig(
     // Restores capture performance config from cache (survives reset); re-armed on a /flags reload.
     // capturePerformance is read from the cache by the caller (off featureFlagsLock, since that read
     // can hit disk); this only re-evaluates it in memory.
+    private fun reevaluateCapturePerformanceFromCachedConfig(capturePerformance: Any?) {
+        if (capturePerformance == null) {
+            config.logger.log("No cached capture performance config to re-evaluate; network timing stays disabled.")
+            return
+        }
+        processCapturePerformanceConfig(capturePerformance, persist = false)
+    }
+
     /**
      * Parses the `push` slice and returns the app_ids that became registerable since the last time
      * we looked, so the push manager can re-register a device that was stuck.
@@ -704,14 +712,6 @@ public class PostHogRemoteConfig(
         val newlyRegisterable = newlyRegisterablePushAppIds
         newlyRegisterablePushAppIds = emptySet()
         return newlyRegisterable
-    }
-
-    private fun reevaluateCapturePerformanceFromCachedConfig(capturePerformance: Any?) {
-        if (capturePerformance == null) {
-            config.logger.log("No cached capture performance config to re-evaluate; network timing stays disabled.")
-            return
-        }
-        processCapturePerformanceConfig(capturePerformance, persist = false)
     }
 
     /**

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfig.kt
@@ -676,15 +676,37 @@ public class PostHogRemoteConfig(
             }
 
         pushAppIds = appIds
-        if (persist) {
-            if (appIds != null) {
-                config.cachePreferences?.setValue(PUSH, mapOf("appIds" to appIds))
-            } else {
-                config.cachePreferences?.remove(PUSH)
-            }
+        val newlyRegisterable = appIds?.toSet().orEmpty() - previous
+
+        // When an app_id becomes registerable, the cached list must not advance until the delivered
+        // marker is durably cleared. Otherwise a crash in that window leaves the next launch preloading
+        // the new list, no longer detecting the transition, with a stale marker that permanently
+        // suppresses registration. Defer the write to persistPushConfigCache(), called once the manager
+        // has cleared the marker. With no transition there is nothing to clear, so persist immediately.
+        if (persist && newlyRegisterable.isEmpty()) {
+            writePushConfigCache(appIds)
         }
 
-        return appIds?.toSet().orEmpty() - previous
+        return newlyRegisterable
+    }
+
+    private fun writePushConfigCache(appIds: List<String>?) {
+        if (appIds != null) {
+            config.cachePreferences?.setValue(PUSH, mapOf("appIds" to appIds))
+        } else {
+            config.cachePreferences?.remove(PUSH)
+        }
+    }
+
+    /**
+     * Advances the on-disk push app_id cache to the current in-memory list. Called by the push manager
+     * once it has durably cleared the delivered marker for a transition, so a crash between the two can
+     * never strand a device on a stale marker.
+     */
+    public fun persistPushConfigCache() {
+        synchronized(remoteConfigLock) {
+            writePushConfigCache(pushAppIds)
+        }
     }
 
     private fun preloadPushConfig() {

--- a/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfigResponse.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogRemoteConfigResponse.kt
@@ -16,4 +16,9 @@ public open class PostHogRemoteConfigResponse(
     public val errorTracking: Any? = false,
     // its either a boolean (false = disabled) or a map with "network_timing" key
     public val capturePerformance: Any? = false,
+    // a map with an "appIds" list: the app_ids this project can accept push registrations for.
+    // Defaults to null, not false: absent means the server predates the key, which is not the
+    // same as a project with none configured. See docs/internal/push-subscription-registration.md
+    // in PostHog/posthog.
+    public val push: Any? = null,
 )

--- a/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
@@ -1471,5 +1471,4 @@ internal class PostHogPushSubscriptionManagerTest {
 
         assertEquals(1, http.requestCount)
     }
-
 }

--- a/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
@@ -46,6 +46,7 @@ internal class PostHogPushSubscriptionManagerTest {
         maxRetries: Int = 3,
         encryption: PostHogEncryption? = null,
         pushAppIds: List<String>? = null,
+        pushAppIdsProvider: (() -> List<String>?)? = null,
     ): Triple<PostHogPushSubscriptionManager, PostHogConfig, String?> {
         val config =
             PostHogConfig(API_KEY, host = http.url("/").toString()).apply {
@@ -55,7 +56,7 @@ internal class PostHogPushSubscriptionManagerTest {
                 this.encryption = encryption
             }
         val api = PostHogApi(config)
-        val manager = PostHogPushSubscriptionManager(config, api, executor, { distinctId }, { pushAppIds })
+        val manager = PostHogPushSubscriptionManager(config, api, executor, { distinctId }, pushAppIdsProvider ?: { pushAppIds })
         return Triple(manager, config, storagePrefix)
     }
 
@@ -1404,6 +1405,28 @@ internal class PostHogPushSubscriptionManagerTest {
         // The record is still persisted: onPushAppIdsChanged needs a token to register once the
         // project configures push, rather than waiting for the app to hand us one again.
         assertTrue(pendingFile(storagePrefix!!).exists())
+    }
+
+    @Test
+    fun `eligibility revoked during the identity token mint skips the send`() {
+        val http = mockHttp()
+        // Registerable at attempt() time; remote config drops the app_id while the mint is outstanding.
+        var appIds: List<String>? = listOf("firebase-project")
+        val (sut, config, storagePrefix) = getSut(http, pushAppIdsProvider = { appIds })
+        val mints = java.util.concurrent.LinkedBlockingQueue<(String?) -> Unit>()
+        config.pushIdentityProvider = { _, _, completion -> mints.add(completion) }
+
+        sut.register("fcm-token", "firebase-project", "android")
+        flush()
+
+        // Config resolves mid-mint and no longer lists this app_id.
+        appIds = emptyList()
+        mints.take().invoke("jwt-abc")
+        flush()
+
+        // Without the post-mint re-check the token would POST, get discarded, and be marked delivered.
+        assertEquals(0, http.requestCount)
+        assertFalse(pendingFile(storagePrefix!!).readText().contains("delivered_for_distinct_id"))
     }
 
     @Test

--- a/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
@@ -1479,6 +1479,29 @@ internal class PostHogPushSubscriptionManagerTest {
     }
 
     @Test
+    fun `onPushAppIdsChanged runs the cache-advance callback after handling the transition`() {
+        // The cached app_id list must advance only after the delivered marker is durably cleared, so a
+        // crash in that window can't leave the next launch with a stale marker and no transition to
+        // detect. The manager signals durability by invoking onDurable once, on the executor, after it
+        // has handled (and persisted) the marker clear.
+        val http = mockHttp()
+        var appIds: List<String>? = emptyList()
+        val (_, config, _) = getSut(http)
+        val gated =
+            PostHogPushSubscriptionManager(config, PostHogApi(config), executor, { distinctId }, { appIds })
+
+        gated.register("fcm-token", "firebase-project", "android")
+        flush()
+
+        var durableCalls = 0
+        appIds = listOf("firebase-project")
+        gated.onPushAppIdsChanged(setOf("firebase-project")) { durableCalls++ }
+        flush()
+
+        assertEquals(1, durableCalls)
+    }
+
+    @Test
     fun `an unrelated app_id becoming registerable does not re-register`() {
         val http = mockHttp()
         val (sut, _, _) = getSut(http, pushAppIds = listOf("firebase-project"))

--- a/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/PostHogPushSubscriptionManagerTest.kt
@@ -45,6 +45,7 @@ internal class PostHogPushSubscriptionManagerTest {
         networkStatus: PostHogNetworkStatus? = null,
         maxRetries: Int = 3,
         encryption: PostHogEncryption? = null,
+        pushAppIds: List<String>? = null,
     ): Triple<PostHogPushSubscriptionManager, PostHogConfig, String?> {
         val config =
             PostHogConfig(API_KEY, host = http.url("/").toString()).apply {
@@ -54,7 +55,7 @@ internal class PostHogPushSubscriptionManagerTest {
                 this.encryption = encryption
             }
         val api = PostHogApi(config)
-        val manager = PostHogPushSubscriptionManager(config, api, executor) { distinctId }
+        val manager = PostHogPushSubscriptionManager(config, api, executor, { distinctId }, { pushAppIds })
         return Triple(manager, config, storagePrefix)
     }
 
@@ -1390,4 +1391,85 @@ internal class PostHogPushSubscriptionManagerTest {
                 override fun close() = inputStream.close()
             }
     }
+
+    @Test
+    fun `register sends nothing when the app_id is not configured for the project`() {
+        val http = mockHttp()
+        val (sut, _, storagePrefix) = getSut(http, pushAppIds = listOf("another-project"))
+
+        sut.register("fcm-token", "firebase-project", "android")
+        flush()
+
+        assertEquals(0, http.requestCount)
+        // The record is still persisted: onPushAppIdsChanged needs a token to register once the
+        // project configures push, rather than waiting for the app to hand us one again.
+        assertTrue(pendingFile(storagePrefix!!).exists())
+    }
+
+    @Test
+    fun `register sends when no app_id list has been published`() {
+        val http = mockHttp()
+        // A server older than the push config key sends nothing, and an SDK cannot tell that apart
+        // from a project with push disabled. Failing closed here would silently disable push against
+        // every deployment that predates the key.
+        val (sut, _, _) = getSut(http, pushAppIds = null)
+
+        sut.register("fcm-token", "firebase-project", "android")
+        flush()
+
+        assertEquals(1, http.requestCount)
+    }
+
+    @Test
+    fun `register sends when the app_id is configured for the project`() {
+        val http = mockHttp()
+        val (sut, _, _) = getSut(http, pushAppIds = listOf("firebase-project"))
+
+        sut.register("fcm-token", "firebase-project", "android")
+        flush()
+
+        assertEquals(1, http.requestCount)
+    }
+
+    @Test
+    fun `an app_id becoming registerable clears the delivered marker and re-registers`() {
+        val http = mockHttp()
+        // The device registered while the project had no integration: the server answered 200 and
+        // discarded the token, but the SDK recorded a delivery and stopped asking. Clearing that
+        // marker is the only thing that reaches the device once the project configures push.
+        var appIds: List<String>? = emptyList()
+        // getSut only supplies a fixed list; this case needs one that changes mid-test.
+        val (_, config, storagePrefix) = getSut(http)
+        val gated =
+            PostHogPushSubscriptionManager(config, PostHogApi(config), executor, { distinctId }, { appIds })
+
+        gated.register("fcm-token", "firebase-project", "android")
+        flush()
+        assertEquals(0, http.requestCount)
+
+        appIds = listOf("firebase-project")
+        gated.onPushAppIdsChanged(setOf("firebase-project"))
+        flush()
+
+        assertNotNull(http.takeRequest(2, TimeUnit.SECONDS))
+        assertEquals("distinct-1", readRecord(config, pendingFile(storagePrefix!!))?.deliveredForDistinctId)
+    }
+
+    @Test
+    fun `an unrelated app_id becoming registerable does not re-register`() {
+        val http = mockHttp()
+        val (sut, _, _) = getSut(http, pushAppIds = listOf("firebase-project"))
+
+        sut.register("fcm-token", "firebase-project", "android")
+        flush()
+        assertEquals(1, http.requestCount)
+
+        // Firing on every config load would put the request back on every launch, which is exactly
+        // what the delivered marker exists to prevent.
+        sut.onPushAppIdsChanged(setOf("some-other-project"))
+        flush()
+
+        assertEquals(1, http.requestCount)
+    }
+
 }


### PR DESCRIPTION
## :bulb: Motivation and Context

A device on a project without push configured makes a registration request on every app open that the server can only throw away, and a project that turns push on afterwards never reaches the devices it already has.

- The SDK registers its token at startup whenever push capture is on, against every project it reports to. It has no way to know whether that project opted in.
- `/api/push_subscriptions/` answers those with `200 {"stored": false, "push_enabled": false}` and discards the token.
- Because any 2xx writes `deliveredForDistinctId`, the device then records a success for a token the server never kept and stops asking. No response reaches a client that has stopped asking, so a project that configures push later reaches nothing installed before it — until a token rotation, an `identify()` to a different distinct id, or a reinstall.

Server side is merged: PostHog/posthog#83148 publishes the list, and the contract this implements is `docs/internal/push-subscription-registration.md` there (plus PostHog/posthog#83941, which adds the caching requirement below).

## Changes

Remote config now carries `push.appIds` — the Firebase project ids and APNs bundle ids a project accepts registrations for.

- **The send is gated in `attempt()`**, the choke point that already covers `register`, flush-driven `retryPending`, and the identify resend. The record is still persisted when the send is gated, so `onPushAppIdsChanged` has a token to register later rather than waiting for the app to hand us one again.
- **The list is cached and preloaded on launch**, mirroring `errorTracking`. Registration runs at startup and remote config resolves asynchronously, so without the cache the gate would only take effect from the second launch onward.
- **Absent stays permissive.** A server older than the key sends nothing, which an SDK cannot tell apart from a project with push disabled, so `null` means attempt. Only a published empty list means skip.
- **`onPushAppIdsChanged` clears the delivered marker** for an `app_id` that just became registerable, and re-registers. It fires only on that transition — firing on every config load would put the request back on every launch, which is what the marker exists to prevent.

On the first launch that ever sees the key, the previous list is treated as empty rather than unknown, so every configured `app_id` counts as new. That costs one request per device, once, and it is the only way to reach a device whose project was configured before it updated to an SDK that reads this key.

## :green_heart: How did you test it?

New unit tests in `PostHogPushSubscriptionManagerTest`:

- An `app_id` outside the list sends nothing but still persists the record. Catches the gate being dropped, and catches the record not being persisted, which would leave `onPushAppIdsChanged` with no token.
- A null list still registers. Catches the gate failing closed against a server older than the key, which would silently disable push on every such deployment.
- An `app_id` inside the list registers. Catches the gate being inverted.
- An `app_id` becoming registerable clears the delivered marker and re-registers. This is the un-stranding path.
- An unrelated `app_id` becoming registerable does not re-register. Catches over-firing.





### Manual E2E on the emulator against a local server

Ran the six-scenario verification brief on an Android emulator (posthog-android-sample as `com.posthog.pushtest`, real FCM token, Firebase project `posthog-dev`) against a local PostHog serving real `push.appIds` remote config for a team with a togglable Firebase integration. `:posthog:test` (62 push-manager cases) and the full suite pass.

- Configured launch: exactly one POST, server store, person property `$device_push_subscription_posthog-dev` set (verified in ClickHouse and the persons UI).
- Unconfigured launch: no POST, "skipped: posthog-dev not configured", `push_subscription.pending` written without a delivered marker.
- Cold start unconfigured: skip logged ~7s before a deliberately delayed `/config` responded, so the disk-cached slice gated it, not the fresh fetch.
- Un-stranding: after the integration was added, the next launch logged "became registerable; re-registering" and sent exactly one POST.
- No repeat: three further relaunches sent nothing.
- Old server: with the `push` key removed from the response, the SDK registered.


## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context


Authored with Claude Code, as the reference implementation of the three client rules; iOS mirrors it next, matching how PostHog/posthog-android#656 and PostHog/posthog-ios#735 were kept in step.

Two design points worth a reviewer's attention. The gate lives in `attempt()` rather than `performRegister` so flush and identify resends are covered by the same check. And the transition set is computed in `processPushConfig` from the previously cached list, then drained once by `consumeNewlyRegisterablePushAppIds`, so a device re-registers on the transition and not on every subsequent config load.

I read the server behavior from the merged endpoint rather than assuming it, and the delivered-marker mechanics from this repo's own `performRegister` and `currentRecord`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbav6vE7Tm24KkdRhZmvNM)_
