### PR TITLE
chore: ignore Compose BOM Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "androidx.compose:compose-bom"
     groups:
       gradle-dependencies:
         patterns:


### PR DESCRIPTION
## :bulb: Motivation and Context

Dependabot included `androidx.compose:compose-bom` in the grouped Gradle update in #744. Compose BOM updates should be managed manually instead of being included in automated dependency pull requests.

## :green_heart: How did you test it?

Parsed `.github/dependabot.yml` with Ruby's YAML parser and verified that the Gradle configuration contains the exact `androidx.compose:compose-bom` ignore rule.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi was used to add the requested Dependabot ignore rule, validate the YAML configuration, and prepare this pull request. The change is limited to repository dependency automation configuration.
