### PR TITLE
docs(surveys): correct EmojiRating unselected tint in KDoc

### DIFF
--- a/posthog-android-surveys-compose/src/main/java/com/posthog/android/surveys/compose/internal/ui/EmojiRating.kt
+++ b/posthog-android-surveys-compose/src/main/java/com/posthog/android/surveys/compose/internal/ui/EmojiRating.kt
@@ -50,7 +50,9 @@ import com.posthog.surveys.PostHogDisplaySurveyTextContentType
  *
  * Selected emojis are tinted
  * [com.posthog.android.surveys.compose.internal.theme.ResolvedSurveyAppearance.ratingButtonActiveColor],
- * unselected use `ratingButtonColor`.
+ * unselected use
+ * [com.posthog.android.surveys.compose.internal.theme.ResolvedSurveyAppearance.inputTextColor]
+ * at 50% alpha.
  */
 @Composable
 internal fun EmojiRating(

--- a/posthog-android-surveys-compose/src/main/java/com/posthog/android/surveys/compose/internal/ui/EmojiRating.kt
+++ b/posthog-android-surveys-compose/src/main/java/com/posthog/android/surveys/compose/internal/ui/EmojiRating.kt
@@ -40,8 +40,9 @@ import com.posthog.surveys.PostHogDisplaySurveyTextContentType
  * [PostHogDisplayRatingQuestion.ratingType] equal to
  * [PostHogDisplaySurveyRatingType.EMOJI].
  *
- * Renders 3 or 5 face shapes (Dissatisfied / Neutral / Satisfied for scale 3,
- * VeryDissatisfied → VerySatisfied for scale 5). The face artwork is the same
+ * Renders 2, 3, or 5 shapes (thumbs up / thumbs down for scale 2,
+ * Dissatisfied / Neutral / Satisfied for scale 3, VeryDissatisfied →
+ * VerySatisfied for scale 5). The artwork is the same
  * SVG used by the web product (posthog-js
  * `packages/browser/src/extensions/surveys/icons.tsx`) — the exact `d` path
  * strings are embedded verbatim in [PostHogEmoji] and parsed at draw time by
@@ -50,7 +51,7 @@ import com.posthog.surveys.PostHogDisplaySurveyTextContentType
  *
  * Selected emojis are tinted
  * [com.posthog.android.surveys.compose.internal.theme.ResolvedSurveyAppearance.ratingButtonActiveColor],
- * unselected use
+ * unselected ones use
  * [com.posthog.android.surveys.compose.internal.theme.ResolvedSurveyAppearance.inputTextColor]
  * at 50% alpha.
  */


### PR DESCRIPTION
## :bulb: Motivation and Context

The `EmojiRating` KDoc says unselected emojis use `ratingButtonColor`. The code tints them with `inputTextColor` at 50% alpha:

```kotlin
val tint =
    if (isSelected) {
        appearance.ratingButtonActiveColor
    } else {
        appearance.inputTextColor.copy(alpha = 0.5f)
    }
```

The code is right and matches the iOS SDK, so this corrects the doc to describe what it does. `ratingButtonColor` is not read in this file at all, which makes the old wording actively misleading for anyone reasoning about survey appearance across platforms.

Spotted by an SDK user while they were investigating a related iOS rendering bug ([posthog-ios#793](https://github.com/PostHog/posthog-ios/pull/793)).

- From https://us.posthog.com/project/2/support/tickets/70521

## :green_heart: How did you test it?

Not built — comment-only change, no behavior touched. I checked that both KDoc links resolve: `ResolvedSurveyAppearance` declares `inputTextColor` and `ratingButtonActiveColor`.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

No changeset — nothing user-facing changes, so there is nothing to put in release notes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Opus in PostHog Desktop. This came out of investigating an iOS emoji rating bug, where the Android implementation was the reference for correct behavior. Reading it turned up the doc mismatch. Verified against the source rather than the report: read the tint branch and the `ResolvedSurveyAppearance` fields before editing.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
