### PR TITLE
fix(replay): resume manually started replay after an internal stop

### DIFF
--- a/.changeset/manual-replay-survives-internal-stop.md
+++ b/.changeset/manual-replay-survives-internal-stop.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Fix session replay started with `sessionReplay = false` staying stopped for the rest of the process after an internal stop, such as the session being cleared while the app is backgrounded.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -177,20 +177,14 @@ public class PostHogReplayIntegration(
             color = Color.BLACK
         }
 
-    private enum class RecordingState {
-        INACTIVE,
-        AUTOMATIC,
-        MANUAL,
-    }
-
     @Volatile
-    private var recordingState: RecordingState = RecordingState.INACTIVE
+    private var isSessionReplayActive: Boolean = false
 
-    private val isSessionReplayActive: Boolean
-        get() = recordingState != RecordingState.INACTIVE
-
-    private val isManualSessionReplayActive: Boolean
-        get() = recordingState == RecordingState.MANUAL
+    // Set by any start that happens while config.sessionReplay is false — the manual API or an
+    // event trigger. Survives stopRecording() so an internal stop (session cleared, sampled out,
+    // flag off) can still resume later; only an explicit stop() or uninstall() clears it.
+    @Volatile
+    private var startedWithAutomaticDisabled: Boolean = false
 
     // Event triggers for session recording
     private val eventTriggersLock = Any()
@@ -585,7 +579,8 @@ public class PostHogReplayIntegration(
                 status.drawState.invalidateMaskCapture()
             }
 
-            recordingState = RecordingState.INACTIVE
+            startedWithAutomaticDisabled = false
+            isSessionReplayActive = false
 
             pixelCopyThread?.quitSafely()
             pixelCopyThread = null
