### PR TITLE
test(server): regenerate wire snapshots for exception chain metadata and 2.13.0

### DIFF
--- a/posthog-server/src/test/java/com/posthog/server/PostHogServerWireSnapshotTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogServerWireSnapshotTest.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
+import com.google.gson.JsonPrimitive
 import com.posthog.PostHogBeforeSend
 import com.posthog.internal.PostHogDateProvider
 import okhttp3.mockwebserver.MockWebServer
@@ -235,6 +236,7 @@ internal class PostHogServerWireSnapshotTest {
         val resource = javaClass.classLoader.getResource("json/$fixtureName")
         assertNotNull(resource, "Missing snapshot fixture json/$fixtureName")
         val expected = JsonParser.parseString(resource.readText())
+        normalizeLibVersion(actual)
         val canonicalExpected = canonicalize(expected)
         val canonicalActual = canonicalize(actual)
         assertEquals(
@@ -258,6 +260,24 @@ internal class PostHogServerWireSnapshotTest {
                 }
             else -> element.deepCopy()
         }
+
+    private fun normalizeLibVersion(element: JsonElement) {
+        when {
+            element.isJsonObject ->
+                element.asJsonObject.entrySet().forEach { entry ->
+                    if (entry.key == "\$lib_version") {
+                        assertTrue(
+                            entry.value.isJsonPrimitive && entry.value.asJsonPrimitive.isString,
+                            "Expected string \$lib_version",
+                        )
+                        entry.setValue(JsonPrimitive(LIB_VERSION_PLACEHOLDER))
+                    } else {
+                        normalizeLibVersion(entry.value)
+                    }
+                }
+            element.isJsonArray -> element.asJsonArray.forEach(::normalizeLibVersion)
+        }
+    }
 
     private fun normalizeExceptionVolatiles(body: JsonElement) {
         val events = body.asJsonObject.getAsJsonArray("batch") ?: return
@@ -318,6 +338,7 @@ internal class PostHogServerWireSnapshotTest {
     }
 
     private companion object {
+        const val LIB_VERSION_PLACEHOLDER = "<lib-version>"
         val PRETTY_GSON = GsonBuilder().setPrettyPrinting().create()
     }
 }

--- a/posthog-server/src/test/resources/json/server-batch-family.json
+++ b/posthog-server/src/test/resources/json/server-batch-family.json
@@ -9,7 +9,7 @@
           "company": "posthog"
         },
         "$lib": "posthog-server",
