### PR TITLE
fix(server): Preserve evaluate flag group properties

### DIFF
--- a/.changeset/calm-groups-merge.md
+++ b/.changeset/calm-groups-merge.md
@@ -1,0 +1,5 @@
+---
+'posthog-server': patch
+---
+
+Preserve existing group properties when adding bulk evaluate-flags options.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogBuilderUtils.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogBuilderUtils.kt
@@ -27,3 +27,12 @@ internal fun MutableMap<String, MutableMap<String, Any?>>?.putBuilderGroupProper
             getOrPut(group) { mutableMapOf() }.putAll(properties)
         }
     }
+
+internal fun MutableMap<String, Map<String, Any?>>?.mergeBuilderGroupProperties(
+    groupProperties: Map<String, Map<String, Any?>>,
+): MutableMap<String, Map<String, Any?>> =
+    (this ?: mutableMapOf()).apply {
+        groupProperties.forEach { (group, properties) ->
+            put(group, get(group).orEmpty() + properties)
+        }
+    }

--- a/posthog-server/src/main/java/com/posthog/server/PostHogEvaluateFlagsOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogEvaluateFlagsOptions.kt
@@ -123,7 +123,7 @@ public class PostHogEvaluateFlagsOptions private constructor(
          * @return This builder.
          */
         public fun groupProperties(groupProperties: Map<String, Map<String, Any?>>): Builder {
-            this.groupProperties = this.groupProperties.putBuilderValues(groupProperties)
+            this.groupProperties = this.groupProperties.mergeBuilderGroupProperties(groupProperties)
             return this
         }
 

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsOptionsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsOptionsTest.kt
@@ -62,6 +62,28 @@ internal class PostHogEvaluateFlagsOptionsTest {
     }
 
     @Test
+    fun `groupProperties merges with existing group properties without mutating input maps`() {
+        val companyProperties = mapOf<String, Any?>("size" to "large", "plan" to "premium")
+        val input = mapOf("company" to companyProperties, "project" to mapOf("tier" to 2))
+
+        val options =
+            PostHogEvaluateFlagsOptions.builder()
+                .groupProperty("company", "industry", "tech")
+                .groupProperty("company", "size", "small")
+                .groupProperties(input)
+                .build()
+
+        assertEquals(
+            mapOf(
+                "company" to mapOf("industry" to "tech", "size" to "large", "plan" to "premium"),
+                "project" to mapOf("tier" to 2),
+            ),
+            options.groupProperties,
+        )
+        assertEquals(mapOf("size" to "large", "plan" to "premium"), companyProperties)
+    }
+
+    @Test
     fun `later values replace earlier values for matching keys`() {
         val options =
             PostHogEvaluateFlagsOptions.builder()


### PR DESCRIPTION
## :bulb: Motivation and Context

`PostHogEvaluateFlagsOptions.Builder.groupProperties` replaced all properties for an existing group. This discarded values previously added with `groupProperty`, despite the method documenting merge behavior.

This change deep-merges each group's properties. Values from the later bulk call still replace matching keys, while unrelated existing properties and groups remain.

## :green_heart: How did you test it?

- `./gradlew :posthog-server:test --tests 'com.posthog.server.PostHogEvaluateFlagsOptionsTest'`
- `make checkFormat`
- Autoreview against `origin/main`

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi API coding agent and the bundled autoreview tool. The change reuses the internal builder helper boundary rather than adding a public builder abstraction. Autoreview reported no actionable findings.
