### PR TITLE
fix(flags): align local string matching with the flags service

### DIFF
--- a/.changeset/calm-flags-fold.md
+++ b/.changeset/calm-flags-fold.md
@@ -2,4 +2,4 @@
 "posthog-server": patch
 ---
 
-Match local feature flag string operators using the same ASCII and Unicode lowercase rules as the flags service.
+Match local feature flag string operators using the flags service's boolean coercion, JSON stringification, and case rules.

--- a/.changeset/calm-flags-fold.md
+++ b/.changeset/calm-flags-fold.md
@@ -1,0 +1,5 @@
+---
+"posthog-server": patch
+---
+
+Match local feature flag string operators using the same ASCII and Unicode lowercase rules as the flags service.

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -10,7 +10,6 @@ import com.posthog.internal.PropertyOperator
 import com.posthog.internal.PropertyType
 import com.posthog.internal.PropertyValue
 import java.security.MessageDigest
-import java.text.Normalizer
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -29,7 +28,6 @@ internal class FlagEvaluator(
     companion object {
         private const val LONG_SCALE = 0xFFFFFFFFFFFFFFF.toDouble()
         private val NONE_VALUES_ALLOWED_OPERATORS = setOf(PropertyOperator.IS_NOT)
-        private val REGEX_COMBINING_MARKS = "\\p{M}+".toRegex()
         private val REGEX_RELATIVE_DATE = "^-?([0-9]+)([hdwmy])$".toRegex()
         private val REGEX_SEMVER =
             Regex("""^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.\d+)*(?:[-+].*)?$""")
@@ -40,10 +38,7 @@ internal class FlagEvaluator(
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssXXX")
         private val DATE_FORMATTER_NO_TZ = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
-        private fun casefold(input: String): String {
-            val normalized = Normalizer.normalize(input, Normalizer.Form.NFD)
-            return REGEX_COMBINING_MARKS.replace(normalized, "").uppercase().lowercase()
-        }
+        private fun unicodeLowercase(input: String): String = input.lowercase()
 
         private fun asciiCasefold(input: String): String =
             buildString(input.length) {
@@ -244,23 +239,19 @@ internal class FlagEvaluator(
         propertyValue: Any?,
         overrideValue: Any?,
     ): Boolean {
-        // Lowercase to uppercase to normalize locale (e.g., Turkish i, German ß)
-        // String.equals apparently does this when ignoreCase=true, but it doesn't seem to work.
-        // https://kotlinlang.org/api/core/1.3/kotlin-stdlib/kotlin.text/equals.html
-        val expectedValue = overrideValue?.let { casefold(it.toString()) }
-        return when {
-            propertyValue is List<*> -> {
-                propertyValue.any { v ->
-                    v == expectedValue || (v != null && casefold(v.toString()) == expectedValue)
-                }
-            }
+        if (overrideValue == null) {
+            return if (propertyValue is List<*>) propertyValue.any { it == null } else propertyValue == null
+        }
 
-            else ->
-                propertyValue == expectedValue || (
-                    propertyValue != null && casefold(
-                        propertyValue.toString(),
-                    ) == expectedValue
-                )
+        val expectedValue = unicodeLowercase(overrideValue.toString())
+        return when (propertyValue) {
+            is List<*> ->
+                propertyValue.any { value ->
+                    value != null && unicodeLowercase(value.toString()) == expectedValue
+                }
+
+            null -> false
+            else -> unicodeLowercase(propertyValue.toString()) == expectedValue
         }
     }
 
@@ -270,7 +261,7 @@ internal class FlagEvaluator(
         ignoreCase: Boolean,
     ): Boolean {
         if (ignoreCase) {
-            return casefold(haystack).contains(casefold(needle), ignoreCase = true)
+            return asciiCasefold(haystack).contains(asciiCasefold(needle))
         }
         return haystack.contains(needle)
     }

--- a/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
+++ b/posthog-server/src/main/java/com/posthog/server/internal/FlagEvaluator.kt
@@ -1,5 +1,7 @@
 package com.posthog.server.internal
 
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
 import com.posthog.PostHogConfig
 import com.posthog.internal.FlagConditionGroup
 import com.posthog.internal.FlagDefinition
@@ -27,7 +29,8 @@ internal class FlagEvaluator(
 ) {
     companion object {
         private const val LONG_SCALE = 0xFFFFFFFFFFFFFFF.toDouble()
-        private val NONE_VALUES_ALLOWED_OPERATORS = setOf(PropertyOperator.IS_NOT)
+        private val NONE_VALUES_ALLOWED_OPERATORS = setOf(PropertyOperator.EXACT, PropertyOperator.IS_NOT)
+        private val JSON = GsonBuilder().disableHtmlEscaping().serializeNulls().create()
         private val REGEX_RELATIVE_DATE = "^-?([0-9]+)([hdwmy])$".toRegex()
         private val REGEX_SEMVER =
             Regex("""^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:\.\d+)*(?:[-+].*)?$""")
@@ -153,40 +156,38 @@ internal class FlagEvaluator(
 
             PropertyOperator.ICONTAINS ->
                 stringContains(
-                    overrideValue.toString(),
-                    propertyValue.toString(),
-                    ignoreCase = true,
+                    valueToString(overrideValue),
+                    valueToString(propertyValue),
                 )
 
             PropertyOperator.NOT_ICONTAINS ->
                 !stringContains(
-                    overrideValue.toString(),
-                    propertyValue.toString(),
-                    ignoreCase = true,
+                    valueToString(overrideValue),
+                    valueToString(propertyValue),
                 )
 
             PropertyOperator.STARTS_WITH ->
                 stringStartsWith(
-                    overrideValue.toString(),
-                    propertyValue.toString(),
+                    valueToString(overrideValue),
+                    valueToString(propertyValue),
                 )
 
             PropertyOperator.NOT_STARTS_WITH ->
                 !stringStartsWith(
-                    overrideValue.toString(),
-                    propertyValue.toString(),
+                    valueToString(overrideValue),
+                    valueToString(propertyValue),
                 )
 
             PropertyOperator.ENDS_WITH ->
                 stringEndsWith(
-                    overrideValue.toString(),
-                    propertyValue.toString(),
+                    valueToString(overrideValue),
+                    valueToString(propertyValue),
                 )
 
             PropertyOperator.NOT_ENDS_WITH ->
                 !stringEndsWith(
-                    overrideValue.toString(),
-                    propertyValue.toString(),
+                    valueToString(overrideValue),
+                    valueToString(propertyValue),
                 )
 
             PropertyOperator.REGEX ->
@@ -239,32 +240,130 @@ internal class FlagEvaluator(
         propertyValue: Any?,
         overrideValue: Any?,
     ): Boolean {
-        if (overrideValue == null) {
-            return if (propertyValue is List<*>) propertyValue.any { it == null } else propertyValue == null
+        if (isTruthyOrFalsyPropertyValue(propertyValue)) {
+            return isTruthyPropertyValue(propertyValue) == isTruthyPropertyValue(overrideValue)
         }
 
-        val expectedValue = unicodeLowercase(overrideValue.toString())
+        val expectedValue = unicodeLowercase(valueToString(overrideValue))
         return when (propertyValue) {
             is List<*> ->
                 propertyValue.any { value ->
-                    value != null && unicodeLowercase(value.toString()) == expectedValue
+                    unicodeLowercase(valueToString(value)) == expectedValue
                 }
 
-            null -> false
-            else -> unicodeLowercase(propertyValue.toString()) == expectedValue
+            else -> unicodeLowercase(valueToString(propertyValue)) == expectedValue
         }
     }
+
+    private fun isTruthyOrFalsyPropertyValue(value: Any?): Boolean =
+        when (value) {
+            is Boolean -> true
+            is String -> unicodeLowercase(value).let { it == "true" || it == "false" }
+            is List<*> -> value.all(::isTruthyOrFalsyPropertyValue)
+            else -> false
+        }
+
+    private fun isTruthyPropertyValue(value: Any?): Boolean =
+        when (value) {
+            is Boolean -> value
+            is String -> unicodeLowercase(value) == "true"
+            is List<*> -> value.all(::isTruthyPropertyValue)
+            else -> false
+        }
+
+    private fun valueToString(value: Any?): String {
+        if (value is String) {
+            return value
+        }
+        if (value is Number) {
+            return numberToString(value)
+        }
+        val jsonValue =
+            try {
+                JSON.toJsonTree(value)
+            } catch (error: IllegalArgumentException) {
+                throw InconclusiveMatchException("Cannot stringify JSON value locally: ${error.message}")
+            }
+        return canonicalJson(jsonValue)
+    }
+
+    private fun canonicalJson(value: JsonElement): String =
+        when {
+            value.isJsonNull -> "null"
+            value.isJsonArray ->
+                value.asJsonArray.joinToString(separator = ",", prefix = "[", postfix = "]") { canonicalJson(it) }
+            value.isJsonObject ->
+                value.asJsonObject
+                    .entrySet()
+                    .sortedWith { left, right -> compareJsonKeys(left.key, right.key) }
+                    .joinToString(separator = ",", prefix = "{", postfix = "}") { (key, child) ->
+                        "${quoteJsonString(key)}:${canonicalJson(child)}"
+                    }
+            value.asJsonPrimitive.isString -> quoteJsonString(value.asString)
+            value.asJsonPrimitive.isBoolean -> value.asBoolean.toString()
+            else -> numberToString(value.asNumber)
+        }
+
+    private fun numberToString(value: Number): String {
+        val rawValue = value.toString()
+        if (rawValue.matches(Regex("-?\\d+"))) {
+            return rawValue
+        }
+        throw InconclusiveMatchException("Cannot stringify floating-point JSON number locally: $rawValue")
+    }
+
+    private fun compareJsonKeys(
+        left: String,
+        right: String,
+    ): Int {
+        val leftBytes = left.toByteArray(Charsets.UTF_8)
+        val rightBytes = right.toByteArray(Charsets.UTF_8)
+        for (index in 0 until minOf(leftBytes.size, rightBytes.size)) {
+            val comparison = (leftBytes[index].toInt() and 0xFF) - (rightBytes[index].toInt() and 0xFF)
+            if (comparison != 0) {
+                return comparison
+            }
+        }
+        return leftBytes.size - rightBytes.size
+    }
+
+    private fun quoteJsonString(value: String): String =
+        buildString(value.length + 2) {
+            append('"')
+            value.forEachIndexed { index, character ->
+                when (character) {
+                    '"' -> append("\\\"")
+                    '\\' -> append("\\\\")
+                    '\u0008' -> append("\\b")
+                    '\u000C' -> append("\\f")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    '\t' -> append("\\t")
+                    in '\u0000'..'\u001F' -> append("\\u%04x".format(character.code))
+                    in '\uD800'..'\uDBFF' -> {
+                        val next = value.getOrNull(index + 1)
+                        if (next == null || next !in '\uDC00'..'\uDFFF') {
+                            throw InconclusiveMatchException("Cannot stringify an unpaired Unicode surrogate")
+                        }
+                        append(character)
+                    }
+                    in '\uDC00'..'\uDFFF' -> {
+                        val previous = value.getOrNull(index - 1)
+                        if (previous == null || previous !in '\uD800'..'\uDBFF') {
+                            throw InconclusiveMatchException("Cannot stringify an unpaired Unicode surrogate")
+                        }
+                        append(character)
+                    }
+                    else -> append(character)
+                }
+            }
+            append('"')
+        }
 
     private fun stringContains(
         haystack: String,
         needle: String,
-        ignoreCase: Boolean,
-    ): Boolean {
-        if (ignoreCase) {
-            return asciiCasefold(haystack).contains(asciiCasefold(needle))
-        }
-        return haystack.contains(needle)
-    }
+    ): Boolean = asciiCasefold(haystack).contains(asciiCasefold(needle))
 
     private fun stringStartsWith(
         value: String,

--- a/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
@@ -64,45 +64,39 @@ internal class FlagEvaluatorTest {
     }
 
     @Test
-    internal fun testMatchPropertyExactUnicodeNormalization() {
-        // Test German ß (eszett) - should match "ss" after casefold
-        val propertyStrasse =
-            FlagProperty(
-                key = "location",
-                propertyValue = "Straße",
-                propertyOperator = PropertyOperator.EXACT,
-                type = PropertyType.PERSON,
-                negation = false,
-                dependencyChain = null,
+    internal fun testMatchPropertyExactUsesUnicodeLowercase() {
+        fun match(
+            operator: PropertyOperator,
+            filterValue: String,
+            propertyValue: String,
+        ): Boolean {
+            val property =
+                FlagProperty(
+                    key = "value",
+                    propertyValue = filterValue,
+                    propertyOperator = operator,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            return evaluator.matchProperty(property, mapOf("value" to propertyValue))
+        }
+
+        val comparisons =
+            listOf(
+                Triple("Ä", "ä", true),
+                Triple("É", "e", false),
+                Triple("ß", "ss", false),
+                Triple("Σ", "ς", false),
             )
-
-        // Should match lowercase ß
-        assertTrue(evaluator.matchProperty(propertyStrasse, mapOf("location" to "straße")))
-
-        // Should match "ss" (casefold normalization)
-        assertTrue(evaluator.matchProperty(propertyStrasse, mapOf("location" to "strasse")))
-
-        // Test long s (ſ) - should match regular s after casefold
-        val propertyLongS =
-            FlagProperty(
-                key = "star",
-                propertyValue = "ſun",
-                propertyOperator = PropertyOperator.EXACT,
-                type = PropertyType.PERSON,
-                negation = false,
-                dependencyChain = null,
-            )
-
-        // Should match regular s (casefold normalization)
-        assertTrue(evaluator.matchProperty(propertyLongS, mapOf("star" to "sun")))
-
-        // Should match exact long s
-        assertTrue(evaluator.matchProperty(propertyLongS, mapOf("star" to "ſun")))
+        for ((filterValue, propertyValue, expected) in comparisons) {
+            assertEquals(expected, match(PropertyOperator.EXACT, filterValue, propertyValue))
+            assertEquals(!expected, match(PropertyOperator.IS_NOT, filterValue, propertyValue))
+        }
     }
 
     @Test
-    internal fun testMatchPropertyExactUnicodeNormalizationWithList() {
-        // Test with list values
+    internal fun testMatchPropertyExactUnicodeLowercaseWithList() {
         val property =
             FlagProperty(
                 key = "location",
@@ -113,9 +107,25 @@ internal class FlagEvaluatorTest {
                 dependencyChain = null,
             )
 
-        // Should match with casefold normalization
-        assertTrue(evaluator.matchProperty(property, mapOf("location" to "strasse")))
-        assertTrue(evaluator.matchProperty(property, mapOf("location" to "munchen")))
+        assertTrue(evaluator.matchProperty(property, mapOf("location" to "straße")))
+        assertTrue(evaluator.matchProperty(property, mapOf("location" to "münchen")))
+        assertFalse(evaluator.matchProperty(property, mapOf("location" to "strasse")))
+        assertFalse(evaluator.matchProperty(property, mapOf("location" to "munchen")))
+    }
+
+    @Test
+    internal fun testMatchPropertyExactPreservesIntegralDoubleRepresentation() {
+        val property =
+            FlagProperty(
+                key = "number",
+                propertyValue = "323.0",
+                propertyOperator = PropertyOperator.EXACT,
+                type = PropertyType.PERSON,
+                negation = false,
+                dependencyChain = null,
+            )
+
+        assertTrue(evaluator.matchProperty(property, mapOf("number" to 323.0)))
     }
 
     @Test
@@ -230,10 +240,7 @@ internal class FlagEvaluatorTest {
     }
 
     @Test
-    internal fun testMatchPropertyIcontainsTurkishI() {
-        // Test Turkish i normalization
-        // In Turkish locale, uppercase I → ı (dotless i) and lowercase i → İ (dotted I)
-        // The uppercase().lowercase() normalization should handle this
+    internal fun testMatchPropertyIcontainsUsesAsciiCaseFolding() {
         val property =
             FlagProperty(
                 key = "city",
@@ -244,10 +251,9 @@ internal class FlagEvaluatorTest {
                 dependencyChain = null,
             )
 
-        // Should match with different casing
         assertTrue(evaluator.matchProperty(property, mapOf("city" to "istanbul")))
         assertTrue(evaluator.matchProperty(property, mapOf("city" to "ISTANBUL")))
-        assertTrue(evaluator.matchProperty(property, mapOf("city" to "İstanbul")))
+        assertFalse(evaluator.matchProperty(property, mapOf("city" to "İstanbul")))
     }
 
     @Test
@@ -329,6 +335,32 @@ internal class FlagEvaluatorTest {
         // Case-insensitive suffix match
         assertTrue(evaluator.matchProperty(property, mapOf("email" to "test@example.com")))
         assertFalse(evaluator.matchProperty(property, mapOf("email" to "test@example.org")))
+    }
+
+    @Test
+    internal fun testMatchPropertyStringOperatorsUseAsciiCaseFolding() {
+        val operators =
+            mapOf(
+                PropertyOperator.ICONTAINS to false,
+                PropertyOperator.NOT_ICONTAINS to true,
+                PropertyOperator.STARTS_WITH to false,
+                PropertyOperator.NOT_STARTS_WITH to true,
+                PropertyOperator.ENDS_WITH to false,
+                PropertyOperator.NOT_ENDS_WITH to true,
+            )
+
+        for ((operator, expected) in operators) {
+            val property =
+                FlagProperty(
+                    key = "value",
+                    propertyValue = "ä",
+                    propertyOperator = operator,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            assertEquals(expected, evaluator.matchProperty(property, mapOf("value" to "Ä")))
+        }
     }
 
     @Test

--- a/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
+++ b/posthog-server/src/test/java/com/posthog/server/internal/FlagEvaluatorTest.kt
@@ -88,6 +88,12 @@ internal class FlagEvaluatorTest {
                 Triple("É", "e", false),
                 Triple("ß", "ss", false),
                 Triple("Σ", "ς", false),
+                Triple("ΟΣ", "ος", true),
+                Triple("ΟΣ", "οσ", false),
+                Triple("ΟΔΟΣ", "οδος", true),
+                Triple("ΟΔΟΣ", "οδοσ", false),
+                Triple("İ", "i\u0307", true),
+                Triple("İ", "i", false),
             )
         for ((filterValue, propertyValue, expected) in comparisons) {
             assertEquals(expected, match(PropertyOperator.EXACT, filterValue, propertyValue))
@@ -114,18 +120,157 @@ internal class FlagEvaluatorTest {
     }
 
     @Test
-    internal fun testMatchPropertyExactPreservesIntegralDoubleRepresentation() {
-        val property =
+    internal fun testMatchPropertyExactUsesBackendBooleanCoercion() {
+        val comparisons =
+            listOf(
+                Triple(false, "banana", true),
+                Triple("false", 0, true),
+                Triple("FaLsE", false, true),
+                Triple("falſe", "banana", false),
+                Triple(listOf("false"), "pro", true),
+                Triple(listOf("true", "false"), "true", false),
+                Triple(emptyList<String>(), true, true),
+                Triple(emptyList<String>(), emptyList<String>(), true),
+            )
+
+        for ((filterValue, propertyValue, expected) in comparisons) {
+            for (operator in listOf(PropertyOperator.EXACT, PropertyOperator.IS_NOT)) {
+                val property =
+                    FlagProperty(
+                        key = "value",
+                        propertyValue = filterValue,
+                        propertyOperator = operator,
+                        type = PropertyType.PERSON,
+                        negation = false,
+                        dependencyChain = null,
+                    )
+                val actual = evaluator.matchProperty(property, mapOf("value" to propertyValue))
+                assertEquals(if (operator == PropertyOperator.EXACT) expected else !expected, actual)
+            }
+        }
+
+        val falseFilter =
             FlagProperty(
-                key = "number",
-                propertyValue = "323.0",
+                key = "value",
+                propertyValue = false,
                 propertyOperator = PropertyOperator.EXACT,
                 type = PropertyType.PERSON,
                 negation = false,
                 dependencyChain = null,
             )
+        assertTrue(evaluator.matchProperty(falseFilter, mapOf("value" to null)))
+    }
 
-        assertTrue(evaluator.matchProperty(property, mapOf("number" to 323.0)))
+    @Test
+    internal fun testMatchPropertyExactUsesBackendJsonStringification() {
+        val comparisons =
+            listOf(
+                Triple("[1,2]", listOf(1, 2), true),
+                Triple("[1, 2]", listOf(1, 2), false),
+                Triple("[\"<script>\",\"line\u2028separator\"]", listOf("<script>", "line\u2028separator"), true),
+                Triple("{\"a\":2,\"b\":1}", linkedMapOf("b" to 1, "a" to 2), true),
+                Triple("{\"\uE000\":1,\"\uD800\uDC00\":2}", linkedMapOf("\uD800\uDC00" to 2, "\uE000" to 1), true),
+                Triple("{\"b\":1,\"a\":2}", linkedMapOf("b" to 1, "a" to 2), false),
+                Triple("{\"a\":null}", mapOf("a" to null), true),
+                Triple(
+                    "{\"a\":{\"c\":3,\"d\":4},\"z\":[{\"a\":2,\"b\":1}]}",
+                    linkedMapOf(
+                        "z" to listOf(linkedMapOf("b" to 1, "a" to 2)),
+                        "a" to linkedMapOf("d" to 4, "c" to 3),
+                    ),
+                    true,
+                ),
+                Triple("323", 323, true),
+                Triple("9223372036854775807", Long.MAX_VALUE, true),
+            )
+
+        for ((filterValue, propertyValue, expected) in comparisons) {
+            val property =
+                FlagProperty(
+                    key = "value",
+                    propertyValue = filterValue,
+                    propertyOperator = PropertyOperator.EXACT,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            assertEquals(
+                "filter=$filterValue property=$propertyValue",
+                expected,
+                evaluator.matchProperty(property, mapOf("value" to propertyValue)),
+            )
+        }
+    }
+
+    @Test
+    internal fun testMatchPropertyFloatingPointStringificationFallsBackToServer() {
+        for (
+        number in
+        listOf(
+            323.0,
+            -0.0,
+            1e-7,
+            1e16,
+            1e-5,
+            9.9e-5,
+            Double.MIN_VALUE,
+        )
+        ) {
+            val property =
+                FlagProperty(
+                    key = "value",
+                    propertyValue = number.toString(),
+                    propertyOperator = PropertyOperator.EXACT,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            try {
+                evaluator.matchProperty(property, mapOf("value" to number))
+                throw AssertionError("Expected floating-point exact matching to be inconclusive for $number")
+            } catch (_: InconclusiveMatchException) {
+                // The JVM formatter does not match serde_json for every finite double.
+            }
+        }
+
+        val nestedNonFinite =
+            FlagProperty(
+                key = "value",
+                propertyValue = "[NaN]",
+                propertyOperator = PropertyOperator.EXACT,
+                type = PropertyType.PERSON,
+                negation = false,
+                dependencyChain = null,
+            )
+        try {
+            evaluator.matchProperty(nestedNonFinite, mapOf("value" to listOf(Double.NaN)))
+            throw AssertionError("Expected nested non-finite matching to be inconclusive")
+        } catch (_: InconclusiveMatchException) {
+            // Non-finite numbers cannot be represented by serde_json.
+        }
+    }
+
+    @Test
+    internal fun testMatchPropertyStringOperatorsUseBackendJsonStringification() {
+        val comparisons =
+            listOf(
+                Triple(PropertyOperator.ICONTAINS, "\"a\":2", linkedMapOf("b" to 1, "a" to 2)),
+                Triple(PropertyOperator.STARTS_WITH, "922", Long.MAX_VALUE),
+                Triple(PropertyOperator.ENDS_WITH, "2]", listOf(1, 2)),
+            )
+
+        for ((operator, filterValue, propertyValue) in comparisons) {
+            val property =
+                FlagProperty(
+                    key = "value",
+                    propertyValue = filterValue,
+                    propertyOperator = operator,
+                    type = PropertyType.PERSON,
+                    negation = false,
+                    dependencyChain = null,
+                )
+            assertTrue(evaluator.matchProperty(property, mapOf("value" to propertyValue)))
+        }
     }
 
     @Test


### PR DESCRIPTION
## :bulb: Motivation and Context

The `posthog-server` local evaluator could disagree with the released `/flags` service for exact matching, JSON values, and case-insensitive string operators.

This fixes PostHog/posthog#78019 by matching the current Rust backend contract:

- `exact` and `is_not` apply the backend's boolean-like filter gate before ordinary array membership.
- Boolean-only and empty filter arrays preserve the backend's aggregate truthiness behavior.
- Composite values use compact JSON with recursively sorted keys and backend-compatible escaping.
- Integer values retain their JSON spelling.
- Floating-point matching falls back to the server because JVM formatting is not identical to `serde_json` for every finite double.
- Exact comparisons use full Unicode lowercase, including final sigma and dotted `İ`.
- Contains, prefix, and suffix comparisons retain ASCII-only lowercase.

The proposed backend cleanup in PostHog/posthog#90694 is a separate draft. This PR intentionally follows the released backend until that proposal is accepted.

The patch changes only `posthog-server` and includes a patch changeset.

## :green_heart: How did you test it?

Red-green regression evidence:

- Boolean coercion initially failed for `false` versus `"banana"`; the focused evaluator suite now passes.
- Composite stringification initially failed for `"[1,2]"` versus `[1, 2]`; the focused evaluator suite now passes.
- Review follow-ups reproduced null-member omission, broad long-s boolean matching, and nested non-finite failures before their fixes.

Validation:

- `./gradlew :posthog-server:test --tests 'com.posthog.server.internal.FlagEvaluatorTest' --no-daemon`
- `make checkFormat`
- `./gradlew :posthog-server:animalsnifferMain :posthog-server:animalsnifferTest --no-daemon`
- `$HOME/.pi/agent/skills/autoreview/scripts/autoreview --mode local`

The full `:posthog-server:test` suite reached 512 passing tests. Five unrelated Mockito inline-agent tests fail on the local JDK. Required CI remains the authoritative full-suite check.

Autoreview findings about operand direction and whole-array matching were rejected after verification: `propertyValue` is the filter operand, and the focused 100-test evaluator class passes the cited vectors.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented and reviewed the change under human direction using the address-pr-comments, check-pr, autoreview, and karpathy-guidelines skills. The released Rust matcher was the source of truth; the separate backend draft was not adopted.