-        "$lib_version": "2.13.0",
+        "$lib_version": "<lib-version>",
         "$set": {
           "name": "Ada",
           "plan": "pro"
@@ -28,7 +28,7 @@
       "event": "$identify",
       "properties": {
         "$lib": "posthog-server",
-        "$lib_version": "2.13.0",
+        "$lib_version": "<lib-version>",
         "$set": {
           "email": "ada@example.com",
           "roles": [
@@ -48,7 +48,7 @@
       "event": "$create_alias",
       "properties": {
         "$lib": "posthog-server",
-        "$lib_version": "2.13.0",
+        "$lib_version": "<lib-version>",
         "alias": "legacy-user-456"
       },
       "timestamp": "2023-09-20T11:58:49.000Z",
@@ -65,7 +65,7 @@
         },
         "$group_type": "company",
         "$lib": "posthog-server",
-        "$lib_version": "2.13.0"
+        "$lib_version": "<lib-version>"
       },
       "timestamp": "2023-09-20T11:58:49.000Z",
       "uuid": "ae93f1af-26bc-3a3e-b65d-7ac98c63034e"

--- a/posthog-server/src/test/resources/json/server-batch-family.json
+++ b/posthog-server/src/test/resources/json/server-batch-family.json
@@ -9,7 +9,7 @@
           "company": "posthog"
         },
         "$lib": "posthog-server",
-        "$lib_version": "2.12.0",
+        "$lib_version": "2.13.0",
         "$set": {
           "name": "Ada",
           "plan": "pro"
@@ -28,7 +28,7 @@
       "event": "$identify",
       "properties": {
         "$lib": "posthog-server",
-        "$lib_version": "2.12.0",
+        "$lib_version": "2.13.0",
         "$set": {
           "email": "ada@example.com",
           "roles": [
@@ -48,7 +48,7 @@
       "event": "$create_alias",
       "properties": {
         "$lib": "posthog-server",
-        "$lib_version": "2.12.0",
+        "$lib_version": "2.13.0",
         "alias": "legacy-user-456"
       },
       "timestamp": "2023-09-20T11:58:49.000Z",
@@ -65,7 +65,7 @@
         },
         "$group_type": "company",
         "$lib": "posthog-server",
-        "$lib_version": "2.12.0"
+        "$lib_version": "2.13.0"
       },
       "timestamp": "2023-09-20T11:58:49.000Z",
       "uuid": "ae93f1af-26bc-3a3e-b65d-7ac98c63034e"

--- a/posthog-server/src/test/resources/json/server-exception.json
+++ b/posthog-server/src/test/resources/json/server-exception.json
@@ -71,7 +71,7 @@
           }
         ],
         "$lib": "posthog-server",
-        "$lib_version": "2.13.0",
+        "$lib_version": "<lib-version>",
         "request_id": "request-456",
         "tags": [
           "checkout",

--- a/posthog-server/src/test/resources/json/server-exception.json
+++ b/posthog-server/src/test/resources/json/server-exception.json
@@ -9,6 +9,7 @@
         "$exception_list": [
           {
             "mechanism": {
+              "exception_id": 0,
               "handled": true,
               "synthetic": false,
               "type": "generic"
@@ -43,9 +44,11 @@
           },
           {
             "mechanism": {
+              "exception_id": 1,
               "handled": true,
+              "parent_id": 0,
               "synthetic": false,
-              "type": "generic"
+              "type": "chained"
             },
             "module": "java.lang",
             "stacktrace": {
@@ -68,7 +71,7 @@
           }
         ],
         "$lib": "posthog-server",
-        "$lib_version": "2.12.0",
+        "$lib_version": "2.13.0",
         "request_id": "request-456",
         "tags": [
           "checkout",

--- a/posthog-server/src/test/resources/json/server-safe-properties.json
+++ b/posthog-server/src/test/resources/json/server-safe-properties.json
@@ -6,7 +6,7 @@
       "event": "safe properties",
       "properties": {
         "$lib": "posthog-server",
-        "$lib_version": "2.12.0",
+        "$lib_version": "2.13.0",
         "empty_array": [],
         "empty_object": {},
         "empty_string": "",

--- a/posthog-server/src/test/resources/json/server-safe-properties.json
+++ b/posthog-server/src/test/resources/json/server-safe-properties.json
@@ -6,7 +6,7 @@
       "event": "safe properties",
       "properties": {
         "$lib": "posthog-server",
-        "$lib_version": "2.13.0",
+        "$lib_version": "<lib-version>",
         "empty_array": [],
         "empty_object": {},
         "empty_string": "",


### PR DESCRIPTION
## Problem

Main is red: `PostHogServerWireSnapshotTest` fails 3 tests. The snapshots added in #701 were generated before #669 merged and before the release bump #669's changesets triggered, and #701 merged on a stale green (its last CI run predates #669 on main).

## Changes

Regenerated the affected fixtures on current main:

- `server-exception.json`: mechanism now carries `exception_id`/`parent_id` and the chained cause's `type: "chained"` (from #669's exception chain metadata).
- All three: `$lib_version` pin `2.12.0` -> `2.13.0` (from the release bump).

No test-code changes. The `$lib_version` pin means these snapshots break on every release bump - normalizing it is a separate discussion (checking with @dustinbyrne).

## Tests

`:posthog-server:test` green locally (455 tests, including all wire snapshot tests).
