### PR TITLE
fix(release): opt private packages into changesets v3 versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
     "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": []
+    "ignore": [],
+    "privatePackages": { "version": true, "tag": false }
 }


### PR DESCRIPTION
## Problem

`@changesets/cli` v3 stopped versioning private packages unless you opt in. Every workspace package here is `"private": true` (`posthog`, `posthog-android`, `posthog-android-surveys-compose`, `posthog-server`, `posthog-android-gradle-plugin` all exist only to track versions for changesets), so on v3 `pnpm changeset version` becomes a no-op: versions stay put, changeset files stay in place, and it prints its usual success line and exits 0.

That cascades quietly through `release.yml`. `Check for version bump changes` finds an empty `git status --porcelain`, so `Commit version bump`, `Tag and push` and `Create GitHub release` are all skipped while the run still reports success, because every step genuinely succeeded.

This repo is still on `^2.31.1` so nothing is broken yet, but the npm dependabot group is `patterns: ["*"]` on a weekly schedule with a 7-day cooldown, so the v3 bump is queued rather than avoided. The same bump already cost posthog-ios two releases (PostHog/posthog-ios#778), posthog-flutter two (PostHog/posthog-flutter#546) and posthog-go one (PostHog/posthog-go#292). Fixing it ahead of the bump is a lot cheaper than noticing afterwards that a release quietly did nothing.

## Changes

Sets `privatePackages: { "version": true, "tag": false }` in `.changeset/config.json`, which is a no-op on the current v2 and keeps versioning working when v3 lands. `tag: false` because `Tag and push ${{ matrix.package.name }}` creates the per-package tags itself, nothing here calls `changeset tag`.

## How did you test it?

Ran `changeset version` on CLI 3.0.0 against a copy of this branch's `.changeset/`, `pnpm-workspace.yaml` and all five workspace `package.json` files, with a synthetic `posthog-android` patch changeset:

| config | result |
| --- | --- |
| without this fix | stays on `3.60.4`, changeset untouched, exits 0 |
| with this fix | bumps to `3.60.5`, changeset consumed |

No changeset on this PR, it's a release-config fix with nothing user-facing for the changelog. `release.yml` filters on `.changeset/*.md`, so touching `config.json` won't kick off a release on merge.

## 🤖 Agent context

**DRI:** @ioannisj
**Autonomy:** Human-driven (agent-assisted)
