### PR TITLE
fix: handle malformed survey JSON safely

### DIFF
--- a/.changeset/calm-rivers-log.md
+++ b/.changeset/calm-rivers-log.md
@@ -1,5 +1,6 @@
 ---
 'posthog': patch
+'posthog-android': patch
 ---
 
 Prevent malformed survey JSON from throwing while logging deserialization errors.

--- a/.changeset/calm-rivers-log.md
+++ b/.changeset/calm-rivers-log.md
@@ -1,0 +1,5 @@
+---
+'posthog': patch
+---
+
+Prevent malformed survey JSON from throwing while logging deserialization errors.

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyEnumAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyEnumAdapter.kt
@@ -29,7 +29,7 @@ internal abstract class GsonSurveyEnumAdapter<T>(
         return try {
             fromValue(json.asString)
         } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
+            config.logger.log("$json isn't a known type: $e.")
             null
         }
     }

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyQuestionAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyQuestionAdapter.kt
@@ -42,7 +42,7 @@ internal class GsonSurveyQuestionAdapter(private val config: PostHogConfig) :
                 else -> null
             }
         } catch (e: Throwable) {
-            config.logger.log("${json.asString} isn't a known type: $e.")
+            config.logger.log("$json isn't a known type: $e.")
             null
         }
     }

--- a/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyTextContentTypeAdapter.kt
+++ b/posthog/src/main/java/com/posthog/internal/surveys/GsonSurveyTextContentTypeAdapter.kt
@@ -28,7 +28,7 @@ internal class GsonSurveyTextContentTypeAdapter(private val config: PostHogConfi
         return try {
             SurveyTextContentType.fromValue(json.asString)
         } catch (e: Throwable) {
-            config.logger.log("${json.asInt} isn't a known type: $e.")
+            config.logger.log("$json isn't a known type: $e.")
             null
         }
     }

--- a/posthog/src/test/java/com/posthog/internal/surveys/GsonSurveyAdaptersTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/surveys/GsonSurveyAdaptersTest.kt
@@ -1,0 +1,69 @@
+package com.posthog.internal.surveys
+
+import com.google.gson.GsonBuilder
+import com.posthog.API_KEY
+import com.posthog.PostHogConfig
+import com.posthog.TestLogger
+import com.posthog.surveys.SurveyQuestion
+import com.posthog.surveys.SurveyTextContentType
+import com.posthog.surveys.SurveyType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+internal class GsonSurveyAdaptersTest {
+    @Test
+    fun `question adapter returns null for malformed object`() {
+        val logger = TestLogger()
+        val gson =
+            GsonBuilder()
+                .registerTypeAdapter(SurveyQuestion::class.java, GsonSurveyQuestionAdapter(config(logger)))
+                .create()
+
+        val result = gson.fromJson("{}", SurveyQuestion::class.java)
+
+        assertNull(result)
+        assertMalformedObjectLogged(logger)
+    }
+
+    @Test
+    fun `text content adapter returns null for malformed object`() {
+        val logger = TestLogger()
+        val gson =
+            GsonBuilder()
+                .registerTypeAdapter(
+                    SurveyTextContentType::class.java,
+                    GsonSurveyTextContentTypeAdapter(config(logger)),
+                ).create()
+
+        val result = gson.fromJson("{}", SurveyTextContentType::class.java)
+
+        assertNull(result)
+        assertMalformedObjectLogged(logger)
+    }
+
+    @Test
+    fun `enum adapter returns null for malformed object`() {
+        val logger = TestLogger()
+        val gson =
+            GsonBuilder()
+                .registerTypeAdapter(SurveyType::class.java, GsonSurveyTypeAdapter(config(logger)))
+                .create()
+
+        val result = gson.fromJson("{}", SurveyType::class.java)
+
+        assertNull(result)
+        assertMalformedObjectLogged(logger)
+    }
+
+    private fun config(logger: TestLogger): PostHogConfig =
+        PostHogConfig(API_KEY).apply {
+            this.logger = logger
+        }
+
+    private fun assertMalformedObjectLogged(logger: TestLogger) {
+        assertEquals(1, logger.messages.size)
+        assertTrue(logger.messages.single().startsWith("{} isn't a known type:"))
+    }
+}

