### PR TITLE
fix(flags): handle empty evaluation key scopes

### DIFF
--- a/.changeset/gentle-flags-scope.md
+++ b/.changeset/gentle-flags-scope.md
@@ -1,0 +1,5 @@
+---
+'posthog-server': patch
+---
+
+Return an empty server flag snapshot when evaluation receives an explicit empty key scope.

--- a/posthog-server/src/main/java/com/posthog/server/PostHogEvaluateFlagsOptions.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogEvaluateFlagsOptions.kt
@@ -9,8 +9,9 @@ package com.posthog.server
  * @property personProperties Person properties to use for flag evaluation.
  * @property groupProperties Group properties to use for flag evaluation, keyed by group type.
  * @property flagKeys Optional list of flag keys to evaluate, scoping both local evaluation and the
- *   remote request. When null, all matching flags are evaluated. Keys with no local definition are
- *   included in the `/flags` fallback. After a clean response also omits a key, later calls suppress
+ *   remote request. When null, all matching flags are evaluated. An empty list returns an empty
+ *   snapshot without consulting caches, local definitions, or `/flags`. Keys with no local
+ *   definition are included in the `/flags` fallback. After a clean response also omits a key, later calls suppress
  *   its fallback until the next successful definitions refresh, bounding deleted keys and typos to
  *   at most one clean probe per refresh interval.
  * @property onlyEvaluateLocally Whether the snapshot must hold exactly what local evaluation
