### PR TITLE
fix(replay): keep manually started replay active after session rotation

### DIFF
--- a/.changeset/fix-manual-replay-start.md
+++ b/.changeset/fix-manual-replay-start.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix manually started session replay being stopped by a queued session-rotation callback when automatic replay is disabled with `sessionReplay = false`.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -2418,14 +2418,14 @@ public class PostHogReplayIntegration(
 
     /**
      * Whether the live (or, on a fetch failure, disk-cached) remote config permits recording the
-     * current session right now. Mirrors the decision [reevaluateRecordingState] makes — master
-     * switch, session-replay flag, event triggers, and the sampling decision — so the buffered
+     * current session right now. Mirrors the decision [reevaluateRecordingState] makes — automatic
+     * start setting, session-replay flag, event triggers, and the sampling decision — so the buffered
      * opening window is migrated only when the session is genuinely recordable, never for one the
      * fresh config samples out.
      */
     private fun isRecordingPermittedForCurrentSession(): Boolean {
         val remoteConfig = config.remoteConfigHolder ?: return false
-        if (!config.sessionReplay || !remoteConfig.isSessionReplayFlagActive()) {
+        if ((!config.sessionReplay && !isSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
             return false
         }
         if (shouldWaitForEventTriggers()) {
@@ -2436,9 +2436,10 @@ public class PostHogReplayIntegration(
     }
 
     /**
-     * Re-evaluate recording against the live remote config: stop when session replay is no longer
-     * permitted (master switch off, flag off, or sampled out) and resume when it turns on. Without
-     * this, a fresh-`false` would keep recording until the next session rotation.
+     * Re-evaluate recording against the live remote config: preserve a manual recording when
+     * automatic replay is off, stop when the project flag turns off or the session is sampled out,
+     * and automatically resume only when automatic replay is enabled. Without this, a fresh-`false`
+     * would keep recording until the next session rotation.
      *
      * The very first delivery is exempt from the **flag-off** stop only: on that delivery
      * [resolveFirstRemoteConfig] already owns the stop-and-drop decision for the buffered opening
@@ -2449,7 +2450,7 @@ public class PostHogReplayIntegration(
         val postHog = this.postHog ?: return
         val remoteConfig = config.remoteConfigHolder ?: return
 
-        if (!config.sessionReplay || !remoteConfig.isSessionReplayFlagActive()) {
+        if ((!config.sessionReplay && !isSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
             if (!isFirstDelivery) {
                 stopIfActive("Remote config disabled recording. Stopping.")
             }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -180,6 +180,9 @@ public class PostHogReplayIntegration(
     @Volatile
     private var isSessionReplayActive: Boolean = false
 
+    @Volatile
+    private var isManualSessionReplayActive: Boolean = false
+
     // Event triggers for session recording
     private val eventTriggersLock = Any()
 
@@ -2091,6 +2094,9 @@ public class PostHogReplayIntegration(
         resetSessionStateIfNeeded(currentSessionId, force = !resumeCurrent)
 
         isSessionReplayActive = true
+        // Automatic setup never starts while this setting is false. A start in that state comes
+        // from the manual API or an event trigger and must survive automatic-start checks.
+        isManualSessionReplayActive = !config.sessionReplay
 
         if (!resumeCurrent) {
             // Without this, on a static UI the first user-driven onDraw can be tens of seconds
@@ -2115,6 +2121,7 @@ public class PostHogReplayIntegration(
 
     override fun stop() {
         isSessionReplayActive = false
+        isManualSessionReplayActive = false
         synchronized(decorViews) {
             decorViews.values.forEach { it.drawState.invalidateMaskCapture() }
         }
@@ -2204,7 +2211,8 @@ public class PostHogReplayIntegration(
         mainHandler.handler.post {
             // config.sessionReplay controls automatic starts. An active replay may have been
             // started manually, so preserve it across rotation even when automatic replay is off.
-            if (!config.sessionReplay && !isSessionReplayActive) {
+            if (!config.sessionReplay && !isManualSessionReplayActive) {
+                if (isSessionReplayActive) stop()
                 return@post
             }
             if (remoteConfig?.isSessionReplayFlagActive() != true) {
@@ -2425,7 +2433,7 @@ public class PostHogReplayIntegration(
      */
     private fun isRecordingPermittedForCurrentSession(): Boolean {
         val remoteConfig = config.remoteConfigHolder ?: return false
-        if ((!config.sessionReplay && !isSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
+        if ((!config.sessionReplay && !isManualSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
             return false
         }
         if (shouldWaitForEventTriggers()) {
@@ -2450,7 +2458,7 @@ public class PostHogReplayIntegration(
         val postHog = this.postHog ?: return
         val remoteConfig = config.remoteConfigHolder ?: return
 
-        if ((!config.sessionReplay && !isSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
+        if ((!config.sessionReplay && !isManualSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
             if (!isFirstDelivery) {
                 stopIfActive("Remote config disabled recording. Stopping.")
             }
@@ -2494,6 +2502,7 @@ public class PostHogReplayIntegration(
             // persisting immediately (PostHogReplayQueue.shouldPersist reads isActive), instead of
             // leaking snapshots to the send queue in the window before the posted stop() runs on main.
             isSessionReplayActive = false
+            isManualSessionReplayActive = false
             mainHandler.handler.post { stop() }
         }
     }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -177,11 +177,20 @@ public class PostHogReplayIntegration(
             color = Color.BLACK
         }
 
-    @Volatile
-    private var isSessionReplayActive: Boolean = false
+    private enum class RecordingState {
+        INACTIVE,
+        AUTOMATIC,
+        MANUAL,
+    }
 
     @Volatile
-    private var isManualSessionReplayActive: Boolean = false
+    private var recordingState: RecordingState = RecordingState.INACTIVE
+
+    private val isSessionReplayActive: Boolean
+        get() = recordingState != RecordingState.INACTIVE
+
+    private val isManualSessionReplayActive: Boolean
+        get() = recordingState == RecordingState.MANUAL
 
     // Event triggers for session recording
     private val eventTriggersLock = Any()
@@ -576,7 +585,7 @@ public class PostHogReplayIntegration(
                 status.drawState.invalidateMaskCapture()
             }
 
-            isSessionReplayActive = false
+            recordingState = RecordingState.INACTIVE
 
             pixelCopyThread?.quitSafely()
             pixelCopyThread = null
@@ -2093,10 +2102,9 @@ public class PostHogReplayIntegration(
         val currentSessionId = postHog?.getSessionId()?.toString()
         resetSessionStateIfNeeded(currentSessionId, force = !resumeCurrent)
 
-        isSessionReplayActive = true
         // Automatic setup never starts while this setting is false. A start in that state comes
         // from the manual API or an event trigger and must survive automatic-start checks.
-        isManualSessionReplayActive = !config.sessionReplay
+        recordingState = if (config.sessionReplay) RecordingState.AUTOMATIC else RecordingState.MANUAL
 
         if (!resumeCurrent) {
             // Without this, on a static UI the first user-driven onDraw can be tens of seconds
@@ -2120,8 +2128,7 @@ public class PostHogReplayIntegration(
     }
 
     override fun stop() {
-        isSessionReplayActive = false
-        isManualSessionReplayActive = false
+        recordingState = RecordingState.INACTIVE
         synchronized(decorViews) {
             decorViews.values.forEach { it.drawState.invalidateMaskCapture() }
         }
@@ -2501,8 +2508,7 @@ public class PostHogReplayIntegration(
             // Flip the active gate synchronously so a concurrent add() on the replay executor stops
             // persisting immediately (PostHogReplayQueue.shouldPersist reads isActive), instead of
             // leaking snapshots to the send queue in the window before the posted stop() runs on main.
-            isSessionReplayActive = false
-            isManualSessionReplayActive = false
+            recordingState = RecordingState.INACTIVE
             mainHandler.handler.post { stop() }
         }
     }

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -2202,11 +2202,9 @@ public class PostHogReplayIntegration(
         // rotated; going through PostHog.startSessionReplay(false) would double-rotate).
         config.logger.log("[Session Replay] Session changed. Re-initializing recording for new session.")
         mainHandler.handler.post {
-            // config.sessionReplay is the customer-facing master switch: a config-level disable
-            // must not be overridden by remote flag + sampling. Manual PostHog.startSessionReplay
-            // calls and trigger-matched starts go through different code paths and are unaffected.
-            if (!config.sessionReplay) {
-                if (isSessionReplayActive) stop()
+            // config.sessionReplay controls automatic starts. An active replay may have been
+            // started manually, so preserve it across rotation even when automatic replay is off.
+            if (!config.sessionReplay && !isSessionReplayActive) {
                 return@post
             }
             if (remoteConfig?.isSessionReplayFlagActive() != true) {

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -414,9 +414,7 @@ internal class PostHogReplayIntegrationTest {
     }
 
     @Test
-    fun `onSessionIdChanged stops active replay on rotation when config sessionReplay is false`() {
-        // Defensive: if replay was somehow started (e.g. trigger-matched, or pre-config-flip),
-        // a rotation under config.sessionReplay = false should stop it rather than restart.
+    fun `onSessionIdChanged keeps manually active replay running when config sessionReplay is false`() {
         val sut =
             getSut(
                 configWithSampling(
@@ -435,7 +433,39 @@ internal class PostHogReplayIntegrationTest {
             sut.onSessionIdChanged()
             shadowOf(Looper.getMainLooper()).idle()
 
-            assertFalse(sut.isActive())
+            assertTrue(sut.isActive())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `manual replay start survives queued session change when config sessionReplay is false`() {
+        val sut =
+            getSut(
+                configWithSampling(
+                    flagActive = true,
+                    samplingPasses = true,
+                    sessionReplay = false,
+                ),
+            )
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            PostHogSessionManager.startSession()
+
+            // Mirror PostHog.startSessionReplay(resumeCurrent = false): session changes notify
+            // replay before the explicit manual start, while re-initialization is queued on main.
+            PostHogSessionManager.endSession()
+            sut.onSessionIdChanged()
+            PostHogSessionManager.startSession()
+            sut.onSessionIdChanged()
+            sut.start(resumeCurrent = false)
+
+            assertTrue(sut.isActive())
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertTrue(sut.isActive())
         } finally {
             sut.uninstall()
         }

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -661,6 +661,34 @@ internal class PostHogReplayIntegrationTest {
     }
 
     @Test
+    fun `first remote config keeps manually started replay active when automatic replay is disabled`() {
+        val fx =
+            createIntegrationWithRealQueue(
+                flagActive = true,
+                hasFetched = false,
+                sessionReplay = false,
+            )
+        val postHog = mock<PostHogInterface>()
+        whenever(postHog.getSessionId()).thenReturn(UUID.randomUUID())
+        fx.sut.install(postHog)
+        fx.sut.start(resumeCurrent = true)
+        try {
+            fx.replayQueue.add(createTestEvent("snapshot_1"))
+            Thread.sleep(5)
+            fx.replayQueue.add(createTestEvent("snapshot_2"))
+            awaitReplayExecutors()
+            assertEquals(2, fx.replayQueue.bufferDepth)
+
+            fx.sut.onRemoteConfig()
+
+            awaitCondition { fx.replayQueue.bufferDepth == 0 && fx.replayQueue.depth == 2 }
+            assertTrue(fx.sut.isActive())
+        } finally {
+            fx.sut.uninstall()
+        }
+    }
+
+    @Test
     fun `first remote config with flag off clears buffer and stops recording`() {
         val fx = createIntegrationWithRealQueue(flagActive = false, hasFetched = false)
         fx.sut.install(mock<PostHogInterface>())
@@ -729,6 +757,28 @@ internal class PostHogReplayIntegrationTest {
             shadowOf(Looper.getMainLooper()).idle()
 
             assertFalse(fx.sut.isActive())
+        } finally {
+            fx.sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `onRemoteConfig keeps manually started replay active when automatic replay is disabled`() {
+        val fx =
+            createIntegrationWithRealQueue(
+                flagActive = true,
+                hasFetched = true,
+                sessionReplay = false,
+            )
+        val postHog = mock<PostHogInterface>()
+        whenever(postHog.getSessionId()).thenReturn(UUID.randomUUID())
+        fx.sut.install(postHog)
+        fx.sut.start(resumeCurrent = true)
+        try {
+            fx.sut.onRemoteConfig()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertTrue(fx.sut.isActive())
         } finally {
             fx.sut.uninstall()
         }

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -440,6 +440,27 @@ internal class PostHogReplayIntegrationTest {
     }
 
     @Test
+    fun `onSessionIdChanged stops automatically started replay after config sessionReplay turns false`() {
+        val config = configWithSampling(flagActive = true, samplingPasses = true)
+        val sut = getSut(config)
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            PostHogSessionManager.startSession()
+            sut.start(resumeCurrent = true)
+            assertTrue(sut.isActive())
+
+            config.sessionReplay = false
+            sut.onSessionIdChanged()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertFalse(sut.isActive())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
     fun `manual replay start survives queued session change when config sessionReplay is false`() {
         val sut =
             getSut(
@@ -779,6 +800,24 @@ internal class PostHogReplayIntegrationTest {
             shadowOf(Looper.getMainLooper()).idle()
 
             assertTrue(fx.sut.isActive())
+        } finally {
+            fx.sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `onRemoteConfig stops automatically started replay after automatic replay is disabled`() {
+        val fx = createIntegrationWithRealQueue(flagActive = true, hasFetched = true)
+        val postHog = mock<PostHogInterface>()
+        whenever(postHog.getSessionId()).thenReturn(UUID.randomUUID())
+        fx.sut.install(postHog)
+        fx.sut.start(resumeCurrent = true)
+        try {
+            fx.config.sessionReplay = false
+            fx.sut.onRemoteConfig()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertFalse(fx.sut.isActive())
         } finally {
             fx.sut.uninstall()
         }


### PR DESCRIPTION
## :bulb: Motivation and Context

Calling `PostHog.startSessionReplay(false)` with automatic replay disabled creates a new session. The session-change callback is queued before the manual start completes. When that callback runs, it sees `sessionReplay = false` and stops the recording, so `isSessionReplayActive()` briefly reports `true` but no snapshots are captured.

This change tracks whether recording started while automatic replay was disabled. Session changes and remote-config updates preserve that manual recording, including the first live config response during cold start. An inactive recorder is not started when `sessionReplay` is false, and an automatically started recording still stops if that setting changes to false. Project replay flags and sampling decisions continue to apply.

Fixes #721.

## :green_heart: How did you test it?

- `./gradlew :posthog-android:test`
- `make checkFormat`
- Added regression tests for manual replay during session rotation and the queued callback ordering.
- Android 15 emulator in wireframe mode with `sessionReplay = false` and a main-thread `startSessionReplay(false)` call. Before the fix, replay reported active but sent no snapshot requests. With the fix, it sent the full wireframe and interaction snapshots to `/s/`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the regression, reproduced both the queued callback and first remote-config paths, and implemented the fix. Recording state is published atomically so background callers cannot expose a partially updated manual-start state. The project replay flag and sampling checks remain in place.
