### PR TITLE
fix(ci): build the compliance adapter with the repo Gradle wrapper

### DIFF
--- a/sdk_compliance_adapter/Dockerfile
+++ b/sdk_compliance_adapter/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=linux/amd64 gradle:9.6.1-jdk17 AS builder
+# Build with the repo's own Gradle wrapper: an image-pinned Gradle skews from
+# the wrapper-generated lockfiles on every wrapper bump (the embedded Kotlin
+# build-tools version is locked strictly per Gradle release).
+FROM --platform=linux/amd64 eclipse-temurin:17-jdk AS builder
 
 WORKDIR /app
 
@@ -8,7 +11,7 @@ RUN echo 'include(":sdk_compliance_adapter")' >> settings.gradle.kts && \
     sed -i '/^dependencyResolutionManagement/i plugins {\n    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"\n}' settings.gradle.kts && \
     mkdir -p /root/.gradle && \
     echo 'org.gradle.java.installations.auto-download=true' > /root/.gradle/gradle.properties && \
-    gradle :sdk_compliance_adapter:installDist --no-daemon
+    ./gradlew :sdk_compliance_adapter:installDist --no-daemon
 
 FROM eclipse-temurin:11-jre
 


### PR DESCRIPTION
## Problem

The SDK compliance job fails on every branch since #702 bumped the Gradle wrapper to 9.7.0. The adapter's Dockerfile pins its own Gradle (`FROM gradle:9.6.1-jdk17`) and runs plain `gradle`, but the lockfiles are generated by the wrapper - and dependency locking pins the embedded Kotlin build-tools strictly per Gradle release (9.7.0 locks 2.4.0, the container's 9.6.1 requests 2.3.21). Configuration of the gradle-plugin project fails before any test runs.

It slipped through because the compliance workflow's path filter (`posthog/**`, `sdk_compliance_adapter/**`) never fires on wrapper or lockfile changes, so #702 merged without ever running the job.

## Changes

Build the adapter with the repo's own `./gradlew` on a plain JDK image instead of an image-pinned Gradle. The container now always uses exactly the wrapper the lockfiles were generated with, so future wrapper bumps cannot skew it again.

## Tests

Local `docker build -f sdk_compliance_adapter/Dockerfile .` of the exact CI invocation completes successfully (previously failed with the lock conflict). The compliance workflow also runs on this PR since it touches `sdk_compliance_adapter/**`.