@@ -134,7 +135,8 @@ public class PostHogEvaluateFlagsOptions private constructor(
          * This scopes what the server computes; the snapshot's `only(...)` helper, by contrast,
          * filters in memory.
          *
-         * @param flagKeys Feature flag keys to request.
+         * @param flagKeys Feature flag keys to request. An empty list returns an empty snapshot
+         *   without performing evaluation work.
          * @return This builder.
          */
         public fun flagKeys(flagKeys: List<String>): Builder {

--- a/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
+++ b/posthog-server/src/main/java/com/posthog/server/PostHogInterface.kt
@@ -658,9 +658,11 @@ public sealed interface PostHogInterface {
      * @param groups groups for group-based flags
      * @param personProperties person properties for flag evaluation
      * @param groupProperties group properties for flag evaluation
-     * @param flagKeys when non-empty, restricts both local evaluation and the underlying request to
-     *   the given keys, so a flag you did not ask for cannot force a request. Requested keys with no
-     *   local definition are logged and included in the `/flags` fallback, so a flag created since
+     * @param flagKeys when null, evaluates all flags. An empty list returns an empty snapshot
+     *   without consulting caches, local definitions, or `/flags`. Otherwise, restricts both local
+     *   evaluation and the underlying request to the given keys, so a flag you did not ask for
+     *   cannot force a request. Requested keys with no local definition are logged and included in
+     *   the `/flags` fallback, so a flag created since
      *   the last definitions poll still resolves. After a clean response also omits a key, later
      *   calls suppress that key's fallback until the next successful definitions refresh. A deleted
      *   flag or typo therefore costs at most one clean probe per refresh interval. This is distinct

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -1000,6 +1000,10 @@ internal class PostHogFeatureFlags(
         onlyEvaluateLocally: Boolean,
         disableGeoip: Boolean,
     ): EvaluateFlagsResult {
+        if (flagKeys?.isEmpty() == true) {
+            return EMPTY_EVALUATE_FLAGS_RESULT
+        }
+
         if (onlyEvaluateLocally && personalApiKey == null) {
             logMissingPersonalApiKey()
             return EMPTY_EVALUATE_FLAGS_RESULT
@@ -1014,10 +1018,6 @@ internal class PostHogFeatureFlags(
                 flagKeys = flagKeys,
                 disableGeoip = disableGeoip,
             )
-        // Only local scoping treats an empty list as "no scope"; the cache key and the `/flags` body
-        // take the raw list.
-        val requestedKeys = flagKeys?.takeIf { it.isNotEmpty() }
-
         // Without definitions there is nothing to evaluate locally, so an existing entry ends the
         // call. This keeps the cached-failure backoff, and caps the blocking `/local_evaluation`
         // attempt below: a personal API key that always fails never sets `definitionsLoaded`.
@@ -1045,7 +1045,7 @@ internal class PostHogFeatureFlags(
                 groups,
                 personProperties,
                 groupProperties,
-                requestedKeys,
+                flagKeys,
             )
 
         val localFlags = local?.flags ?: EMPTY_FLAGS

--- a/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/PostHogEvaluateFlagsTest.kt
@@ -278,6 +278,30 @@ internal class PostHogEvaluateFlagsTest {
     }
 
     @Test
+    fun `explicit empty flagKeys returns a valid empty snapshot without a flags request`() {
+        val mockServer = MockWebServer()
+        mockServer.enqueue(jsonResponse(createFlagsResponse("unexpected", enabled = true)))
+        mockServer.start()
+
+        val postHog =
+            PostHog.with(
+                PostHogConfig.builder(TEST_API_KEY)
+                    .host(mockServer.url("/").toString())
+                    .build(),
+            )
+
+        val options = PostHogEvaluateFlagsOptions.builder().flagKeys(emptyList()).build()
+        val snapshot = postHog.evaluateFlags("user-1", options)
+
+        assertEquals("user-1", snapshot.distinctId)
+        assertTrue(snapshot.keys.isEmpty())
+        assertEquals(0, mockServer.requestCount, "an empty scope must not consult /flags")
+
+        postHog.close()
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `evaluateFlags uses request context distinctId when omitted or null`() {
         val cases =
             listOf<Pair<String, (PostHogInterface) -> PostHogFeatureFlagEvaluations>>(

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -5,11 +5,13 @@ import com.posthog.server.CountingDispatcher
 import com.posthog.server.PostHogBlockingFlagDefinitionCacheProvider
 import com.posthog.server.PostHogFlagDefinitionCacheProvider
 import com.posthog.server.TestLogger
+import com.posthog.server.conclusiveFlagDefinition
 import com.posthog.server.createEmptyFlagsResponse
 import com.posthog.server.createFlagsResponse
 import com.posthog.server.createFlagsResponseWithErrors
 import com.posthog.server.createFlagsResponseWithQuotaLimited
 import com.posthog.server.createLocalEvaluationResponse
+import com.posthog.server.createLocalEvaluationResponseFrom
 import com.posthog.server.createMockHttp
 import com.posthog.server.createMultipleFlagsResponse
 import com.posthog.server.createTestConfig
@@ -631,6 +633,92 @@ internal class PostHogFeatureFlagsTest {
             onlyEvaluateLocally = onlyEvaluateLocally,
             disableGeoip = false,
         )
+
+    @Test
+    fun `empty flagKeys skips caches local definitions and remote work while other scopes still evaluate`() {
+        val dispatcher =
+            CountingDispatcher(
+                {
+                    jsonResponse(
+                        createLocalEvaluationResponseFrom(
+                            conclusiveFlagDefinition("first-flag"),
+                            conclusiveFlagDefinition("second-flag"),
+                        ),
+                    )
+                },
+                { jsonResponse(createFlagsResponse("unexpected", enabled = true)) },
+            )
+        val mockServer = MockWebServer()
+        mockServer.dispatcher = dispatcher
+        mockServer.start()
+
+        val config = createTestConfig(host = mockServer.url("/").toString())
+        val definitionCache = TestFlagDefinitionCacheProvider(shouldFetch = true)
+        val featureFlags =
+            PostHogFeatureFlags(
+                config,
+                PostHogApi(config),
+                60000,
+                100,
+                localEvaluation = true,
+                personalApiKey = "test-personal-key",
+                pollerEnabled = false,
+                flagDefinitionCacheProvider = definitionCache,
+            )
+
+        val empty =
+            featureFlags.evaluateFlags(
+                distinctId = "user-1",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = emptyList(),
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+
+        assertTrue(empty.flags.isEmpty())
+        assertTrue(empty.locallyEvaluated.isEmpty())
+        assertNull(empty.requestId)
+        assertNull(empty.evaluatedAt)
+        assertNull(empty.definitionsLoadedAt)
+        assertNull(empty.responseError)
+        assertEquals(0, definitionCache.shouldFetchCalls, "must not consult the definition cache")
+        assertEquals(0, definitionCache.getCalls, "must not read cached definitions")
+        assertEquals(0, dispatcher.localEvaluationCalls.get(), "must not load local definitions")
+        assertEquals(0, dispatcher.flagsCalls.get(), "must not consult /flags")
+        assertEquals(0, mockServer.requestCount, "must do no request-time network work")
+
+        val all =
+            featureFlags.evaluateFlags(
+                distinctId = "user-1",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = null,
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+        val scoped =
+            featureFlags.evaluateFlags(
+                distinctId = "user-2",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = listOf("second-flag"),
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+
+        assertEquals(setOf("first-flag", "second-flag"), all.flags.keys, "null still evaluates all flags")
+        assertEquals(setOf("second-flag"), scoped.flags.keys, "a non-empty list remains exactly scoped")
+        assertEquals(1, definitionCache.shouldFetchCalls, "null uses the normal definition-cache path")
+        assertEquals(1, dispatcher.localEvaluationCalls.get(), "definitions load once through the normal path")
+        assertEquals(0, dispatcher.flagsCalls.get(), "both normal-path evaluations resolve locally")
+
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
 
     @Test
     fun `evaluateFlags forwards the original scope and keeps locally resolved flags`() {


### PR DESCRIPTION
## :bulb: Motivation and Context

`evaluateFlags` treated an explicit empty flag key list like an unrestricted local scope. That could consult definition caches, load local definitions, or call `/flags` even though the caller requested no flags.

This change implements the behavior defined in [sdk-specs PR #47](https://github.com/PostHog/sdk-specs/pull/47). When the flag key option is omitted or null, evaluation still includes all matching flags. An explicit empty list now returns a valid empty snapshot without consulting caches, local definitions, or `/flags`. A non-empty list still evaluates only the requested keys and preserves the existing remote fallback for unresolved keys.

The change only affects `posthog-server` and includes a patch changeset.

## :green_heart: How did you test it?

- `./gradlew :posthog-server:test --tests 'com.posthog.server.PostHogEvaluateFlagsTest' --tests 'com.posthog.server.internal.PostHogFeatureFlagsTest'` - passed. The two focused classes ran 102 tests with 0 failures, 0 errors, and 0 skipped tests.
- `make checkFormat` - passed.
- `./gradlew :posthog-server:lint` - passed.
- `~/.pi/agent/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean with no accepted or actionable findings for commit `2ca5342a6f53366f5b7e239e1c3774504292db03`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

<!-- For more details check RELEASING.md -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi's implementation agent used the `pr` and `autoreview` skills to inspect the prepared fix, add the required changeset, run focused validation, review the committed branch, push it, and open this draft PR. The implementation keeps the change at the server evaluation entry point so an explicit empty scope exits before any cache, local-definition, or network work. A human must review the PR before merge.
