### PR TITLE
fix(android): prevent date offset overflow

### DIFF
--- a/.changeset/calm-clocks-count.md
+++ b/.changeset/calm-clocks-count.md
@@ -1,0 +1,5 @@
+---
+'posthog-android': patch
+---
+
+Prevent date arithmetic from overflowing for large second offsets.

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogAndroidDateProvider.kt
@@ -46,7 +46,7 @@ internal class PostHogAndroidDateProvider(
     }
 
     override fun addSecondsToCurrentDate(seconds: Int): Date {
-        return Date(currentTimeMillis() + seconds * 1000)
+        return Date(currentTimeMillis() + seconds * 1000L)
     }
 
     override fun currentTimeMillis(): Long {

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogAndroidDateProviderTest.kt
@@ -30,6 +30,22 @@ internal class PostHogAndroidDateProviderTest {
     }
 
     @Test
+    fun `adds seconds to the current date`() {
+        val clock = CountingClock(1_000_000L)
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L })
+
+        assertEquals(1_005_000L, sut.addSecondsToCurrentDate(5).time)
+    }
+
+    @Test
+    fun `adds seconds without overflowing integer milliseconds`() {
+        val clock = CountingClock(1_000_000L)
+        val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L })
+
+        assertEquals(1_000_000L + Int.MAX_VALUE * 1_000L, sut.addSecondsToCurrentDate(Int.MAX_VALUE).time)
+    }
+
+    @Test
     fun `does not query the network clock on every call`() {
         val clock = CountingClock(1_000_000L)
         val sut = PostHogAndroidDateProvider(networkClock = clock, elapsedRealtimeMs = { 100L }, refreshIntervalMs = 60_000L)


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogAndroidDateProvider` multiplied second offsets as an `Int` before adding them to a millisecond timestamp. Large offsets could overflow before being converted to `Long`, producing the wrong date.

This changes the multiplication to use `Long` arithmetic. It preserves the existing behavior for normal offsets and supports the full `Int` range accepted by the API.

## :green_heart: How did you test it?

- `./gradlew :posthog-android:testDebugUnitTest --tests "com.posthog.android.internal.PostHogAndroidDateProviderTest"`
- `make checkFormat`
- Pi autoreview against `origin/main`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the focused arithmetic fix and regression tests after a human-directed Slopo duplication review. Pi autoreview checked the committed branch and reported no actionable findings. The implementation keeps the existing `Int` API and changes only the intermediate multiplication type.
