### PR TITLE
ci: verify release dependency locks before merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ jobs:
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: make compile
 
+      - name: Check release tasks and dependency locks
+        if: needs.detect-markdown-only.outputs.markdown_only != 'true'
+        run: make checkRelease
+
       - name: Make stop
         if: needs.detect-markdown-only.outputs.markdown_only != 'true'
         run: make stop

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ generateLintBaseLine:
 checkRelease:
 	CI=false ./gradlew publishToMavenLocal :posthog-android-gradle-plugin:publishToMavenLocal --write-locks
 	git diff --exit-code -- ':(glob)**/gradle.lockfile'
+	@test -z "$$(git status --porcelain --untracked-files=all -- ':(glob)**/gradle.lockfile')" || \
+		(git status --short --untracked-files=all -- ':(glob)**/gradle.lockfile'; exit 1)
 
 # Regenerate gradle.lockfile for all build and publishing configurations
 updateLocks:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: clean compile stop checkFormat format api dryRelease release testReport test testJava generateLintBaseLine updateLocks
+.PHONY: clean compile stop checkFormat format api dryRelease release testReport test testJava generateLintBaseLine checkRelease updateLocks
 
 clean:
 	./gradlew clean
 
 compile:
-	./gradlew build
+	./gradlew build :posthog-android-gradle-plugin:build
 
 # We stop gradle at the end to make sure the cache folders
 # don't contain any lock files and are free to be cached.
@@ -71,6 +71,12 @@ generateLintBaseLine:
 	rm -f posthog-android/lint-baseline.xml
 	./gradlew lintDebug -Dlint.baselines.continue=true
 
-# Regenerate gradle.lockfile for all projects after dependency changes
+# Verify release tasks succeed and committed dependency locks are complete
+checkRelease:
+	CI=false ./gradlew publishToMavenLocal :posthog-android-gradle-plugin:publishToMavenLocal --write-locks
+	git diff --exit-code -- ':(glob)**/gradle.lockfile'
+
+# Regenerate gradle.lockfile for all build and publishing configurations
 updateLocks:
-	./gradlew build --write-locks
+	./gradlew build :posthog-android-gradle-plugin:build --write-locks
+	CI=false ./gradlew publishToMavenLocal :posthog-android-gradle-plugin:publishToMavenLocal --write-locks


### PR DESCRIPTION
## :bulb: Motivation and Context

The root Gradle build does not run the `posthog-android-gradle-plugin` build because the plugin is included as a composite build. This allowed pull requests to remove Dokka dependency locks while the Build Job still passed. The missing locks were only detected when the release workflow ran, most recently in #708.

This change explicitly includes the Gradle plugin build in `make compile`. It also adds a pull request check that runs every local publication with `--write-locks` and fails if any tracked, staged, or untracked `gradle.lockfile` changes. `make updateLocks` now resolves both build and publishing configurations for the root projects and the included plugin.

Local publication uses `CI=false` so pull request jobs do not require release signing keys. All documentation, artifact generation, publication, and dependency resolution tasks still run.

## :green_heart: How did you test it?

- `make checkRelease`
- `CI=true ./gradlew :posthog-android-gradle-plugin:build --console=plain`
- `make checkFormat`
- `actionlint .github/workflows/build.yml`
- Removed the three Dokka Javadoc entries restored by #708 and confirmed `make checkRelease` regenerated them and failed on the lockfile diff.
- Added an untracked `gradle.lockfile` and confirmed `make checkRelease` failed and reported it.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi using GPT-5.6-sol authored the change under Manoel's direction. The session is not publicly shared. An isolated autoreview found that the first version did not detect newly generated untracked lockfiles. That finding was accepted, fixed, tested, and the final review reported no actionable findings.