--- a/posthog/src/test/java/com/posthog/internal/surveys/GsonSurveyAdaptersTest.kt
+++ b/posthog/src/test/java/com/posthog/internal/surveys/GsonSurveyAdaptersTest.kt
@@ -14,47 +14,26 @@ import kotlin.test.assertTrue
 
 internal class GsonSurveyAdaptersTest {
     @Test
-    fun `question adapter returns null for malformed object`() {
-        val logger = TestLogger()
-        val gson =
-            GsonBuilder()
-                .registerTypeAdapter(SurveyQuestion::class.java, GsonSurveyQuestionAdapter(config(logger)))
-                .create()
+    fun `survey adapters return null for malformed objects`() {
+        val adapters =
+            listOf<Pair<Class<*>, (PostHogConfig) -> Any>>(
+                SurveyQuestion::class.java to { GsonSurveyQuestionAdapter(it) },
+                SurveyTextContentType::class.java to { GsonSurveyTextContentTypeAdapter(it) },
+                SurveyType::class.java to { GsonSurveyTypeAdapter(it) },
+            )
 
-        val result = gson.fromJson("{}", SurveyQuestion::class.java)
+        adapters.forEach { (targetType, adapterFactory) ->
+            val logger = TestLogger()
+            val gson =
+                GsonBuilder()
+                    .registerTypeAdapter(targetType, adapterFactory(config(logger)))
+                    .create()
 
-        assertNull(result)
-        assertMalformedObjectLogged(logger)
-    }
+            val result = gson.fromJson("{}", targetType)
 
-    @Test
-    fun `text content adapter returns null for malformed object`() {
-        val logger = TestLogger()
-        val gson =
-            GsonBuilder()
-                .registerTypeAdapter(
-                    SurveyTextContentType::class.java,
-                    GsonSurveyTextContentTypeAdapter(config(logger)),
-                ).create()
-
-        val result = gson.fromJson("{}", SurveyTextContentType::class.java)
-
-        assertNull(result)
-        assertMalformedObjectLogged(logger)
-    }
-
-    @Test
-    fun `enum adapter returns null for malformed object`() {
-        val logger = TestLogger()
-        val gson =
-            GsonBuilder()
-                .registerTypeAdapter(SurveyType::class.java, GsonSurveyTypeAdapter(config(logger)))
-                .create()
-
-        val result = gson.fromJson("{}", SurveyType::class.java)
-
-        assertNull(result)
-        assertMalformedObjectLogged(logger)
+            assertNull(result, "${targetType.simpleName} adapter should return null")
+            assertMalformedObjectLogged(logger)
+        }
     }
 
     private fun config(logger: TestLogger): PostHogConfig =


### PR DESCRIPTION
## :bulb: Motivation and Context

Malformed survey JSON can enter an adapter's error handler and then throw again while the handler tries to read the value as a string or integer for logging. This prevents the adapters from returning `null` as intended.

This change logs the original JSON element without another type conversion. It covers the question, text content type, and shared enum adapters. The changeset includes patch releases for both the core and Android artifacts because Android consumes these survey adapters.

## :green_heart: How did you test it?

- `./gradlew :posthog:test --tests 'com.posthog.internal.surveys.GsonSurveyAdaptersTest'`
- `make checkFormat`
- Autoreview against `origin/main`

The malformed-input cases share one parameterized setup covering all three adapter and target-type combinations.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's implementation worker made this change after a Slopo duplication review identified the unsafe catch-path logging. The implementation keeps the existing null return contract and adds parameterized malformed-object regression coverage for all affected adapter paths. Follow-up commits added the Android patch release and addressed review feedback about duplicated test setup.
