### PR TITLE
chore: add android and server changesets for the exception chain metadata work

### DIFF
--- a/.changeset/exception-chain-metadata-artifacts.md
+++ b/.changeset/exception-chain-metadata-artifacts.md
@@ -1,0 +1,13 @@
+---
+'posthog-android': minor
+'posthog-server': minor
+---
+
+Release the shared `ThrowableCoercer` error-tracking improvements (shipped in core 6.32.0, PostHog/posthog-android#669) in the Android and server artifacts:
+
+- Each `$exception_list` item's mechanism now carries `exception_id` (0-based position); cause items get `parent_id` and mechanism `type: "chained"`, suppressed exceptions (`Throwable.suppressed`) are serialized with mechanism `type: "suppressed"` and the holder's `parent_id`. A single-item list carries no ids, matching the other SDKs. The ids are emitted on the wire for cross-SDK parity; PostHog ingestion does not persist them yet.
+- Caps: at most 50 items per `$exception_list` and 64 frames per stacktrace (keeps the frames nearest the crash); the cap bounds the traversal itself.
+- Compiler-generated frames (JVM and Kotlin lambdas, Android D8/R8 desugared lambdas and outlines, Spring CGLIB proxies, reflection accessors, dynamic proxies) are flagged with `method_synthetic: true` rather than dropped.
+- New `PostHogErrorTrackingConfig.inAppExcludes` to force frames out of `in_app` (excludes win over `inAppIncludes`); matching happens against runtime class names before symbolication.
+
+All field/key names and `platform: "java"` are unchanged; the additions are backwards compatible on the wire.


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to #669: its changeset bumped only the core `posthog` artifact, so core 6.32.0 released with the shared-coercer error-tracking work while `posthog-android` and `posthog-server` — the artifacts users actually consume it through — got no changelog entry or release. Per the convention used by #603 and #668, shared-coercer changes should list every shipping artifact.

This adds the missing changeset (minor for both artifacts), with the summary adapted from the merged one.

## :green_heart: How did you test it?

Changeset-only change; frontmatter format matches existing changesets in `.changeset/`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. (n/a — changeset only)
- [x] I updated the docs if needed. (n/a)
- [x] No breaking change or entry added to the changelog.
