### PR TITLE
feat(gradle-plugin): add event release mode via posthog.releaseMode

### DIFF
--- a/.changeset/gradle-plugin-event-release-mode.md
+++ b/.changeset/gradle-plugin-event-release-mode.md
@@ -1,0 +1,5 @@
+---
+'posthog-android-gradle-plugin': minor
+---
+
+Add the `posthog.releaseMode` gradle property (falling back to the `POSTHOG_RELEASE_MODE` environment variable), which selects how the uploaded proguard mapping is associated with a release. `symbol-set`, the default, is unchanged. Experimental `event` passes `--release-mode event` to `posthog-cli` (>= 0.12.0) so the mapping is uploaded release-independent, and each event resolves its own release from the `$app_namespace` / `$app_version` / `$app_build` the SDK already sends — two releases that ship the same mapping no longer both report whichever release uploaded it first. An unrecognized value fails the build instead of silently falling back.

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogAndroidGradlePlugin.kt
@@ -31,6 +31,8 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
             val androidComponentsExt =
                 project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java)
 
+            val releaseMode = resolvePostHogReleaseMode(project)
+
             androidComponentsExt.onVariants { variant ->
                 if (!variant.isMinifyEnabled) {
                     return@onVariants
@@ -41,7 +43,7 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
                 // TODO: skip variants, skip autoUpload, release info, allow failure, debug mode
 
                 val paths = OutputPaths(project, variant.name)
-                val generateMapIdTask = generateMapIdTask(project, variant, paths)
+                val generateMapIdTask = generateMapIdTask(project, variant, paths, releaseMode)
                 tasksGeneratingProperties.add(generateMapIdTask)
 
                 variant.apply {
@@ -81,6 +83,7 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
         project: Project,
         variant: ApplicationVariant,
         paths: OutputPaths,
+        releaseMode: PostHogReleaseMode,
     ): TaskProvider<PostHogGenerateMapIdTask> {
         val generateMapIdTask =
             PostHogGenerateMapIdTask.register(
@@ -96,6 +99,7 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
                 generateMapIdTask = generateMapIdTask,
                 variant = variant,
                 mappingFiles = variant.mappingFileProvider(project),
+                releaseMode = releaseMode,
             )
 
         generateMapIdTask.hookWithMinifyTasks(project, variant.name, generateMapIdTask)
@@ -110,6 +114,7 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
         generateMapIdTask: Provider<PostHogGenerateMapIdTask>,
         variant: ApplicationVariant,
         mappingFiles: Provider<FileCollection>,
+        releaseMode: PostHogReleaseMode,
     ): TaskProvider<PostHogUploadProguardMappingsTask> {
         val primaryOutput = variant.outputs.firstOrNull()
         val uploadMapIdTask =
@@ -121,6 +126,7 @@ internal class PostHogAndroidGradlePlugin : Plugin<Project> {
                 releaseName = variant.applicationId,
                 releaseVersion = primaryOutput?.versionName?.map { it.orEmpty() },
                 build = primaryOutput?.versionCode?.map { it ?: 0 },
+                releaseMode = releaseMode,
             )
         return uploadMapIdTask
     }

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
@@ -62,6 +62,12 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
         if (!mappingsFiles.isPresent || mappingsFiles.get().isEmpty) {
             error("[PostHog] Mapping files are missing!")
         }
+        // posthog-cli reads POSTHOG_RELEASE_MODE itself when --release-mode is absent, and the
+        // Gradle daemon's environment may carry one that contradicts the mode resolved here —
+        // where the gradle property is supposed to win. Pin the resolved mode in the child's
+        // environment so it cannot be overridden by inheritance. A posthog-cli predating the flag
+        // has no such argument and ignores the variable, so this stays safe for old CLIs.
+        releaseMode.orNull?.let { environment(POSTHOG_RELEASE_MODE_ENV, it) }
         super.exec()
     }
 

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/PostHogUploadProguardMappingsTask.kt
@@ -53,6 +53,11 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
     @get:Optional
     public abstract val build: Property<Int>
 
+    /** [PostHogReleaseMode.cliValue], as the enum itself is internal to the plugin. */
+    @get:Input
+    @get:Optional
+    public abstract val releaseMode: Property<String>
+
     override fun exec() {
         if (!mappingsFiles.isPresent || mappingsFiles.get().isEmpty) {
             error("[PostHog] Mapping files are missing!")
@@ -94,6 +99,12 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
             args.add("--build")
             args.add(it.toString())
         }
+        // Passed only outside the default mode, so a symbol-set build keeps working against a
+        // posthog-cli predating the flag.
+        releaseMode.orNull?.takeIf { it != PostHogReleaseMode.SYMBOL_SET.cliValue }?.let {
+            args.add("--release-mode")
+            args.add(it)
+        }
     }
 
     internal companion object {
@@ -105,6 +116,7 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
             releaseName: Provider<String>? = null,
             releaseVersion: Provider<String>? = null,
             build: Provider<Int>? = null,
+            releaseMode: PostHogReleaseMode = PostHogReleaseMode.SYMBOL_SET,
         ): TaskProvider<PostHogUploadProguardMappingsTask> {
             val uploadPostHogProguardMappingsTask =
                 project.tasks.register(
@@ -118,6 +130,7 @@ public abstract class PostHogUploadProguardMappingsTask : PostHogCliExecTask() {
                     releaseName?.let { this.releaseName.set(it) }
                     releaseVersion?.let { this.releaseVersion.set(it) }
                     build?.let { this.build.set(it) }
+                    this.releaseMode.set(releaseMode.cliValue)
                     resolvePostHogDotenvFile(project)?.let { this.postHogDotenvFile.set(it) }
                 }
             return uploadPostHogProguardMappingsTask

--- a/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/Utils.kt
+++ b/posthog-android-gradle-plugin/src/main/kotlin/com/posthog/android/Utils.kt
@@ -116,6 +116,56 @@ internal fun resolvePostHogDotenvFile(project: Project): String? {
     return if (file.isAbsolute) file.path else File(project.rootDir, value).path
 }
 
+internal const val POSTHOG_RELEASE_MODE_PROPERTY = "posthog.releaseMode"
+
+internal const val POSTHOG_RELEASE_MODE_ENV = "POSTHOG_RELEASE_MODE"
+
+/** How the release a build belongs to gets associated with the exceptions it reports. */
+internal enum class PostHogReleaseMode(val cliValue: String) {
+    /**
+     * posthog-cli stamps the release onto the uploaded mapping file, and exceptions inherit it
+     * from the mapping their frames resolved against. The behavior before event mode existed.
+     */
+    SYMBOL_SET("symbol-set"),
+
+    /**
+     * The mapping is uploaded release-independent, and each event resolves its own release from
+     * the `$app_namespace` / `$app_version` / `$app_build` the SDK already sends. Nothing is
+     * injected into the app. A map id is derived from the mapping's content, so two releases
+     * sharing a mapping would otherwise both report whichever release uploaded it first.
+     */
+    EVENT("event"),
+    ;
+
+    internal companion object {
+        fun from(value: String): PostHogReleaseMode? = values().firstOrNull { it.cliValue == value }
+    }
+}
+
+/**
+ * Release mode for this build: the `posthog.releaseMode` gradle property, then the
+ * `POSTHOG_RELEASE_MODE` environment variable posthog-cli and the bundler plugins already read,
+ * then [PostHogReleaseMode.SYMBOL_SET].
+ *
+ * An unrecognized value fails the build rather than falling back, so a typo can't silently leave
+ * a build binding its mapping to a release it meant to keep independent.
+ */
+internal fun resolvePostHogReleaseMode(
+    project: Project,
+    environment: Map<String, String> = System.getenv(),
+): PostHogReleaseMode {
+    val value =
+        project.findProperty(POSTHOG_RELEASE_MODE_PROPERTY)?.toString()?.trim()?.takeIf { it.isNotEmpty() }
+            ?: environment[POSTHOG_RELEASE_MODE_ENV]?.trim()?.takeIf { it.isNotEmpty() }
+            ?: return PostHogReleaseMode.SYMBOL_SET
+
+    return PostHogReleaseMode.from(value)
+        ?: error(
+            "$POSTHOG_RELEASE_MODE_PROPERTY must be one of " +
+                "${PostHogReleaseMode.values().joinToString { it.cliValue }}, was '$value'",
+        )
+}
+
 /**
  * Locates posthog-cli for builds whose environment lacks the shell PATH —
  * IDE-launched Gradle daemons don't source shell profiles, so a CLI installed


### PR DESCRIPTION
## :bulb: Motivation and Context

The mapping upload binds the release it creates to the mapping. Map ids are derived from the mapping's content, so two releases shipping the same mapping both report whichever one uploaded it first.

`posthog.releaseMode=event` (or `POSTHOG_RELEASE_MODE=event`, which posthog-cli and the bundler plugins already read) passes `--release-mode event` to posthog-cli, leaving the mapping unbound. Nothing has to be injected into the app: the server resolves each event's release from the `$app_namespace` / `$app_version` / `$app_build` the SDK already sends — same shape as posthog-ios with `dsym upload --no-release-bind`.

The flag is only passed outside the default mode, so symbol-set builds keep working against a posthog-cli predating it. An unrecognised mode fails the build rather than silently falling back.

Needs PostHog/posthog#84478.

## :green_heart: How did you test it?

### Before

| Symol set (bound to a release) | Issue shows release |
|--------|--------|
| <img width="667" height="335" alt="CleanShot 2026-08-18 at 16 28 51" src="https://github.com/user-attachments/assets/781e9246-e8c6-4973-a6af-15b3e9ff3835" /> | <img width="961" height="310" alt="CleanShot 2026-08-18 at 16 29 19" src="https://github.com/user-attachments/assets/9e798b93-10e2-4c58-8060-a7e8c42cad47" /> | 

### After

| Symol set (NOT bound to a release) | Issue STILL shows release (resolved via cymbal) |
|--------|--------|
| <img width="687" height="241" alt="CleanShot 2026-08-18 at 16 31 31" src="https://github.com/user-attachments/assets/b3e52edd-ad49-41b8-b348-01bfb6ca9d67" /> | <img width="961" height="310" alt="CleanShot 2026-08-18 at 16 30 39" src="https://github.com/user-attachments/assets/63c1b6bc-1679-4197-a694-cd025483b34a" />
 | 
 
 ### CLI output AFTER

In the new mode I uploaded source maps and then modified version without changing anything in the code. That means we should create new release but still skip the upload. In previous version this was not possible.

| New release but same map skips upload |
|--------|
| <img width="1860" height="218" alt="CleanShot 2026-08-18 at 16 35 12@2x" src="https://github.com/user-attachments/assets/ba9a0417-613a-4bc2-8275-a9094c30db30" /> | 

Assembled the sample app in each mode and checked the CLI invocation: `-Pposthog.releaseMode=event` and `POSTHOG_RELEASE_MODE=event` both append `--release-mode event`, the default appends nothing, and `=events` fails the build. No tests — the module has no test infrastructure.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.