### PR TITLE
fix(flags): align presence operator semantics

### DIFF
--- a/.changeset/steady-flags-align.md
+++ b/.changeset/steady-flags-align.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Align local `is_set` and `is_not_set` evaluation with partial property context.

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -139,9 +139,8 @@ internal class FlagEvaluator(
             throw InconclusiveMatchException("Can't match properties without a given property value")
         }
 
-        // is_not_set operator can't be evaluated locally
-        if (propertyOperator == PropertyOperator.IS_NOT_SET) {
-            throw InconclusiveMatchException("Can't match properties with operator is_not_set")
+        if (propertyOperator == PropertyOperator.IS_SET || propertyOperator == PropertyOperator.IS_NOT_SET) {
+            return propertyOperator == PropertyOperator.IS_SET
         }
 
         val overrideValue = propertyValues[key]
@@ -157,7 +156,6 @@ internal class FlagEvaluator(
                 if (propertyOperator == PropertyOperator.EXACT) matches else !matches
             }
 
-            PropertyOperator.IS_SET -> propertyValues.containsKey(key)
             PropertyOperator.ICONTAINS ->
                 stringContains(
                     overrideValue.toString(),

--- a/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/PostHogFeatureFlags.kt
@@ -884,7 +884,7 @@ internal class PostHogFeatureFlags(
                 }
 
                 // Use group's key and properties for evaluation
-                Pair(groupKey, groupProperties)
+                Pair(groupKey, groupProperties?.get(groupTypeName))
             } else {
                 // Person-based flag - use person's ID and properties
                 Pair(distinctId, personProperties)

--- a/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
@@ -159,15 +159,58 @@ internal class FlagEvaluatorTest {
                 negation = false,
                 dependencyChain = null,
             )
-        val properties = mapOf("email" to "test@example.com")
-        assertTrue(evaluator.matchProperty(property, properties))
-
         val propertiesWithout = mapOf("name" to "Test")
         try {
             evaluator.matchProperty(property, propertiesWithout)
             assertTrue("Should have thrown InconclusiveMatchException", false)
         } catch (e: InconclusiveMatchException) {
             // Expected
+        }
+
+        val presentValues =
+            listOf(
+                null,
+                false,
+                0,
+                "",
+                emptyList<Any?>(),
+                emptyMap<String, Any?>(),
+            )
+        for (value in presentValues) {
+            assertTrue(evaluator.matchProperty(property, mapOf("email" to value)))
+        }
+    }
+
+    @Test
+    internal fun testMatchPropertyIsNotSet() {
+        val property =
+            FlagProperty(
+                key = "email",
+                propertyValue = null,
+                propertyOperator = PropertyOperator.IS_NOT_SET,
+                type = PropertyType.PERSON,
+                negation = false,
+                dependencyChain = null,
+            )
+        val propertiesWithout = mapOf("name" to "Test")
+        try {
+            evaluator.matchProperty(property, propertiesWithout)
+            assertTrue("Should have thrown InconclusiveMatchException", false)
+        } catch (e: InconclusiveMatchException) {
+            // Expected
+        }
+
+        val presentValues =
+            listOf(
+                null,
+                false,
+                0,
+                "",
+                emptyList<Any?>(),
+                emptyMap<String, Any?>(),
+            )
+        for (value in presentValues) {
+            assertFalse(evaluator.matchProperty(property, mapOf("email" to value)))
         }
     }
 

--- a/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/PostHogFeatureFlagsTest.kt
@@ -1699,6 +1699,77 @@ internal class PostHogFeatureFlagsTest {
     }
 
     @Test
+    fun `group presence operators use properties for the matching group type`() {
+        for ((operator, expected) in mapOf("is_set" to true, "is_not_set" to false)) {
+            val flagKey = "group-$operator"
+            val localEvalResponse =
+                """
+                {
+                    "flags": [
+                        {
+                            "id": 1,
+                            "name": "$flagKey",
+                            "key": "$flagKey",
+                            "active": true,
+                            "filters": {
+                                "aggregation_group_type_index": 2,
+                                "groups": [
+                                    {
+                                        "properties": [
+                                            {
+                                                "key": "plan",
+                                                "value": "$operator",
+                                                "operator": "$operator",
+                                                "type": "person",
+                                                "negation": false
+                                            }
+                                        ],
+                                        "rollout_percentage": 100
+                                    }
+                                ]
+                            },
+                            "version": 1
+                        }
+                    ],
+                    "group_type_mapping": { "2": "organization" },
+                    "cohorts": {}
+                }
+                """.trimIndent()
+            val logger = TestLogger()
+            val mockServer =
+                createMockHttp(
+                    jsonResponse(localEvalResponse),
+                    jsonResponse(createEmptyFlagsResponse()),
+                )
+            val config = createTestConfig(logger, mockServer.url("/").toString())
+            val featureFlags =
+                PostHogFeatureFlags(
+                    config,
+                    PostHogApi(config),
+                    60000,
+                    100,
+                    localEvaluation = true,
+                    personalApiKey = "test-personal-key",
+                )
+
+            val result =
+                featureFlags.getFeatureFlag(
+                    key = flagKey,
+                    defaultValue = null,
+                    distinctId = "user-123",
+                    groups = mapOf("organization" to "org-456"),
+                    groupProperties = mapOf("organization" to mapOf("plan" to null)),
+                )
+
+            assertEquals(expected, result)
+            assertTrue(logger.containsLog("Local evaluation successful"))
+
+            featureFlags.shutDown()
+            mockServer.shutdown()
+        }
+    }
+
+    @Test
     fun `group-based flag returns false when required group is missing`() {
         val logger = TestLogger()
         val localEvalResponse =


### PR DESCRIPTION
## :bulb: Motivation and Context

[sdk-specs PR #49](https://github.com/PostHog/sdk-specs/pull/49) defines presence operators using property-key presence and partial property context. The `posthog-server` evaluator treated a present null value as not set and could not resolve `is_not_set` when the key was present.

This change makes every present key match `is_set` and not match `is_not_set`, including null and other falsey values. An omitted key remains inconclusive so remote evaluation stays eligible. Group flags now select the property map for their matching group type before applying the same rules.

## :green_heart: How did you test it?

- `./gradlew :posthog-server:test --tests "com.posthog.server.internal.FlagEvaluatorTest"`
- `./gradlew :posthog-server:test --tests "com.posthog.server.internal.PostHogFeatureFlagsTest"`
- `./gradlew spotlessCheck`
- Autoreview completed on commit `6811c125` with no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent worker subagents implemented and validated the focused `posthog-server` change. The bundled autoreview tool reviewed the final committed diff against `origin/main`.