@@ -2102,9 +2097,8 @@ public class PostHogReplayIntegration(
         val currentSessionId = postHog?.getSessionId()?.toString()
         resetSessionStateIfNeeded(currentSessionId, force = !resumeCurrent)
 
-        // Automatic setup never starts while this setting is false. A start in that state comes
-        // from the manual API or an event trigger and must survive automatic-start checks.
-        recordingState = if (config.sessionReplay) RecordingState.AUTOMATIC else RecordingState.MANUAL
+        startedWithAutomaticDisabled = !config.sessionReplay
+        isSessionReplayActive = true
 
         if (!resumeCurrent) {
             // Without this, on a static UI the first user-driven onDraw can be tens of seconds
@@ -2128,7 +2122,12 @@ public class PostHogReplayIntegration(
     }
 
     override fun stop() {
-        recordingState = RecordingState.INACTIVE
+        startedWithAutomaticDisabled = false
+        stopRecording()
+    }
+
+    private fun stopRecording() {
+        isSessionReplayActive = false
         synchronized(decorViews) {
             decorViews.values.forEach { it.drawState.invalidateMaskCapture() }
         }
@@ -2195,7 +2194,7 @@ public class PostHogReplayIntegration(
         if (!triggers.isNullOrEmpty() && activatedSession != currentSessionId) {
             if (isSessionReplayActive) {
                 config.logger.log("[Session Replay] Session changed. Stopping until trigger is matched.")
-                stop()
+                stopRecording()
             }
             return
         }
@@ -2205,7 +2204,7 @@ public class PostHogReplayIntegration(
         if (currentSessionId == null) {
             if (isSessionReplayActive) {
                 config.logger.log("[Session Replay] Session cleared. Stopping recording.")
-                mainHandler.handler.post { stop() }
+                mainHandler.handler.post { stopRecording() }
             }
             return
         }
@@ -2216,21 +2215,21 @@ public class PostHogReplayIntegration(
         // rotated; going through PostHog.startSessionReplay(false) would double-rotate).
         config.logger.log("[Session Replay] Session changed. Re-initializing recording for new session.")
         mainHandler.handler.post {
-            // config.sessionReplay controls automatic starts. An active replay may have been
-            // started manually, so preserve it across rotation even when automatic replay is off.
-            if (!config.sessionReplay && !isManualSessionReplayActive) {
-                if (isSessionReplayActive) stop()
+            // config.sessionReplay controls automatic starts. A recording started while it was
+            // off must survive rotation, so it is preserved here too.
+            if (!config.sessionReplay && !startedWithAutomaticDisabled) {
+                if (isSessionReplayActive) stopRecording()
                 return@post
             }
             if (remoteConfig?.isSessionReplayFlagActive() != true) {
-                if (isSessionReplayActive) stop()
+                if (isSessionReplayActive) stopRecording()
                 return@post
             }
             if (remoteConfig.makeSamplingDecision(currentSessionId).not()) {
-                if (isSessionReplayActive) stop()
+                if (isSessionReplayActive) stopRecording()
                 return@post
             }
-            if (isSessionReplayActive) stop()
+            if (isSessionReplayActive) stopRecording()
             start(resumeCurrent = false)
         }
     }
@@ -2421,7 +2420,7 @@ public class PostHogReplayIntegration(
             // Self-gate the capturer first so no new snapshot re-enters the buffer, then drop the
             // buffer, and only then disarm — an in-flight add() checks isBuffering and enqueues in
             // separate steps, so it could otherwise route a stale snapshot past the disarm.
-            stop()
+            stopRecording()
             replayQueue?.clearBuffer()
             synchronized(bufferingLock) {
                 if (bufferingGeneration == generation) {
@@ -2440,7 +2439,7 @@ public class PostHogReplayIntegration(
      */
     private fun isRecordingPermittedForCurrentSession(): Boolean {
         val remoteConfig = config.remoteConfigHolder ?: return false
-        if ((!config.sessionReplay && !isManualSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
+        if ((!config.sessionReplay && !startedWithAutomaticDisabled) || !remoteConfig.isSessionReplayFlagActive()) {
             return false
         }
         if (shouldWaitForEventTriggers()) {
@@ -2465,7 +2464,7 @@ public class PostHogReplayIntegration(
         val postHog = this.postHog ?: return
         val remoteConfig = config.remoteConfigHolder ?: return
 
-        if ((!config.sessionReplay && !isManualSessionReplayActive) || !remoteConfig.isSessionReplayFlagActive()) {
+        if ((!config.sessionReplay && !startedWithAutomaticDisabled) || !remoteConfig.isSessionReplayFlagActive()) {
             if (!isFirstDelivery) {
                 stopIfActive("Remote config disabled recording. Stopping.")
             }
@@ -2507,9 +2506,9 @@ public class PostHogReplayIntegration(
             config.logger.log("[Session Replay] $reason")
             // Flip the active gate synchronously so a concurrent add() on the replay executor stops
             // persisting immediately (PostHogReplayQueue.shouldPersist reads isActive), instead of
-            // leaking snapshots to the send queue in the window before the posted stop() runs on main.
-            recordingState = RecordingState.INACTIVE
-            mainHandler.handler.post { stop() }
+            // leaking snapshots to the send queue in the window before the posted stopRecording() runs on main.
+            isSessionReplayActive = false
+            mainHandler.handler.post { stopRecording() }
         }
     }
 

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -556,6 +556,47 @@ internal class PostHogReplayIntegrationTest {
     }
 
     @Test
+    fun `trigger started replay does not resume on a session the trigger has not activated`() {
+        val remoteConfig =
+            mock<PostHogRemoteConfig> {
+                on { isSessionReplayFlagActive() } doReturn true
+                on { makeSamplingDecision(any()) } doReturn true
+                on { getEventTriggers() } doReturn setOf("checkout_started")
+                on { hasRemoteConfigFetched() } doReturn true
+            }
+        val config =
+            PostHogAndroidConfig(API_KEY).apply {
+                remoteConfigHolder = remoteConfig
+                sessionReplay = false
+            }
+        val sut = getSut(config)
+        val postHog = mock<PostHogInterface>()
+        whenever(postHog.getSessionId()).thenAnswer { PostHogSessionManager.peekSessionId() }
+        sut.install(postHog)
+        try {
+            PostHogSessionManager.startSession()
+            sut.onEvent("checkout_started", null)
+            shadowOf(Looper.getMainLooper()).idle()
+            assertTrue(sut.isActive())
+
+            // Rotating into a session the trigger has not matched must stop recording, and the
+            // preserved manual intent must not let remote config resume it behind the trigger gate.
+            PostHogSessionManager.endSession()
+            PostHogSessionManager.startSession()
+            sut.onSessionIdChanged()
+            shadowOf(Looper.getMainLooper()).idle()
+            assertFalse(sut.isActive())
+
+            sut.onRemoteConfig()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertFalse(sut.isActive())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
     fun `clears buffer when PostHogReplayIntegration is installed`() {
         val config = PostHogAndroidConfig(API_KEY)
         val replayQueue = createReplayQueue(config)

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -493,6 +493,69 @@ internal class PostHogReplayIntegrationTest {
     }
 
     @Test
+    fun `manually started replay resumes after the session is cleared and a new one starts`() {
+        val sut =
+            getSut(
+                configWithSampling(
+                    flagActive = true,
+                    samplingPasses = true,
+                    sessionReplay = false,
+                ),
+            )
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            PostHogSessionManager.startSession()
+            sut.start(resumeCurrent = false)
+            shadowOf(Looper.getMainLooper()).idle()
+            assertTrue(sut.isActive())
+
+            // Backgrounded past the inactivity window: the session is cleared and recording stops.
+            PostHogSessionManager.endSession()
+            sut.onSessionIdChanged()
+            shadowOf(Looper.getMainLooper()).idle()
+            assertFalse(sut.isActive())
+
+            PostHogSessionManager.startSession()
+            sut.onSessionIdChanged()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertTrue(sut.isActive())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `explicit stop of a manually started replay is not resumed by a rotation`() {
+        val sut =
+            getSut(
+                configWithSampling(
+                    flagActive = true,
+                    samplingPasses = true,
+                    sessionReplay = false,
+                ),
+            )
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            PostHogSessionManager.startSession()
+            sut.start(resumeCurrent = false)
+            shadowOf(Looper.getMainLooper()).idle()
+            sut.stop()
+
+            PostHogSessionManager.endSession()
+            PostHogSessionManager.startSession()
+            sut.onSessionIdChanged()
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertFalse(sut.isActive())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
     fun `clears buffer when PostHogReplayIntegration is installed`() {
         val config = PostHogAndroidConfig(API_KEY)
         val replayQueue = createReplayQueue(config)


### PR DESCRIPTION
## :bulb: Motivation and Context

Follow-up to #722. That PR fixed the reported symptom in #721 — a manual `startSessionReplay` no longer being killed by the session-change callback it triggers — but replay still dies permanently the first time anything else stops it.

`recordingState` held both "is recording" and "was started manually" in one field, so every `stop()` erased the manual intent. Once the session is cleared on a long background, the manual marker is gone and `!config.sessionReplay` blocks every restart path for the rest of the process.

Verified on a Pixel 9 emulator (Android 17) with `SESSION_INACTIVITY_DURATION` shortened to 30s, using the setup from #721 (`sessionReplay = false` + `startSessionReplay(false)`):

| | before background | after 45s backgrounded + 40s interaction |
|---|---|---|
| `main` (130ecd1f) | 11 snapshot POSTs | **11** — replay never returns |
| this branch | 11 snapshot POSTs | **58** |

```
[Session Replay] Session cleared. Stopping recording.
[Session Replay] Session changed. Re-initializing recording for new session.
→ 59 snapshots under the new session id
```

Automatic replay already recovered from the same clear (13 → 58), so this brings the manual path in line rather than changing automatic behaviour.

The fix splits the two facts apart: `startedWithAutomaticDisabled` records the intent, and internal stops go through a private `stopRecording()` that leaves it alone. Only an explicit `stop()` (i.e. `PostHog.stopSessionReplay()`) or `uninstall()` clears it, so a customer-initiated stop still sticks. This also removes the two-reads-of-one-volatile-field pattern in the rotation gate, since the two conditions now live in separate fields.

## :green_heart: How did you test it?

- `./gradlew :posthog-android:testDebugUnitTest :posthog:test :posthog:apiCheck :posthog-android:apiCheck` — 1251 tests, 0 failures, no public API change.
- `make checkFormat`
- Two new regression tests. `manually started replay resumes after the session is cleared and a new one starts` fails on `main` and passes here; `explicit stop of a manually started replay is not resumed by a rotation` pins the other direction so an explicit stop is not resurrected.
- Device runs above, plus an automatic-replay run to confirm that path is unchanged.

## :warning: Related, not fixed here

@ioannisj raised on #722 that an in-flight flags response can undo an explicit stop. Tracing it on device, the dominant path is `internalOnFeatureFlagsLoaded` in `PostHog.kt` — it calls `startSessionReplay(resumeCurrent = true)` on *every* flags load, not just the first, despite the comment saying otherwise. That is in `posthog` core, predates #722, and needs its own change; I've left it alone rather than half-fix it here. Confirmed on device: after `stopSessionReplay()`, an `identify()`-triggered reload restarts replay with or without this PR.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file
