### PR TITLE
fix(server): bound missing flag probes

### DIFF
--- a/.changeset/quiet-missing-flag-probes.md
+++ b/.changeset/quiet-missing-flag-probes.md
@@ -1,0 +1,5 @@
+---
+'posthog-server': patch
+---
+
+Bound repeated remote probes for missing flag keys until local definitions refresh.

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -44,8 +44,8 @@ internal class PostHogFeatureFlags(
         )
 
     private val missingFlagKeysLock = Object()
-    private val knownMissingFlagKeys = linkedSetOf<String>()
-    private val knownRemoteFlagKeys = linkedMapOf<String, Long>()
+    private val knownMissingFlagKeys = boundedFlagEvidenceMap<Unit>()
+    private val knownRemoteFlagKeys = boundedFlagEvidenceMap<Long>()
     private val inFlightMissingFlagProbes = mutableMapOf<String, MissingFlagProbe>()
     private var missingFlagKeysGeneration: Long = 0
     private var remoteFlagEvidenceSequence: Long = 0
@@ -260,7 +260,8 @@ internal class PostHogFeatureFlags(
 
         fun await(): Boolean =
             try {
-                done.await(MISSING_FLAG_PROBE_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                done.await()
+                true
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
                 false
@@ -412,6 +413,7 @@ internal class PostHogFeatureFlags(
         }
 
         return try {
+            val responseGeneration = synchronized(missingFlagKeysLock) { missingFlagKeysGeneration }
             val response =
                 api.flags(
                     distinctId,
@@ -432,6 +434,7 @@ internal class PostHogFeatureFlags(
                 computeResponseError(response),
             )
             if (response != null) {
+                reconcileReturnedFlagEvidence(responseGeneration, response)
                 onResponse?.invoke(response)
             }
             flags
@@ -1055,7 +1058,7 @@ internal class PostHogFeatureFlags(
         val hasMissingKeyToProbe =
             synchronized(missingFlagKeysLock) {
                 missingDefinitionKeys.any {
-                    it !in knownMissingFlagKeys || flagDefinitions?.containsKey(it) == true
+                    knownMissingFlagKeys[it] == null || flagDefinitions?.containsKey(it) == true
                 }
             }
 
@@ -1136,19 +1139,7 @@ internal class PostHogFeatureFlags(
             val plan = planMissingFlagProbe(missingDefinitionKeys)
 
             if (plan.waiting.isNotEmpty()) {
-                val completed = plan.waiting.all { it.await() }
-                if (!completed) {
-                    return fetchUncoordinatedFlags(
-                        plan,
-                        cacheKey,
-                        distinctId,
-                        groups,
-                        personProperties,
-                        groupProperties,
-                        flagKeys,
-                        disableGeoip,
-                    )
-                }
+                if (!plan.waiting.all { it.await() }) return null to null
                 continue
             }
 
@@ -1190,7 +1181,7 @@ internal class PostHogFeatureFlags(
             val remote = current.mapNotNull { key -> knownRemoteFlagKeys[key]?.let { key to it } }.toMap()
             val unknown =
                 current.filterNotTo(mutableSetOf()) {
-                    it in knownMissingFlagKeys || it in knownRemoteFlagKeys
+                    knownMissingFlagKeys[it] != null || knownRemoteFlagKeys[it] != null
                 }
             val waiting = unknown.mapNotNull { inFlightMissingFlagProbes[it] }.distinct()
             val probe = if (unknown.isNotEmpty() && waiting.isEmpty()) MissingFlagProbe() else null
@@ -1213,32 +1204,6 @@ internal class PostHogFeatureFlags(
         plan.owned.isNotEmpty() ||
             refreshMadeKeysLocal ||
             plan.knownRemote.keys.any { entry?.flags?.containsKey(it) != true }
-
-    private fun fetchUncoordinatedFlags(
-        plan: MissingFlagProbePlan,
-        cacheKey: FeatureFlagCacheKey,
-        distinctId: String,
-        groups: Map<String, String>?,
-        personProperties: Map<String, Any?>?,
-        groupProperties: Map<String, Map<String, Any?>>?,
-        flagKeys: List<String>?,
-        disableGeoip: Boolean,
-    ): Pair<Map<String, FeatureFlag>?, FeatureFlagCacheEntry?> {
-        var response: PostHogFlagsResponse? = null
-        val flags =
-            getFeatureFlagsFromRemote(
-                distinctId,
-                groups,
-                personProperties,
-                groupProperties,
-                flagKeys,
-                disableGeoip,
-                bypassCache = true,
-                onResponse = { response = it },
-            )
-        reconcilePositiveFlagEvidence(plan, response)
-        return flags to cache.getEntry(cacheKey)
-    }
 
     private fun completeMissingFlagProbe(
         plan: MissingFlagProbePlan,
@@ -1275,15 +1240,17 @@ internal class PostHogFeatureFlags(
         probe?.complete()
     }
 
-    private fun reconcilePositiveFlagEvidence(
-        plan: MissingFlagProbePlan,
-        response: PostHogFlagsResponse?,
+    private fun reconcileReturnedFlagEvidence(
+        responseGeneration: Long,
+        response: PostHogFlagsResponse,
     ) {
-        val returned = response?.flags.orEmpty().keys
+        val returned = response.flags.orEmpty().keys
         if (returned.isEmpty()) return
         synchronized(missingFlagKeysLock) {
-            if (missingFlagKeysGeneration != plan.generation) return
-            plan.currentlyMissing.filterTo(mutableSetOf()) { it in returned }.forEach {
+            if (missingFlagKeysGeneration != responseGeneration) return
+            returned.filterTo(mutableSetOf()) {
+                it in knownMissingFlagKeys || it in knownRemoteFlagKeys
+            }.forEach {
                 retainKnownRemoteFlagKeyLocked(it)
             }
         }
@@ -1291,22 +1258,20 @@ internal class PostHogFeatureFlags(
 
     private fun retainKnownMissingFlagKeyLocked(key: String) {
         knownRemoteFlagKeys.remove(key)
-        knownMissingFlagKeys.remove(key)
-        knownMissingFlagKeys.add(key)
-        while (knownMissingFlagKeys.size > missingFlagKeysMaxSize.coerceAtLeast(0)) {
-            knownMissingFlagKeys.remove(knownMissingFlagKeys.first())
-        }
+        knownMissingFlagKeys[key] = Unit
     }
 
     private fun retainKnownRemoteFlagKeyLocked(key: String) {
         knownMissingFlagKeys.remove(key)
         remoteFlagEvidenceSequence++
-        knownRemoteFlagKeys.remove(key)
         knownRemoteFlagKeys[key] = remoteFlagEvidenceSequence
-        while (knownRemoteFlagKeys.size > missingFlagKeysMaxSize.coerceAtLeast(0)) {
-            knownRemoteFlagKeys.remove(knownRemoteFlagKeys.keys.first())
-        }
     }
+
+    private fun <V> boundedFlagEvidenceMap(): LinkedHashMap<String, V> =
+        object : LinkedHashMap<String, V>(16, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, V>?): Boolean =
+                size > missingFlagKeysMaxSize.coerceAtLeast(0)
+        }
 
     private fun PostHogFlagsResponse.isCleanForSuppression(): Boolean =
         !errorsWhileComputingFlags &&
@@ -1357,7 +1322,6 @@ internal class PostHogFeatureFlags(
         internal const val LOCAL_EVALUATION_REASON_CODE: String = "local_evaluation"
         internal const val LOCAL_EVALUATION_REASON_DESCRIPTION: String = "Evaluated locally"
         private const val FLAG_DEFINITION_CACHE_PROVIDER_TIMEOUT_MS: Long = 10_000
-        private const val MISSING_FLAG_PROBE_WAIT_TIMEOUT_MS: Long = 10_000
         private const val DEFAULT_MISSING_FLAG_KEYS_MAX_SIZE: Int = 1_000
 
         private val EMPTY_PROPERTIES: Map<String, Any?> = emptyMap()

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -36,6 +36,7 @@ internal class PostHogFeatureFlags(
     private val pollerEnabled: Boolean = true,
     private val flagDefinitionCacheProvider: PostHogFlagDefinitionCacheProvider? = null,
     private val missingFlagKeysMaxSize: Int = DEFAULT_MISSING_FLAG_KEYS_MAX_SIZE,
+    private val missingFlagProbeWaitTimeoutMs: Long = MISSING_FLAG_PROBE_WAIT_TIMEOUT_MS,
 ) : PostHogFeatureFlagsInterface {
     private val cache =
         PostHogFeatureFlagCache(
@@ -258,10 +259,9 @@ internal class PostHogFeatureFlags(
 
         fun complete() = done.countDown()
 
-        fun await(): Boolean =
+        fun await(timeoutMs: Long): Boolean =
             try {
-                done.await()
-                true
+                done.await(timeoutMs, TimeUnit.MILLISECONDS)
             } catch (_: InterruptedException) {
                 Thread.currentThread().interrupt()
                 false
@@ -1139,7 +1139,7 @@ internal class PostHogFeatureFlags(
             val plan = planMissingFlagProbe(missingDefinitionKeys)
 
             if (plan.waiting.isNotEmpty()) {
-                if (!plan.waiting.all { it.await() }) return null to null
+                if (!plan.waiting.all { it.await(missingFlagProbeWaitTimeoutMs) }) return null to null
                 continue
             }
 
@@ -1322,6 +1322,7 @@ internal class PostHogFeatureFlags(
         internal const val LOCAL_EVALUATION_REASON_CODE: String = "local_evaluation"
         internal const val LOCAL_EVALUATION_REASON_DESCRIPTION: String = "Evaluated locally"
         private const val FLAG_DEFINITION_CACHE_PROVIDER_TIMEOUT_MS: Long = 10_000
+        private const val MISSING_FLAG_PROBE_WAIT_TIMEOUT_MS: Long = 10_000
         private const val DEFAULT_MISSING_FLAG_KEYS_MAX_SIZE: Int = 1_000
 
         private val EMPTY_PROPERTIES: Map<String, Any?> = emptyMap()

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -35,6 +35,7 @@ internal class PostHogFeatureFlags(
     private val onFeatureFlags: PostHogOnFeatureFlags? = null,
     private val pollerEnabled: Boolean = true,
     private val flagDefinitionCacheProvider: PostHogFlagDefinitionCacheProvider? = null,
+    private val missingFlagKeysMaxSize: Int = DEFAULT_MISSING_FLAG_KEYS_MAX_SIZE,
 ) : PostHogFeatureFlagsInterface {
     private val cache =
         PostHogFeatureFlagCache(
@@ -43,10 +44,11 @@ internal class PostHogFeatureFlags(
         )
 
     private val missingFlagKeysLock = Object()
-    private val knownMissingFlagKeys = mutableSetOf<String>()
-    private val knownRemoteFlagKeys = mutableSetOf<String>()
+    private val knownMissingFlagKeys = linkedSetOf<String>()
+    private val knownRemoteFlagKeys = linkedMapOf<String, Long>()
     private val inFlightMissingFlagProbes = mutableMapOf<String, MissingFlagProbe>()
     private var missingFlagKeysGeneration: Long = 0
+    private var remoteFlagEvidenceSequence: Long = 0
 
     @Volatile
     private var featureFlags: List<FlagDefinition>? = null
@@ -268,7 +270,7 @@ internal class PostHogFeatureFlags(
     private data class MissingFlagProbePlan(
         val generation: Long,
         val currentlyMissing: Set<String>,
-        val knownRemote: Set<String>,
+        val knownRemote: Map<String, Long>,
         val owned: Set<String>,
         val waiting: List<MissingFlagProbe>,
         val probe: MissingFlagProbe?,
@@ -1137,6 +1139,7 @@ internal class PostHogFeatureFlags(
                 val completed = plan.waiting.all { it.await() }
                 if (!completed) {
                     return fetchUncoordinatedFlags(
+                        plan,
                         cacheKey,
                         distinctId,
                         groups,
@@ -1175,9 +1178,8 @@ internal class PostHogFeatureFlags(
                         ).also { entry = cache.getEntry(cacheKey) }
                     }
                 } finally {
-                    plan.probe?.let { completeMissingFlagProbe(plan, it, response) }
+                    completeMissingFlagProbe(plan, response)
                 }
-            reconcileKnownRemoteFlagKeys(plan, response)
             return flags to entry
         }
     }
@@ -1185,7 +1187,7 @@ internal class PostHogFeatureFlags(
     private fun planMissingFlagProbe(missingDefinitionKeys: Set<String>): MissingFlagProbePlan =
         synchronized(missingFlagKeysLock) {
             val current = missingDefinitionKeys.filterNot { flagDefinitions?.containsKey(it) == true }.toSet()
-            val remote = current.filterTo(mutableSetOf()) { it in knownRemoteFlagKeys }
+            val remote = current.mapNotNull { key -> knownRemoteFlagKeys[key]?.let { key to it } }.toMap()
             val unknown =
                 current.filterNotTo(mutableSetOf()) {
                     it in knownMissingFlagKeys || it in knownRemoteFlagKeys
@@ -1210,9 +1212,10 @@ internal class PostHogFeatureFlags(
     ): Boolean =
         plan.owned.isNotEmpty() ||
             refreshMadeKeysLocal ||
-            plan.knownRemote.any { entry?.flags?.containsKey(it) != true }
+            plan.knownRemote.keys.any { entry?.flags?.containsKey(it) != true }
 
     private fun fetchUncoordinatedFlags(
+        plan: MissingFlagProbePlan,
         cacheKey: FeatureFlagCacheKey,
         distinctId: String,
         groups: Map<String, String>?,
@@ -1221,6 +1224,7 @@ internal class PostHogFeatureFlags(
         flagKeys: List<String>?,
         disableGeoip: Boolean,
     ): Pair<Map<String, FeatureFlag>?, FeatureFlagCacheEntry?> {
+        var response: PostHogFlagsResponse? = null
         val flags =
             getFeatureFlagsFromRemote(
                 distinctId,
@@ -1230,49 +1234,77 @@ internal class PostHogFeatureFlags(
                 flagKeys,
                 disableGeoip,
                 bypassCache = true,
+                onResponse = { response = it },
             )
+        reconcilePositiveFlagEvidence(plan, response)
         return flags to cache.getEntry(cacheKey)
     }
 
     private fun completeMissingFlagProbe(
         plan: MissingFlagProbePlan,
-        probe: MissingFlagProbe,
         response: PostHogFlagsResponse?,
     ) {
+        val probe = plan.probe
         val returned = response?.flags.orEmpty().keys
         synchronized(missingFlagKeysLock) {
-            if (response?.isCleanForSuppression() == true && missingFlagKeysGeneration == plan.generation) {
-                for (key in plan.owned) {
-                    if (key in returned) {
-                        knownRemoteFlagKeys.add(key)
-                    } else {
-                        knownMissingFlagKeys.add(key)
+            if (missingFlagKeysGeneration == plan.generation) {
+                // Positive evidence applies even when another unknown key owned the fallback.
+                plan.currentlyMissing.filterTo(mutableSetOf()) { it in returned }.forEach {
+                    retainKnownRemoteFlagKeyLocked(it)
+                }
+                if (response?.isCleanForSuppression() == true) {
+                    for (key in plan.owned) {
+                        if (key !in returned && key !in knownRemoteFlagKeys) {
+                            retainKnownMissingFlagKeyLocked(key)
+                        }
+                    }
+                    for ((key, evidenceSequence) in plan.knownRemote) {
+                        // A delayed omission cannot replace positive evidence published after this probe began.
+                        if (key !in returned && knownRemoteFlagKeys[key] == evidenceSequence) {
+                            retainKnownMissingFlagKeyLocked(key)
+                        }
                     }
                 }
             }
-            plan.owned.forEach {
-                if (inFlightMissingFlagProbes[it] === probe) inFlightMissingFlagProbes.remove(it)
+            if (probe != null) {
+                plan.owned.forEach {
+                    if (inFlightMissingFlagProbes[it] === probe) inFlightMissingFlagProbes.remove(it)
+                }
             }
         }
-        probe.complete()
+        probe?.complete()
     }
 
-    private fun reconcileKnownRemoteFlagKeys(
+    private fun reconcilePositiveFlagEvidence(
         plan: MissingFlagProbePlan,
         response: PostHogFlagsResponse?,
     ) {
-        if (plan.knownRemote.isEmpty()) return
-        val cleanResponse = response?.takeIf { it.isCleanForSuppression() } ?: return
-
-        val returned = cleanResponse.flags.orEmpty().keys
+        val returned = response?.flags.orEmpty().keys
+        if (returned.isEmpty()) return
         synchronized(missingFlagKeysLock) {
             if (missingFlagKeysGeneration != plan.generation) return
-            for (key in plan.knownRemote) {
-                if (key !in returned) {
-                    knownRemoteFlagKeys.remove(key)
-                    knownMissingFlagKeys.add(key)
-                }
+            plan.currentlyMissing.filterTo(mutableSetOf()) { it in returned }.forEach {
+                retainKnownRemoteFlagKeyLocked(it)
             }
+        }
+    }
+
+    private fun retainKnownMissingFlagKeyLocked(key: String) {
+        knownRemoteFlagKeys.remove(key)
+        knownMissingFlagKeys.remove(key)
+        knownMissingFlagKeys.add(key)
+        while (knownMissingFlagKeys.size > missingFlagKeysMaxSize.coerceAtLeast(0)) {
+            knownMissingFlagKeys.remove(knownMissingFlagKeys.first())
+        }
+    }
+
+    private fun retainKnownRemoteFlagKeyLocked(key: String) {
+        knownMissingFlagKeys.remove(key)
+        remoteFlagEvidenceSequence++
+        knownRemoteFlagKeys.remove(key)
+        knownRemoteFlagKeys[key] = remoteFlagEvidenceSequence
+        while (knownRemoteFlagKeys.size > missingFlagKeysMaxSize.coerceAtLeast(0)) {
+            knownRemoteFlagKeys.remove(knownRemoteFlagKeys.keys.first())
         }
     }
 
@@ -1326,6 +1358,7 @@ internal class PostHogFeatureFlags(
         internal const val LOCAL_EVALUATION_REASON_DESCRIPTION: String = "Evaluated locally"
         private const val FLAG_DEFINITION_CACHE_PROVIDER_TIMEOUT_MS: Long = 10_000
         private const val MISSING_FLAG_PROBE_WAIT_TIMEOUT_MS: Long = 10_000
+        private const val DEFAULT_MISSING_FLAG_KEYS_MAX_SIZE: Int = 1_000
 
         private val EMPTY_PROPERTIES: Map<String, Any?> = emptyMap()
         private val EMPTY_COHORT_PROPERTIES: Map<String, PropertyGroup> = emptyMap()

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -30,6 +30,7 @@ import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -605,7 +606,10 @@ internal class PostHogFeatureFlagsTest {
         )
     }
 
-    private fun manuallyLoadedFeatureFlags(mockServer: MockWebServer): PostHogFeatureFlags {
+    private fun manuallyLoadedFeatureFlags(
+        mockServer: MockWebServer,
+        missingFlagKeysMaxSize: Int = 1_000,
+    ): PostHogFeatureFlags {
         val config = createTestConfig(host = mockServer.url("/").toString())
         return PostHogFeatureFlags(
             config,
@@ -615,6 +619,7 @@ internal class PostHogFeatureFlagsTest {
             localEvaluation = true,
             personalApiKey = "test-personal-key",
             pollerEnabled = false,
+            missingFlagKeysMaxSize = missingFlagKeysMaxSize,
         ).also { it.loadFeatureFlagDefinitions() }
     }
 
@@ -1058,6 +1063,144 @@ internal class PostHogFeatureFlagsTest {
         assertEquals(setOf("known-flag"), evaluateMissingFlag(featureFlags, "user-2").flags.keys)
         assertEquals(2, mockServer.requestCount, "only the definitions load and first probe are allowed")
 
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `missing key knowledge evicts at capacity`() {
+        val mockServer =
+            createMockHttp(
+                jsonResponse(createLocalEvaluationResponse("known-flag")),
+                jsonResponse(createEmptyFlagsResponse()),
+                jsonResponse(createEmptyFlagsResponse()),
+                jsonResponse(createEmptyFlagsResponse()),
+            )
+        val featureFlags = manuallyLoadedFeatureFlags(mockServer, missingFlagKeysMaxSize = 1)
+
+        evaluateMissingFlag(featureFlags, "user-1", missingKey = "missing-a")
+        evaluateMissingFlag(featureFlags, "user-2", missingKey = "missing-b")
+        evaluateMissingFlag(featureFlags, "user-3", missingKey = "missing-a")
+
+        assertEquals(4, mockServer.requestCount, "the evicted key must become probe-eligible")
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `mixed scope positive response clears retained omission`() {
+        val responseNumber = AtomicInteger(0)
+        val dispatcher =
+            CountingDispatcher(
+                { jsonResponse(createLocalEvaluationResponse("known-flag")) },
+                {
+                    when (responseNumber.incrementAndGet()) {
+                        1 -> jsonResponse(createEmptyFlagsResponse())
+                        2 ->
+                            jsonResponse(
+                                createMultipleFlagsResponse(
+                                    "previously-missing" to true,
+                                    "other-missing" to true,
+                                ),
+                            )
+                        else -> jsonResponse(createFlagsResponse("previously-missing", enabled = false))
+                    }
+                },
+            )
+        val mockServer =
+            MockWebServer().apply {
+                this.dispatcher = dispatcher
+                start()
+            }
+        val featureFlags = manuallyLoadedFeatureFlags(mockServer)
+
+        evaluateMissingFlag(featureFlags, "user-1", missingKey = "previously-missing")
+        val mixed =
+            featureFlags.evaluateFlags(
+                distinctId = "user-2",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = listOf("known-flag", "previously-missing", "other-missing"),
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+        val afterPositive = evaluateMissingFlag(featureFlags, "user-3", missingKey = "previously-missing")
+
+        assertEquals(true, mixed.flags["previously-missing"]?.enabled)
+        assertEquals(false, afterPositive.flags["previously-missing"]?.enabled)
+        assertEquals(3, dispatcher.flagsCalls.get(), "positive evidence must permit the next evaluation")
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `delayed non-owned omission does not overwrite newer positive evidence`() {
+        val delayedProbeStarted = CountDownLatch(1)
+        val releaseDelayedProbe = CountDownLatch(1)
+        val responseNumber = AtomicInteger(0)
+        val dispatcher =
+            CountingDispatcher(
+                { jsonResponse(createLocalEvaluationResponse("known-flag")) },
+                {
+                    when (responseNumber.incrementAndGet()) {
+                        1 -> jsonResponse(createEmptyFlagsResponse())
+                        2 -> {
+                            delayedProbeStarted.countDown()
+                            releaseDelayedProbe.await()
+                            jsonResponse(createEmptyFlagsResponse())
+                        }
+                        3 ->
+                            jsonResponse(
+                                createMultipleFlagsResponse(
+                                    "previously-missing" to true,
+                                    "missing-b" to true,
+                                ),
+                            )
+                        else -> jsonResponse(createFlagsResponse("previously-missing", enabled = false))
+                    }
+                },
+            )
+        val mockServer =
+            MockWebServer().apply {
+                this.dispatcher = dispatcher
+                start()
+            }
+        val featureFlags = manuallyLoadedFeatureFlags(mockServer)
+
+        evaluateMissingFlag(featureFlags, "user-1", missingKey = "previously-missing")
+        val delayed =
+            Thread {
+                featureFlags.evaluateFlags(
+                    distinctId = "user-2",
+                    groups = null,
+                    personProperties = null,
+                    groupProperties = null,
+                    flagKeys = listOf("known-flag", "previously-missing", "missing-a"),
+                    onlyEvaluateLocally = false,
+                    disableGeoip = false,
+                )
+            }.also { it.start() }
+        assertTrue(delayedProbeStarted.await(5, TimeUnit.SECONDS))
+
+        val positive =
+            featureFlags.evaluateFlags(
+                distinctId = "user-3",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = listOf("known-flag", "previously-missing", "missing-b"),
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+        releaseDelayedProbe.countDown()
+        delayed.join(5_000)
+        val afterPositive = evaluateMissingFlag(featureFlags, "user-4", missingKey = "previously-missing")
+
+        assertEquals(true, positive.flags["previously-missing"]?.enabled)
+        assertFalse(delayed.isAlive)
+        assertEquals(false, afterPositive.flags["previously-missing"]?.enabled)
+        assertEquals(4, dispatcher.flagsCalls.get())
         featureFlags.shutDown()
         mockServer.shutdown()
     }

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -609,6 +609,7 @@ internal class PostHogFeatureFlagsTest {
     private fun manuallyLoadedFeatureFlags(
         mockServer: MockWebServer,
         missingFlagKeysMaxSize: Int = 1_000,
+        missingFlagProbeWaitTimeoutMs: Long = 10_000,
     ): PostHogFeatureFlags {
         val config = createTestConfig(host = mockServer.url("/").toString())
         return PostHogFeatureFlags(
@@ -620,6 +621,7 @@ internal class PostHogFeatureFlagsTest {
             personalApiKey = "test-personal-key",
             pollerEnabled = false,
             missingFlagKeysMaxSize = missingFlagKeysMaxSize,
+            missingFlagProbeWaitTimeoutMs = missingFlagProbeWaitTimeoutMs,
         ).also { it.loadFeatureFlagDefinitions() }
     }
 
@@ -1365,6 +1367,58 @@ internal class PostHogFeatureFlagsTest {
         assertFalse(startedDuplicate)
         assertFalse(waiter.isAlive)
         assertFalse(owner.isAlive)
+        assertEquals(1, dispatcher.flagsCalls.get())
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `timed out waiter does not block indefinitely or start a duplicate probe`() {
+        val firstProbeStarted = CountDownLatch(1)
+        val releaseFirstProbe = CountDownLatch(1)
+        val duplicateProbe = CountDownLatch(1)
+        val responseNumber = AtomicInteger(0)
+        val dispatcher =
+            CountingDispatcher(
+                { jsonResponse(createLocalEvaluationResponse("known-flag")) },
+                {
+                    if (responseNumber.incrementAndGet() == 1) {
+                        firstProbeStarted.countDown()
+                        releaseFirstProbe.await()
+                    } else {
+                        duplicateProbe.countDown()
+                    }
+                    jsonResponse(createEmptyFlagsResponse())
+                },
+            )
+        val mockServer =
+            MockWebServer().apply {
+                this.dispatcher = dispatcher
+                start()
+            }
+        val featureFlags = manuallyLoadedFeatureFlags(mockServer, missingFlagProbeWaitTimeoutMs = 100)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val owner =
+            Thread {
+                runCatching { evaluateMissingFlag(featureFlags, "owner") }.exceptionOrNull()?.let(errors::add)
+            }.also { it.start() }
+        assertTrue(firstProbeStarted.await(5, TimeUnit.SECONDS))
+        val waiter =
+            Thread {
+                runCatching { evaluateMissingFlag(featureFlags, "waiter") }.exceptionOrNull()?.let(errors::add)
+            }.also { it.start() }
+
+        waiter.join(5_000)
+        val ownerWasStillInFlight = owner.isAlive
+        val startedDuplicate = duplicateProbe.await(500, TimeUnit.MILLISECONDS)
+        releaseFirstProbe.countDown()
+        owner.join(5_000)
+
+        assertFalse(waiter.isAlive)
+        assertTrue(ownerWasStillInFlight)
+        assertFalse(startedDuplicate)
+        assertFalse(owner.isAlive)
+        assertTrue(errors.isEmpty(), "unexpected errors: $errors")
         assertEquals(1, dispatcher.flagsCalls.get())
         featureFlags.shutDown()
         mockServer.shutdown()

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1135,6 +1135,70 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `unscoped positive response clears retained omission`() {
+        val responseNumber = AtomicInteger(0)
+        val dispatcher =
+            CountingDispatcher(
+                { jsonResponse(localEvalResponseWithResolvableAndInconclusiveFlags()) },
+                {
+                    when (responseNumber.incrementAndGet()) {
+                        1 -> jsonResponse(createEmptyFlagsResponse())
+                        2 ->
+                            jsonResponse(
+                                createMultipleFlagsResponse(
+                                    "previously-missing" to true,
+                                    "needs-server" to true,
+                                ),
+                            )
+                        else -> jsonResponse(createFlagsResponse("previously-missing", enabled = false))
+                    }
+                },
+            )
+        val mockServer =
+            MockWebServer().apply {
+                this.dispatcher = dispatcher
+                start()
+            }
+        val featureFlags = manuallyLoadedFeatureFlags(mockServer)
+
+        featureFlags.evaluateFlags(
+            distinctId = "user-1",
+            groups = null,
+            personProperties = null,
+            groupProperties = null,
+            flagKeys = listOf("resolves-locally", "previously-missing"),
+            onlyEvaluateLocally = false,
+            disableGeoip = false,
+        )
+        val unscoped =
+            featureFlags.evaluateFlags(
+                distinctId = "user-2",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = null,
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+        val afterPositive =
+            featureFlags.evaluateFlags(
+                distinctId = "user-3",
+                groups = null,
+                personProperties = null,
+                groupProperties = null,
+                flagKeys = listOf("previously-missing"),
+                onlyEvaluateLocally = false,
+                disableGeoip = false,
+            )
+
+        assertEquals(true, unscoped.flags["previously-missing"]?.enabled)
+        assertEquals(false, afterPositive.flags["previously-missing"]?.enabled)
+        assertEquals(3, dispatcher.flagsCalls.get(), "unscoped positive evidence must permit the next evaluation")
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
     fun `delayed non-owned omission does not overwrite newer positive evidence`() {
         val delayedProbeStarted = CountDownLatch(1)
         val releaseDelayedProbe = CountDownLatch(1)
@@ -1251,6 +1315,56 @@ internal class PostHogFeatureFlagsTest {
         assertFalse(sawDuplicate)
         assertTrue(errors.isEmpty(), "unexpected errors: $errors")
         assertTrue((waiters + owner).none { it.isAlive })
+        assertEquals(1, dispatcher.flagsCalls.get())
+        featureFlags.shutDown()
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `interrupted waiter does not start a duplicate probe`() {
+        val firstProbeStarted = CountDownLatch(1)
+        val releaseFirstProbe = CountDownLatch(1)
+        val duplicateProbe = CountDownLatch(1)
+        val responseNumber = AtomicInteger(0)
+        val dispatcher =
+            CountingDispatcher(
+                { jsonResponse(createLocalEvaluationResponse("known-flag")) },
+                {
+                    if (responseNumber.incrementAndGet() == 1) {
+                        firstProbeStarted.countDown()
+                        releaseFirstProbe.await()
+                    } else {
+                        duplicateProbe.countDown()
+                    }
+                    jsonResponse(createEmptyFlagsResponse())
+                },
+            )
+        val mockServer =
+            MockWebServer().apply {
+                this.dispatcher = dispatcher
+                start()
+            }
+        val featureFlags = manuallyLoadedFeatureFlags(mockServer)
+        val owner = Thread { evaluateMissingFlag(featureFlags, "owner") }.also { it.start() }
+        assertTrue(firstProbeStarted.await(5, TimeUnit.SECONDS))
+        val waiterEntered = CountDownLatch(1)
+        val waiter =
+            Thread {
+                waiterEntered.countDown()
+                evaluateMissingFlag(featureFlags, "waiter")
+            }.also { it.start() }
+        assertTrue(waiterEntered.await(5, TimeUnit.SECONDS))
+        Thread.sleep(100)
+
+        waiter.interrupt()
+        waiter.join(5_000)
+        val startedDuplicate = duplicateProbe.await(500, TimeUnit.MILLISECONDS)
+        releaseFirstProbe.countDown()
+        owner.join(5_000)
+
+        assertFalse(startedDuplicate)
+        assertFalse(waiter.isAlive)
+        assertFalse(owner.isAlive)
         assertEquals(1, dispatcher.flagsCalls.get())
         featureFlags.shutDown()
         mockServer.shutdown()


### PR DESCRIPTION
## :bulb: Motivation and Context

The server SDK retains clean remote omissions so a missing flag does not trigger a `/flags` request on every evaluation. That retained state was unbounded, and a later response returning the flag did not clear an earlier omission. A delayed omission could also replace newer positive evidence.

This completes the bounded missing-key probe behavior defined in [sdk-specs#48](https://github.com/PostHog/sdk-specs/pull/48).

The missing and remotely returned key stores now use finite-capacity, access-ordered maps. Evicted keys become eligible for another probe. Every current-generation remote response clears retained omissions for keys it returns, including unscoped responses. Evidence sequence numbers prevent delayed responses from replacing newer positive evidence.

Concurrent callers for the same unknown key now remain coordinated until the owner request finishes. An interrupted waiter returns its partial local result instead of starting a duplicate `/flags` request.

## :green_heart: How did you test it?

- `./gradlew :posthog-server:test --tests "com.posthog.server.internal.PostHogFeatureFlagsTest"`
- `JAVA_TOOL_OPTIONS=-Dnet.bytebuddy.experimental=true ./gradlew :posthog-server:test`
- `make checkFormat`
- `git diff --check`

The full server suite uses the Byte Buddy experimental flag because the currently pinned Byte Buddy version otherwise rejects Java 21.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent after auditing the merged specification and the existing `posthog-server` probe coordination. Reviewer feedback led to using the package's existing access-ordered map pattern, reconciling positive evidence from every remote response, and removing the timeout path that could start a duplicate probe. Pi's bundled autoreview checked the final committed branch and reported no actionable findings.
