### PR TITLE
fix(server): respect network and retry status during flush

### DIFF
--- a/.changeset/quiet-queues-wait.md
+++ b/.changeset/quiet-queues-wait.md
@@ -1,0 +1,5 @@
+---
+'posthog-server': patch
+---
+
+Respect network availability and retry pauses during explicit queue flushes.

--- a/.changeset/quiet-queues-wait.md
+++ b/.changeset/quiet-queues-wait.md
@@ -1,5 +1,6 @@
 ---
+'posthog': patch
 'posthog-server': patch
 ---
 
-Respect network availability and retry pauses during explicit queue flushes.
+Respect network availability and retry pauses during explicit queue flushes while allowing shutdown to retry pending events immediately.

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
@@ -72,6 +72,14 @@ internal class PostHogMemoryQueue(
     }
 
     override fun flush() {
+        flush(ignoreRetryPause = false)
+    }
+
+    override fun flushForShutdown() {
+        flush(ignoreRetryPause = true)
+    }
+
+    private fun flush(ignoreRetryPause: Boolean) {
         if (isFlushing.getAndSet(true)) {
             config.logger.log("Queue is flushing.")
             return
@@ -81,7 +89,7 @@ internal class PostHogMemoryQueue(
         // rather than racing ahead of them and seeing an empty queue
         executor.submitSyncSafely {
             try {
-                while (isAboveThreshold(1) && canFlushBatch() && executeBatch()) {
+                while (isAboveThreshold(1) && canFlushBatch(ignoreRetryPause) && executeBatch()) {
                     // Keep draining eligible, successful batches until the queue is empty.
                 }
             } finally {
@@ -141,8 +149,8 @@ internal class PostHogMemoryQueue(
         return false
     }
 
-    private fun canFlushBatch(): Boolean {
-        if (pausedUntil?.after(config.dateProvider.currentDate()) == true) {
+    private fun canFlushBatch(ignoreRetryPause: Boolean = false): Boolean {
+        if (!ignoreRetryPause && pausedUntil?.after(config.dateProvider.currentDate()) == true) {
             config.logger.log("Queue is paused until $pausedUntil")
             return false
         }

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
@@ -81,8 +81,10 @@ internal class PostHogMemoryQueue(
         // rather than racing ahead of them and seeing an empty queue
         executor.submitSyncSafely {
             try {
-                while (isAboveThreshold(1) && executeBatch()) {
-                    // Keep draining successful batches until the queue is empty.
+                if (canFlushBatch()) {
+                    while (isAboveThreshold(1) && executeBatch()) {
+                        // Keep draining successful batches until the queue is empty.
+                    }
                 }
             } finally {
                 isFlushing.set(false)

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogMemoryQueue.kt
@@ -81,10 +81,8 @@ internal class PostHogMemoryQueue(
         // rather than racing ahead of them and seeing an empty queue
         executor.submitSyncSafely {
             try {
-                if (canFlushBatch()) {
-                    while (isAboveThreshold(1) && executeBatch()) {
-                        // Keep draining successful batches until the queue is empty.
-                    }
+                while (isAboveThreshold(1) && canFlushBatch() && executeBatch()) {
+                    // Keep draining eligible, successful batches until the queue is empty.
                 }
             } finally {
                 isFlushing.set(false)

--- a/posthog-server/src/test/java/com/posthog/server/PostHogTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogTest.kt
@@ -374,6 +374,32 @@ internal class PostHogTest {
     }
 
     @Test
+    fun `close retries pending events despite retry pause`() {
+        val mockServer = MockWebServer()
+        mockServer.enqueue(MockResponse().setResponseCode(500))
+        mockServer.enqueue(MockResponse().setResponseCode(200))
+        mockServer.start()
+
+        val postHog =
+            PostHog.with(
+                PostHogConfig.builder(TEST_API_KEY)
+                    .host(mockServer.url("/").toString())
+                    .build(),
+            )
+
+        postHog.capture("user123", "test_event")
+        postHog.flush()
+
+        assertEquals(1, mockServer.requestCount)
+
+        postHog.close()
+
+        assertEquals(2, mockServer.requestCount, "Expected close() to bypass the retry pause")
+
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `capture with appendFeatureFlags false does not enrich properties`() {
         val mockServer = MockWebServer()
         mockServer.enqueue(MockResponse().setResponseCode(200))

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogMemoryQueueTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogMemoryQueueTest.kt
@@ -12,7 +12,9 @@ import com.posthog.server.createMockHttp
 import com.posthog.server.generateEvent
 import com.posthog.server.shutdownAndAwaitTermination
 import com.posthog.server.unGzip
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -248,6 +250,48 @@ internal class PostHogMemoryQueueTest {
         executor.awaitExecution()
 
         assertEquals(1, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `explicit flush stops draining if network disconnects between batches`() {
+        var connected = true
+        val http = createMockHttp()
+        http.dispatcher =
+            object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    connected = false
+                    return MockResponse().setBody("{}")
+                }
+            }
+        val sut =
+            getSut(
+                http.url("/").toString(),
+                flushAt = 10,
+                maxBatchSize = 2,
+                networkStatus =
+                    object : PostHogNetworkStatus {
+                        override fun isConnected() = connected
+                    },
+            )
+
+        repeat(3) {
+            sut.add(generateEvent())
+        }
+        executor.awaitExecution()
+
+        sut.flush()
+        executor.awaitExecution()
+
+        assertEquals(1, http.requestCount)
+
+        connected = true
+        sut.flush()
+        executor.awaitExecution()
+
+        assertEquals(2, http.requestCount)
 
         http.shutdown()
         executor.shutdownAndAwaitTermination()

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogMemoryQueueTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogMemoryQueueTest.kt
@@ -16,11 +16,24 @@ import okhttp3.mockwebserver.MockResponse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import java.util.Date
 import java.util.concurrent.Executors
 import kotlin.test.Test
 
 internal class PostHogMemoryQueueTest {
     private val executor = Executors.newSingleThreadScheduledExecutor(PostHogThreadFactory("Test"))
+
+    private class MutableDateProvider(
+        var nowMillis: Long = 0,
+    ) : PostHogDateProvider {
+        override fun currentDate(): Date = Date(nowMillis)
+
+        override fun addSecondsToCurrentDate(seconds: Int): Date = Date(nowMillis + seconds * 1000L)
+
+        override fun currentTimeMillis(): Long = nowMillis
+
+        override fun nanoTime(): Long = nowMillis * 1_000_000L
+    }
 
     private fun getSut(
         host: String,
@@ -203,6 +216,74 @@ internal class PostHogMemoryQueueTest {
         executor.awaitExecution()
 
         assertEquals(0, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `explicit flush does not flush if network is not connected`() {
+        val http = createMockHttp(MockResponse().setBody("{}"))
+        var connected = false
+        val sut =
+            getSut(
+                http.url("/").toString(),
+                flushAt = 10,
+                networkStatus =
+                    object : PostHogNetworkStatus {
+                        override fun isConnected() = connected
+                    },
+            )
+
+        sut.add(generateEvent())
+        executor.awaitExecution()
+
+        sut.flush()
+        executor.awaitExecution()
+
+        assertEquals(0, http.requestCount)
+
+        connected = true
+        sut.flush()
+        executor.awaitExecution()
+
+        assertEquals(1, http.requestCount)
+
+        http.shutdown()
+        executor.shutdownAndAwaitTermination()
+    }
+
+    @Test
+    fun `explicit flush waits for retry pause to expire`() {
+        val http =
+            createMockHttp(
+                MockResponse().setResponseCode(500),
+                MockResponse().setBody("{}"),
+            )
+        val dateProvider = MutableDateProvider()
+        val sut =
+            getSut(
+                http.url("/").toString(),
+                flushAt = 10,
+                dateProvider = dateProvider,
+                retryDelaySeconds = 5,
+            )
+
+        sut.add(generateEvent())
+        executor.awaitExecution()
+
+        sut.flush()
+        executor.awaitExecution()
+        assertEquals(1, http.requestCount)
+
+        sut.flush()
+        executor.awaitExecution()
+        assertEquals(1, http.requestCount)
+
+        dateProvider.nowMillis += 5_000
+        sut.flush()
+        executor.awaitExecution()
+        assertEquals(2, http.requestCount)
 
         http.shutdown()
         executor.shutdownAndAwaitTermination()

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -948,6 +948,7 @@ public final class com/posthog/internal/PostHogQueue : com/posthog/internal/Post
 	public fun add (Ljava/lang/Object;)V
 	public fun clear ()V
 	public fun flush ()V
+	public fun flushForShutdown ()V
 	public final fun getQueueDirectory ()Ljava/io/File;
 	public final fun reloadFromDisk ()V
 	public fun start ()V
@@ -958,8 +959,13 @@ public abstract interface class com/posthog/internal/PostHogQueueInterface {
 	public abstract fun add (Ljava/lang/Object;)V
 	public abstract fun clear ()V
 	public abstract fun flush ()V
+	public abstract fun flushForShutdown ()V
 	public abstract fun start ()V
 	public abstract fun stop ()V
+}
+
+public final class com/posthog/internal/PostHogQueueInterface$DefaultImpls {
+	public static fun flushForShutdown (Lcom/posthog/internal/PostHogQueueInterface;)V
 }
 
 public final class com/posthog/internal/PostHogRemoteConfig : com/posthog/internal/PostHogFeatureFlagsInterface {

--- a/posthog/src/main/java/com/posthog/PostHogStateless.kt
+++ b/posthog/src/main/java/com/posthog/PostHogStateless.kt
@@ -112,7 +112,7 @@ public open class PostHogStateless protected constructor(
                 }
 
                 // flush pending events before tearing down so queued data isn't lost
-                queue?.flush()
+                queue?.flushForShutdown()
 
                 enabled = false
 

--- a/posthog/src/main/java/com/posthog/internal/PostHogQueueInterface.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogQueueInterface.kt
@@ -16,6 +16,10 @@ public interface PostHogQueueInterface<Record> {
 
     public fun flush()
 
+    public fun flushForShutdown() {
+        flush()
+    }
+
     public fun start()
 
     public fun stop()


### PR DESCRIPTION
## :bulb: Motivation and Context

An explicit server queue flush could send events while the configured network status was offline or while the queue was waiting after a failed request. Timer and threshold flushes already respected both conditions. Explicit flushes should follow the same eligibility rules without dropping queued events.

This change checks queue eligibility before every batch in an explicit drain. Rechecking between batches also stops a long flush if connectivity changes while it is running. The existing flushing guard is still reset after every exit path.

## :green_heart: How did you test it?

- `./gradlew :posthog-server:test --tests 'com.posthog.server.internal.PostHogMemoryQueueTest' --rerun-tasks`
- `make checkFormat`
- Autoreview against `origin/main`

Added tests for an initially offline explicit flush, a disconnect between drained batches, and a retry pause that later expires.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [ ] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The developer asked Pi's worker agent to fix the queue eligibility findings from a duplication report. The implementation follows the existing file-backed queue behavior. Pi autoreview identified that connectivity also needed to be checked between drained batches, so the code and regression coverage were updated before opening this PR.
