### PR TITLE
feat(push): capture a launch intent the SDK was installed too late to read

### DIFF
--- a/.changeset/push-open-late-install.md
+++ b/.changeset/push-open-late-install.md
@@ -1,0 +1,8 @@
+---
+'posthog': minor
+'posthog-android': minor
+'posthog-server': patch
+'posthog-android-surveys-compose': patch
+---
+
+Add `PostHogAndroid.capturePushNotificationOpened(intent)` to capture `$push_notification_opened` for a launch intent the SDK was installed too late to read.

--- a/.changeset/push-open-late-install.md
+++ b/.changeset/push-open-late-install.md
@@ -5,4 +5,4 @@
 'posthog-android-surveys-compose': patch
 ---
 
-Add `PostHogAndroid.capturePushNotificationOpened(intent)` to capture `$push_notification_opened` for a launch intent the SDK was installed too late to read.
+Add `PostHogAndroid.capturePushNotificationOpened(intent)` to capture `$push_notification_opened` for a launch intent the SDK was installed too late to read. In the published test fixtures, `PostHogFake.optOut()` and `optIn()` now change what `isOptOut()` returns, where they were previously no-ops.

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -11,6 +11,7 @@ public final class com/posthog/android/PostHogAndroid {
 }
 
 public final class com/posthog/android/PostHogAndroid$Companion {
+	public final fun capturePushNotificationOpened (Landroid/content/Intent;)V
 	public final fun setup (Landroid/content/Context;Lcom/posthog/android/PostHogAndroidConfig;)V
 	public final fun with (Landroid/content/Context;Lcom/posthog/android/PostHogAndroidConfig;)Lcom/posthog/PostHogInterface;
 }

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -65,11 +65,11 @@ public class PostHogAndroid private constructor() {
          * callback, and should pass the Activity's intent here instead.
          *
          * Deduped by `google.message_id`, so calling it alongside the automatic path cannot
-         * double-count, including across a process-death restore: on this path the id is remembered on
-         * disk, because a caller with no `savedInstanceState` cannot otherwise tell a restore — which
-         * hands the Activity back its original intent — from a real second tap. The cost of that trade
-         * is that a genuine second tap of the *same* notification after a process restart reads as a
-         * restore and is dropped; the persisted id is never cleared.
+         * double-count, including across a process-death restore: on this path recently opened ids are
+         * remembered on disk, because a caller with no `savedInstanceState` cannot otherwise tell a
+         * restore — which hands the Activity back its original intent — from a real second tap. The
+         * cost of that trade is that a genuine second tap of the *same* notification after a process
+         * restart reads as a restore and is dropped, until that id ages out of the remembered set.
          *
          * No-op when [intent] is null or carries no push id, when `capturePushNotificationOpened` is
          * disabled, or before [setup]. Events go to the shared instance, so a host that only called

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -2,9 +2,11 @@ package com.posthog.android
 
 import android.app.Application
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import com.posthog.PostHog
 import com.posthog.PostHogInterface
+import com.posthog.PostHogVisibleForTesting
 import com.posthog.android.errortracking.PostHogNativeCrashIntegration
 import com.posthog.android.internal.MainHandler
 import com.posthog.android.internal.PostHogActivityLifecycleCallbackIntegration
@@ -42,6 +44,54 @@ public class PostHogAndroid private constructor() {
         private val lock = Any()
 
         /**
+         * Retained so a host can hand the SDK a launch intent after setup; see
+         * [capturePushNotificationOpened]. Never cleared in production — a `close()` leaves the last
+         * config here.
+         */
+        @Volatile
+        private var androidConfig: PostHogAndroidConfig? = null
+
+        @PostHogVisibleForTesting
+        internal fun resetAndroidConfig() {
+            androidConfig = null
+        }
+
+        /**
+         * Captures `$push_notification_opened` for a notification tap carried on [intent].
+         *
+         * The SDK reads the tray intent when the launch Activity is created. A host that configures
+         * PostHog from its own runtime — Flutter and React Native reach `setup()` from Dart/JS, after
+         * the launch Activity has already created, started and resumed — installs too late to see that
+         * callback, and should pass the Activity's intent here instead.
+         *
+         * Deduped by `google.message_id`, so calling it alongside the automatic path cannot
+         * double-count, including across a process-death restore: on this path the id is remembered on
+         * disk, because a caller with no `savedInstanceState` cannot otherwise tell a restore — which
+         * hands the Activity back its original intent — from a real second tap. The cost of that trade
+         * is that a genuine second tap of the *same* notification after a process restart reads as a
+         * restore and is dropped; the persisted id is never cleared.
+         *
+         * No-op when [intent] is null or carries no push id, when `capturePushNotificationOpened` is
+         * disabled, or before [setup]. Events go to the shared instance, so a host that only called
+         * [with] is not served.
+         *
+         * Covers launch intents only. A warm-start tap arrives through `Activity.onNewIntent`, which
+         * nothing here observes — pass that intent in yourself.
+         */
+        public fun capturePushNotificationOpened(intent: Intent?) {
+            val config = androidConfig ?: return
+            if (!config.capturePushNotificationOpened) return
+            val pushIntent = intent ?: return
+
+            PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+                intent = pushIntent,
+                postHog = PostHog,
+                config = config,
+                usePersistedDedupe = true,
+            )
+        }
+
+        /**
          * Sets up the SDK and stores it as the global singleton.
          *
          * @param context Android context; the application context is retained internally.
@@ -55,6 +105,11 @@ public class PostHogAndroid private constructor() {
                 setAndroidConfig(context.appContext(), config)
 
                 PostHog.setup(config)
+
+                // Only setup() arms the manual entry point: with() builds a secondary instance whose
+                // config must not decide the gate, or the preferences file, for events that are
+                // delivered to the shared one.
+                androidConfig = config
             }
         }
 

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroid.kt
@@ -108,8 +108,12 @@ public class PostHogAndroid private constructor() {
 
                 // Only setup() arms the manual entry point: with() builds a secondary instance whose
                 // config must not decide the gate, or the preferences file, for events that are
-                // delivered to the shared one.
-                androidConfig = config
+                // delivered to the shared one. The identity check is the other half of that: setup()
+                // no-ops when an instance is already active or the key was empty, and adopting a
+                // config it rejected would gate and persist under a project nothing is sent to.
+                if (PostHog.getConfig<PostHogAndroidConfig>() === config) {
+                    androidConfig = config
+                }
             }
         }
 

--- a/posthog-android/src/main/java/com/posthog/android/PostHogAndroidConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/PostHogAndroidConfig.kt
@@ -28,8 +28,11 @@ import com.posthog.internal.PostHogQueue
  *   still needs the app to forward `onNewToken` to `registerPushNotificationToken(...)`. Default: `true`.
  * @property capturePushNotificationOpened Whether to auto-capture `$push_notification_opened` for
  *   cold-start taps on a tray notification (detected via the launch intent's `google.message_id`
- *   extra). Foreground data messages and warm-start `onNewIntent` are not observable here — forward
- *   those to `capturePushNotificationOpened(...)` manually. Default: `true`.
+ *   extra). A warm-start tap arrives at `Activity.onNewIntent`, which is not observable here —
+ *   forward that intent to [PostHogAndroid.capturePushNotificationOpened], which is deduped against
+ *   this path. Foreground data messages and push delivered outside FCM need
+ *   [PostHog.capturePushNotificationOpened], which is not. Also gates
+ *   [PostHogAndroid.capturePushNotificationOpened]. Default: `true`.
  */
 public open class PostHogAndroidConfig
     @JvmOverloads

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -3,10 +3,13 @@ package com.posthog.android.internal
 import android.app.Activity
 import android.app.Application
 import android.app.Application.ActivityLifecycleCallbacks
+import android.content.Intent
 import android.os.Bundle
 import com.posthog.PostHogIntegration
 import com.posthog.PostHogInterface
+import com.posthog.PostHogVisibleForTesting
 import com.posthog.android.PostHogAndroidConfig
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -21,13 +24,101 @@ internal class PostHogActivityLifecycleCallbackIntegration(
     private var postHog: PostHogInterface? = null
     private var ownsInstallation = false
 
-    @Volatile
-    private var lastHandledPushMessageId: String? = null
-
-    private companion object {
+    internal companion object {
         private val integrationInstalled = AtomicBoolean(false)
 
         private const val GOOGLE_MESSAGE_ID = "google.message_id"
+
+        private val pushDedupeLock = Any()
+
+        /**
+         * Process-wide on purpose: a tap must not be re-captured after a `close()`/`setup()` cycle,
+         * and the static entry point has no integration instance to hang this on.
+         */
+        private var lastHandledPushMessageId: String? = null
+
+        @PostHogVisibleForTesting
+        internal fun resetPushDedupe() {
+            synchronized(pushDedupeLock) { lastHandledPushMessageId = null }
+        }
+
+        /**
+         * Captures `$push_notification_opened` for a tray tap carried on [intent], deduped by
+         * `google.message_id`. Title/body aren't in the tray intent (only the `posthog` JSON extra is).
+         *
+         * [usePersistedDedupe] additionally remembers the id on disk, so the dedupe outlives the
+         * process. Only callers with no restore signal need that: `onActivityCreated` has
+         * `savedInstanceState`, which is strictly better because it separates a restore from a genuine
+         * second tap of the same notification — a persisted id cannot tell those apart, and would drop
+         * the real one. Keeping the write behind the same flag means only hosts that opt in ever
+         * write this key.
+         */
+        internal fun capturePushNotificationOpened(
+            intent: Intent,
+            postHog: PostHogInterface?,
+            config: PostHogAndroidConfig,
+            usePersistedDedupe: Boolean = false,
+        ) {
+            // Reading extras unmarshals the whole Bundle; a launch intent carrying a
+            // Serializable/Parcelable extra whose class isn't on this app's classloader throws
+            // BadParcelableException here. An uncaught throw would surface in a framework callback or
+            // in host code, either way crashing the app.
+            try {
+                val target = postHog ?: return
+                // Marking an id the SDK will refuse to send would burn it for good, and an opt-in later
+                // in the session could never recover it.
+                if (target.isOptOut()) return
+
+                val messageId = intent.getStringExtra(GOOGLE_MESSAGE_ID) ?: return
+
+                // Check and mark under one lock: a second caller for the same id must not slip
+                // through while this one is still delivering.
+                val payload =
+                    synchronized(pushDedupeLock) {
+                        val persistedId =
+                            if (usePersistedDedupe) {
+                                config.cachePreferences?.getValue(PUSH_LAST_OPENED_MESSAGE_ID)
+                            } else {
+                                null
+                            }
+                        if (messageId == lastHandledPushMessageId || messageId == persistedId) {
+                            lastHandledPushMessageId = messageId
+                            // The automatic path marks memory only. Persisting on the way out of a hit
+                            // keeps a later restore — where that path is gated by savedInstanceState —
+                            // from capturing the same tap a second time.
+                            if (usePersistedDedupe && messageId != persistedId) {
+                                config.cachePreferences?.setValue(PUSH_LAST_OPENED_MESSAGE_ID, messageId)
+                            }
+                            return
+                        }
+                        // Read the risky full Bundle first: if toMap() throws, the id stays unmarked so
+                        // a later activity (e.g. a trampoline) with a clean Bundle can retry.
+                        val extras = intent.extras?.toMap()
+                        lastHandledPushMessageId = messageId
+                        if (usePersistedDedupe) {
+                            config.cachePreferences?.setValue(PUSH_LAST_OPENED_MESSAGE_ID, messageId)
+                        }
+                        extras
+                    }
+
+                target.capturePushNotificationOpened(
+                    title = null,
+                    body = null,
+                    payload = payload,
+                )
+            } catch (e: Throwable) {
+                config.logger.log("Failed to capture push notification opened: $e.")
+            }
+        }
+
+        private fun Bundle.toMap(): Map<String, Any?> {
+            val map = mutableMapOf<String, Any?>()
+            for (key in keySet()) {
+                @Suppress("DEPRECATION")
+                map[key] = get(key)
+            }
+            return map
+        }
     }
 
     override fun onActivityCreated(
@@ -66,45 +157,9 @@ internal class PostHogActivityLifecycleCallbackIntegration(
         }
     }
 
-    /**
-     * Captures `$push_notification_opened` for a cold-start tray tap, detected via the launch intent's
-     * `google.message_id`. Title/body aren't in the tray intent (only the `posthog` JSON extra is);
-     * warm-start `onNewIntent` and foreground data messages need the manual API. The message-id guard
-     * dedupes repeat reads within a process; the caller gates on a fresh launch to skip recreations.
-     */
     private fun capturePushNotificationOpenedIfNeeded(activity: Activity) {
         val intent = activity.intent ?: return
-        // Reading extras unmarshals the whole Bundle; a launch intent carrying a Serializable/Parcelable
-        // extra whose class isn't on this app's classloader throws BadParcelableException here. This runs
-        // inside the framework onActivityCreated callback, so an uncaught throw crashes the host app.
-        try {
-            val messageId = intent.getStringExtra(GOOGLE_MESSAGE_ID) ?: return
-
-            if (messageId == lastHandledPushMessageId) {
-                return
-            }
-            // Read the risky full Bundle before marking handled: if toMap() throws, the id must
-            // stay unmarked so a later activity (e.g. a trampoline) with a clean Bundle can retry.
-            val payload = intent.extras?.toMap()
-            lastHandledPushMessageId = messageId
-
-            postHog?.capturePushNotificationOpened(
-                title = null,
-                body = null,
-                payload = payload,
-            )
-        } catch (e: Throwable) {
-            config.logger.log("Failed to capture push notification opened: $e.")
-        }
-    }
-
-    private fun Bundle.toMap(): Map<String, Any?> {
-        val map = mutableMapOf<String, Any?>()
-        for (key in keySet()) {
-            @Suppress("DEPRECATION")
-            map[key] = get(key)
-        }
-        return map
+        capturePushNotificationOpened(intent, postHog, config)
     }
 
     override fun onActivityStarted(activity: Activity) {

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -9,7 +9,7 @@ import com.posthog.PostHogIntegration
 import com.posthog.PostHogInterface
 import com.posthog.PostHogVisibleForTesting
 import com.posthog.android.PostHogAndroidConfig
-import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_OPENED_MESSAGE_IDS
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -28,6 +28,14 @@ internal class PostHogActivityLifecycleCallbackIntegration(
         private val integrationInstalled = AtomicBoolean(false)
 
         private const val GOOGLE_MESSAGE_ID = "google.message_id"
+
+        /**
+         * A launch intent and a warm-start intent are deduped against the same store, and only the
+         * launch one is redelivered after a process death — so remembering just the newest id would
+         * let a warm tap displace it and a later restore re-capture the launch tap.
+         */
+        private const val PUSH_ID_HISTORY = 5
+        private const val PUSH_ID_SEPARATOR = "\n"
 
         private val pushDedupeLock = Any()
 
@@ -75,19 +83,15 @@ internal class PostHogActivityLifecycleCallbackIntegration(
                 // through while this one is still delivering.
                 val payload =
                     synchronized(pushDedupeLock) {
-                        val persistedId =
-                            if (usePersistedDedupe) {
-                                config.cachePreferences?.getValue(PUSH_LAST_OPENED_MESSAGE_ID)
-                            } else {
-                                null
-                            }
-                        if (messageId == lastHandledPushMessageId || messageId == persistedId) {
+                        val persistedIds =
+                            if (usePersistedDedupe) persistedPushIds(config) else emptyList()
+                        if (messageId == lastHandledPushMessageId || messageId in persistedIds) {
                             lastHandledPushMessageId = messageId
                             // The automatic path marks memory only. Persisting on the way out of a hit
                             // keeps a later restore — where that path is gated by savedInstanceState —
                             // from capturing the same tap a second time.
-                            if (usePersistedDedupe && messageId != persistedId) {
-                                config.cachePreferences?.setValue(PUSH_LAST_OPENED_MESSAGE_ID, messageId)
+                            if (usePersistedDedupe && messageId !in persistedIds) {
+                                rememberPushId(config, messageId)
                             }
                             return
                         }
@@ -96,7 +100,7 @@ internal class PostHogActivityLifecycleCallbackIntegration(
                         val extras = intent.extras?.toMap()
                         lastHandledPushMessageId = messageId
                         if (usePersistedDedupe) {
-                            config.cachePreferences?.setValue(PUSH_LAST_OPENED_MESSAGE_ID, messageId)
+                            rememberPushId(config, messageId)
                         }
                         extras
                     }
@@ -109,6 +113,20 @@ internal class PostHogActivityLifecycleCallbackIntegration(
             } catch (e: Throwable) {
                 config.logger.log("Failed to capture push notification opened: $e.")
             }
+        }
+
+        private fun persistedPushIds(config: PostHogAndroidConfig): List<String> =
+            (config.cachePreferences?.getValue(PUSH_OPENED_MESSAGE_IDS) as? String)
+                ?.split(PUSH_ID_SEPARATOR)
+                ?.filter { it.isNotEmpty() }
+                ?: emptyList()
+
+        private fun rememberPushId(
+            config: PostHogAndroidConfig,
+            messageId: String,
+        ) {
+            val ids = (listOf(messageId) + persistedPushIds(config)).distinct().take(PUSH_ID_HISTORY)
+            config.cachePreferences?.setValue(PUSH_OPENED_MESSAGE_IDS, ids.joinToString(PUSH_ID_SEPARATOR))
         }
 
         private fun Bundle.toMap(): Map<String, Any?> {

--- a/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegration.kt
@@ -29,11 +29,8 @@ internal class PostHogActivityLifecycleCallbackIntegration(
 
         private const val GOOGLE_MESSAGE_ID = "google.message_id"
 
-        /**
-         * A launch intent and a warm-start intent are deduped against the same store, and only the
-         * launch one is redelivered after a process death — so remembering just the newest id would
-         * let a warm tap displace it and a later restore re-capture the launch tap.
-         */
+        /** Only the launch intent is redelivered after a process death, so a warm tap must not
+         * displace it. */
         private const val PUSH_ID_HISTORY = 5
         private const val PUSH_ID_SEPARATOR = "\n"
 

--- a/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
@@ -1,6 +1,7 @@
 package com.posthog.android
 
 import android.content.Context
+import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.posthog.PostHog
 import com.posthog.android.errortracking.PostHogNativeCrashIntegration
@@ -14,7 +15,9 @@ import com.posthog.android.internal.PostHogLifecycleObserverIntegration
 import com.posthog.android.internal.PostHogPushSubscriptionIntegration
 import com.posthog.android.internal.PostHogSharedPreferences
 import com.posthog.internal.PostHogLogger
+import com.posthog.internal.PostHogMemoryPreferences
 import com.posthog.internal.PostHogNetworkStatus
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -38,6 +41,9 @@ internal class PostHogAndroidTest {
     @BeforeTest
     fun `set up`() {
         PostHog.close()
+        // androidConfig is a never-cleared process-wide static; without this the manual push entry
+        // stays armed from whichever test ran last.
+        PostHogAndroid.resetAndroidConfig()
     }
 
     @AfterTest
@@ -57,6 +63,39 @@ internal class PostHogAndroidTest {
 
         assertTrue(PostHog.isOptOut())
         assertTrue(logger.messages.any { it.contains("PostHog SDK is disabled because the API key is required") })
+    }
+
+    @Test
+    fun `the manual entry is inert before setup and while the feature is disabled`() {
+        mockContextAppStart(context, tmpDir)
+        val intent = Intent().putExtra("google.message_id", "manual-entry")
+
+        // Before setup(): no config, so nothing is armed and nothing is persisted.
+        PostHogAndroid.capturePushNotificationOpened(intent)
+
+        val config = PostHogAndroidConfig(API_KEY).apply { capturePushNotificationOpened = false }
+        PostHogAndroid.setup(context, config)
+        // Armed now, but the feature is disabled, so still nothing.
+        PostHogAndroid.capturePushNotificationOpened(intent)
+
+        assertNull(config.cachePreferences?.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+    }
+
+    @Test
+    fun `with after setup must not redirect the manual entry to the secondary project`() {
+        mockContextAppStart(context, tmpDir)
+        val primaryPrefs = PostHogMemoryPreferences()
+        val secondaryPrefs = PostHogMemoryPreferences()
+
+        PostHogAndroid.setup(context, PostHogAndroidConfig(API_KEY).apply { cachePreferences = primaryPrefs })
+        PostHogAndroid.with(context, PostHogAndroidConfig(API_KEY_2).apply { cachePreferences = secondaryPrefs })
+
+        PostHogAndroid.capturePushNotificationOpened(Intent().putExtra("google.message_id", "probe"))
+
+        // The event goes to the shared instance, so the dedupe id must land in its preferences —
+        // never in the secondary project's file.
+        assertEquals("probe", primaryPrefs.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertNull(secondaryPrefs.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
     }
 
     @Test

--- a/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
@@ -17,7 +17,7 @@ import com.posthog.android.internal.PostHogSharedPreferences
 import com.posthog.internal.PostHogLogger
 import com.posthog.internal.PostHogMemoryPreferences
 import com.posthog.internal.PostHogNetworkStatus
-import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_OPENED_MESSAGE_IDS
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
@@ -78,7 +78,7 @@ internal class PostHogAndroidTest {
         // Armed now, but the feature is disabled, so still nothing.
         PostHogAndroid.capturePushNotificationOpened(intent)
 
-        assertNull(config.cachePreferences?.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertNull(config.cachePreferences?.getValue(PUSH_OPENED_MESSAGE_IDS))
     }
 
     @Test
@@ -94,8 +94,8 @@ internal class PostHogAndroidTest {
 
         // The event goes to the shared instance, so the dedupe id must land in its preferences —
         // never in the secondary project's file.
-        assertEquals("probe", primaryPrefs.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
-        assertNull(secondaryPrefs.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertEquals("probe", primaryPrefs.getValue(PUSH_OPENED_MESSAGE_IDS))
+        assertNull(secondaryPrefs.getValue(PUSH_OPENED_MESSAGE_IDS))
     }
 
     @Test

--- a/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/PostHogAndroidTest.kt
@@ -82,6 +82,29 @@ internal class PostHogAndroidTest {
     }
 
     @Test
+    fun `a setup the core rejects must not re-arm the manual entry at the rejected config`() {
+        mockContextAppStart(context, tmpDir)
+        val activePrefs = PostHogMemoryPreferences()
+        val rejectedPrefs = PostHogMemoryPreferences()
+
+        PostHogAndroid.setup(context, PostHogAndroidConfig(API_KEY).apply { cachePreferences = activePrefs })
+        // The core no-ops this one — an instance is already active — so the shared client keeps
+        // sending under the first config and this one must not decide the gate or the prefs file.
+        PostHogAndroid.setup(
+            context,
+            PostHogAndroidConfig(API_KEY_2).apply {
+                cachePreferences = rejectedPrefs
+                capturePushNotificationOpened = false
+            },
+        )
+
+        PostHogAndroid.capturePushNotificationOpened(Intent().putExtra("google.message_id", "probe"))
+
+        assertEquals("probe", activePrefs.getValue(PUSH_OPENED_MESSAGE_IDS))
+        assertNull(rejectedPrefs.getValue(PUSH_OPENED_MESSAGE_IDS))
+    }
+
+    @Test
     fun `with after setup must not redirect the manual entry to the secondary project`() {
         mockContextAppStart(context, tmpDir)
         val primaryPrefs = PostHogMemoryPreferences()

--- a/posthog-android/src/test/java/com/posthog/android/Utils.kt
+++ b/posthog-android/src/test/java/com/posthog/android/Utils.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 public const val API_KEY: String = "_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnGI"
+public const val API_KEY_2: String = "_6SG-F7I1vCuZ-HdJL3VZQqjBlaSb1_20hDPwqMNnG2"
 
 public fun mockActivityUri(
     uri: String,

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
@@ -13,7 +13,7 @@ import com.posthog.android.createPostHogFake
 import com.posthog.android.mockActivityUri
 import com.posthog.android.mockScreenTitle
 import com.posthog.internal.PostHogMemoryPreferences
-import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_OPENED_MESSAGE_IDS
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -451,7 +451,39 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
         assertEquals(2, fake.pushOpenedCaptures)
         // The automatic path must never write the persisted key — that is what keeps a pure-native
         // app's stored state unchanged by this feature.
-        assertNull(preferences.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertNull(preferences.getValue(PUSH_OPENED_MESSAGE_IDS))
+    }
+
+    @Test
+    fun `a warm tap does not displace the launch id, so a restore is still deduped`() {
+        val preferences = PostHogMemoryPreferences()
+        val fake = createPostHogFake()
+
+        // Cold launch from notification A, then a tap of notification B while the app is running.
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "A").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "B").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+        assertEquals(2, fake.pushOpenedCaptures)
+
+        // Process dies; the Activity is restored with its original launch intent A.
+        PostHogActivityLifecycleCallbackIntegration.resetPushDedupe()
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "A").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+
+        assertEquals(2, fake.pushOpenedCaptures)
     }
 
     @Test

--- a/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/internal/PostHogActivityLifecycleCallbackIntegrationTest.kt
@@ -12,6 +12,8 @@ import com.posthog.android.PostHogAndroidConfig
 import com.posthog.android.createPostHogFake
 import com.posthog.android.mockActivityUri
 import com.posthog.android.mockScreenTitle
+import com.posthog.internal.PostHogMemoryPreferences
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -33,15 +35,24 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
         captureDeepLinks: Boolean = true,
         captureScreenViews: Boolean = true,
         capturePushNotificationOpened: Boolean = true,
+        cachePreferences: PostHogMemoryPreferences? = null,
     ): PostHogActivityLifecycleCallbackIntegration {
-        val config =
-            PostHogAndroidConfig(API_KEY).apply {
-                this.captureDeepLinks = captureDeepLinks
-                this.captureScreenViews = captureScreenViews
-                this.capturePushNotificationOpened = capturePushNotificationOpened
-            }
+        val config = buildConfig(captureDeepLinks, captureScreenViews, capturePushNotificationOpened, cachePreferences)
         return PostHogActivityLifecycleCallbackIntegration(application, config)
     }
+
+    private fun buildConfig(
+        captureDeepLinks: Boolean = true,
+        captureScreenViews: Boolean = true,
+        capturePushNotificationOpened: Boolean = true,
+        cachePreferences: PostHogMemoryPreferences? = null,
+    ): PostHogAndroidConfig =
+        PostHogAndroidConfig(API_KEY).apply {
+            this.captureDeepLinks = captureDeepLinks
+            this.captureScreenViews = captureScreenViews
+            this.capturePushNotificationOpened = capturePushNotificationOpened
+            this.cachePreferences = cachePreferences
+        }
 
     private fun mockActivityWithExtras(vararg extras: Pair<String, String>): Activity {
         val activity = mock<Activity>()
@@ -55,6 +66,7 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
 
     @BeforeTest
     fun `set up`() {
+        PostHogActivityLifecycleCallbackIntegration.resetPushDedupe()
         PostHog.resetSharedInstance()
     }
 
@@ -371,6 +383,123 @@ internal class PostHogActivityLifecycleCallbackIntegrationTest {
         sut.uninstall()
 
         assertEquals(2, fake.pushOpenedCaptures)
+    }
+
+    @Test
+    fun `captures a launch intent handed over after the Activity was already created`() {
+        val fake = createPostHogFake()
+        val config = buildConfig()
+
+        // No install(): a host that reaches setup() from Dart or JS installs after the launch
+        // Activity has created, started and resumed, so no lifecycle callback ever fires for it.
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "late").intent,
+            fake,
+            config,
+        )
+
+        assertEquals(1, fake.pushOpenedCaptures)
+        assertEquals("late", fake.pushOpenedPayload?.get("google.message_id"))
+    }
+
+    @Test
+    fun `a handed-over intent does not double count against the automatic path`() {
+        val preferences = PostHogMemoryPreferences()
+        val sut = getSut()
+        val fake = createPostHogFake()
+
+        sut.install(fake)
+        sut.onActivityCreated(mockActivityWithExtras("google.message_id" to "both"), null)
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "both").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+
+        // The hand-over must persist the id even though it deduped, or a later restore — where the
+        // automatic path is gated by savedInstanceState — captures the same tap again.
+        PostHogActivityLifecycleCallbackIntegration.resetPushDedupe()
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "both").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+        sut.uninstall()
+
+        assertEquals(1, fake.pushOpenedCaptures)
+    }
+
+    @Test
+    fun `the automatic path still captures a genuine re-tap in a new process`() {
+        val preferences = PostHogMemoryPreferences()
+        val fake = createPostHogFake()
+
+        val first = getSut(cachePreferences = preferences)
+        first.install(fake)
+        first.onActivityCreated(mockActivityWithExtras("google.message_id" to "retap"), null)
+        first.uninstall()
+
+        // savedInstanceState is null, so this is a fresh launch rather than a restore.
+        PostHogActivityLifecycleCallbackIntegration.resetPushDedupe()
+        val second = getSut(cachePreferences = preferences)
+        second.install(fake)
+        second.onActivityCreated(mockActivityWithExtras("google.message_id" to "retap"), null)
+        second.uninstall()
+
+        assertEquals(2, fake.pushOpenedCaptures)
+        // The automatic path must never write the persisted key — that is what keeps a pure-native
+        // app's stored state unchanged by this feature.
+        assertNull(preferences.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+    }
+
+    @Test
+    fun `an opted-out instance neither captures nor burns the message id`() {
+        val preferences = PostHogMemoryPreferences()
+        val optedOut = createPostHogFake().also { it.optOut() }
+
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "optedout").intent,
+            optedOut,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+        assertEquals(0, optedOut.pushOpenedCaptures)
+
+        val optedIn = createPostHogFake()
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "optedout").intent,
+            optedIn,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+
+        assertEquals(1, optedIn.pushOpenedCaptures)
+    }
+
+    @Test
+    fun `a persisted message id survives process death so a restore is not a second tap`() {
+        val preferences = PostHogMemoryPreferences()
+        val fake = createPostHogFake()
+
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "restored").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+        // A process-kill restore hands the Activity back its original intent with the in-memory
+        // guard gone; only the persisted id can tell that apart from a fresh tap.
+        PostHogActivityLifecycleCallbackIntegration.resetPushDedupe()
+        PostHogActivityLifecycleCallbackIntegration.capturePushNotificationOpened(
+            mockActivityWithExtras("google.message_id" to "restored").intent,
+            fake,
+            buildConfig(cachePreferences = preferences),
+            usePersistedDedupe = true,
+        )
+
+        assertEquals(1, fake.pushOpenedCaptures)
     }
 
     @Test

--- a/posthog-samples/posthog-android-sample/src/main/AndroidManifest.xml
+++ b/posthog-samples/posthog-android-sample/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity
             android:name="com.posthog.android.sample.NormalActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.PostHogAndroidSample">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/NormalActivity.kt
+++ b/posthog-samples/posthog-android-sample/src/main/java/com/posthog/android/sample/NormalActivity.kt
@@ -7,6 +7,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import com.posthog.PostHog
 import com.posthog.PostHogOkHttpInterceptor
+import com.posthog.android.PostHogAndroid
 import okhttp3.OkHttpClient
 import okhttp3.internal.closeQuietly
 
@@ -15,6 +16,14 @@ class NormalActivity : ComponentActivity() {
         OkHttpClient.Builder()
             .addInterceptor(PostHogOkHttpInterceptor(captureNetworkTelemetry = true))
             .build()
+
+    // A tap while the app is already running arrives here, not through the SDK's lifecycle
+    // callbacks — Android gives libraries no way to observe it, so the host forwards it.
+    // Cold starts need no code: the SDK reads the launch intent itself.
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        PostHogAndroid.capturePushNotificationOpened(intent)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -914,7 +914,7 @@ public abstract interface class com/posthog/internal/PostHogPreferences {
 	public static final field DISTINCT_ID Ljava/lang/String;
 	public static final field GROUPS Ljava/lang/String;
 	public static final field LAST_SEEN_SURVEY_DATE Ljava/lang/String;
-	public static final field PUSH_LAST_OPENED_MESSAGE_ID Ljava/lang/String;
+	public static final field PUSH_OPENED_MESSAGE_IDS Ljava/lang/String;
 	public static final field STRINGIFIED_KEYS Ljava/lang/String;
 	public static final field SURVEY_SEEN Ljava/lang/String;
 	public static final field VERSION Ljava/lang/String;
@@ -933,7 +933,7 @@ public final class com/posthog/internal/PostHogPreferences$Companion {
 	public static final field DISTINCT_ID Ljava/lang/String;
 	public static final field GROUPS Ljava/lang/String;
 	public static final field LAST_SEEN_SURVEY_DATE Ljava/lang/String;
-	public static final field PUSH_LAST_OPENED_MESSAGE_ID Ljava/lang/String;
+	public static final field PUSH_OPENED_MESSAGE_IDS Ljava/lang/String;
 	public static final field STRINGIFIED_KEYS Ljava/lang/String;
 	public static final field SURVEY_SEEN Ljava/lang/String;
 	public static final field VERSION Ljava/lang/String;

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -914,6 +914,7 @@ public abstract interface class com/posthog/internal/PostHogPreferences {
 	public static final field DISTINCT_ID Ljava/lang/String;
 	public static final field GROUPS Ljava/lang/String;
 	public static final field LAST_SEEN_SURVEY_DATE Ljava/lang/String;
+	public static final field PUSH_LAST_OPENED_MESSAGE_ID Ljava/lang/String;
 	public static final field STRINGIFIED_KEYS Ljava/lang/String;
 	public static final field SURVEY_SEEN Ljava/lang/String;
 	public static final field VERSION Ljava/lang/String;
@@ -932,6 +933,7 @@ public final class com/posthog/internal/PostHogPreferences$Companion {
 	public static final field DISTINCT_ID Ljava/lang/String;
 	public static final field GROUPS Ljava/lang/String;
 	public static final field LAST_SEEN_SURVEY_DATE Ljava/lang/String;
+	public static final field PUSH_LAST_OPENED_MESSAGE_ID Ljava/lang/String;
 	public static final field STRINGIFIED_KEYS Ljava/lang/String;
 	public static final field SURVEY_SEEN Ljava/lang/String;
 	public static final field VERSION Ljava/lang/String;

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -19,7 +19,7 @@ import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
-import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_OPENED_MESSAGE_IDS
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
 import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.internal.PostHogPreferences.Companion.VERSION
@@ -1928,7 +1928,7 @@ public class PostHog private constructor(
         // stable feature flag bucketing across identity changes.
         // Preserve SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE, and SURVEYS (project-level config
         // from /config, not user data) so each survives an identity change without an app restart.
-        // Preserve PUSH_LAST_OPENED_MESSAGE_ID for the same reason: it is device state that stops one
+        // Preserve PUSH_OPENED_MESSAGE_IDS for the same reason: it is device state that stops one
         // notification tap being counted twice, so clearing it would re-enable a duplicate.
         val except =
             mutableListOf(
@@ -1939,7 +1939,7 @@ public class PostHog private constructor(
                 ERROR_TRACKING,
                 CAPTURE_PERFORMANCE,
                 SURVEYS,
-                PUSH_LAST_OPENED_MESSAGE_ID,
+                PUSH_OPENED_MESSAGE_IDS,
             )
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)

--- a/posthog/src/main/java/com/posthog/PostHog.kt
+++ b/posthog/src/main/java/com/posthog/PostHog.kt
@@ -19,6 +19,7 @@ import com.posthog.internal.PostHogPreferences.Companion.GROUPS
 import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
 import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.internal.PostHogPreferences.Companion.VERSION
@@ -1927,7 +1928,19 @@ public class PostHog private constructor(
         // stable feature flag bucketing across identity changes.
         // Preserve SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE, and SURVEYS (project-level config
         // from /config, not user data) so each survives an identity change without an app restart.
-        val except = mutableListOf(VERSION, BUILD, DEVICE_ID, SESSION_REPLAY, ERROR_TRACKING, CAPTURE_PERFORMANCE, SURVEYS)
+        // Preserve PUSH_LAST_OPENED_MESSAGE_ID for the same reason: it is device state that stops one
+        // notification tap being counted twice, so clearing it would re-enable a duplicate.
+        val except =
+            mutableListOf(
+                VERSION,
+                BUILD,
+                DEVICE_ID,
+                SESSION_REPLAY,
+                ERROR_TRACKING,
+                CAPTURE_PERFORMANCE,
+                SURVEYS,
+                PUSH_LAST_OPENED_MESSAGE_ID,
+            )
         // preserve the ANONYMOUS_ID if reuseAnonymousId is enabled (for preserving a guest user
         // account on the device)
         if (config?.reuseAnonymousId == true) {

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -52,6 +52,9 @@ public interface PostHogPreferences {
         internal const val ERROR_TRACKING = "errorTracking"
         internal const val CAPTURE_PERFORMANCE = "capturePerformance"
         internal const val PUSH = "push"
+
+        @PostHogInternal
+        public const val PUSH_LAST_OPENED_MESSAGE_ID: String = "pushLastOpenedMessageId"
         internal const val PERSON_PROPERTIES_FOR_FLAGS = "personPropertiesForFlags"
         internal const val GROUP_PROPERTIES_FOR_FLAGS = "groupPropertiesForFlags"
         public const val SURVEY_SEEN: String = "surveySeen"
@@ -63,6 +66,7 @@ public interface PostHogPreferences {
 
         public val ALL_INTERNAL_KEYS: Set<String> =
             setOf(
+                PUSH_LAST_OPENED_MESSAGE_ID,
                 GROUPS,
                 ANONYMOUS_ID,
                 DISTINCT_ID,

--- a/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
+++ b/posthog/src/main/java/com/posthog/internal/PostHogPreferences.kt
@@ -54,7 +54,7 @@ public interface PostHogPreferences {
         internal const val PUSH = "push"
 
         @PostHogInternal
-        public const val PUSH_LAST_OPENED_MESSAGE_ID: String = "pushLastOpenedMessageId"
+        public const val PUSH_OPENED_MESSAGE_IDS: String = "pushOpenedMessageIds"
         internal const val PERSON_PROPERTIES_FOR_FLAGS = "personPropertiesForFlags"
         internal const val GROUP_PROPERTIES_FOR_FLAGS = "groupPropertiesForFlags"
         public const val SURVEY_SEEN: String = "surveySeen"
@@ -66,7 +66,7 @@ public interface PostHogPreferences {
 
         public val ALL_INTERNAL_KEYS: Set<String> =
             setOf(
-                PUSH_LAST_OPENED_MESSAGE_ID,
+                PUSH_OPENED_MESSAGE_IDS,
                 GROUPS,
                 ANONYMOUS_ID,
                 DISTINCT_ID,

--- a/posthog/src/test/java/com/posthog/PostHogPreferencesInternalKeysTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogPreferencesInternalKeysTest.kt
@@ -1,0 +1,20 @@
+package com.posthog
+
+import com.posthog.internal.PostHogMemoryPreferences
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class PostHogPreferencesInternalKeysTest {
+    @Test
+    fun `the push dedupe id is internal storage, not a super property`() {
+        val preferences = PostHogMemoryPreferences()
+        preferences.setValue(PUSH_LAST_OPENED_MESSAGE_ID, "0:1700000000%abcdef")
+        preferences.setValue("aUserProperty", "kept")
+
+        // getAll() feeds PostHog.buildProperties(), so anything not filtered here rides on every event.
+        assertFalse(preferences.getAll().containsKey(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertTrue(preferences.getAll().containsKey("aUserProperty"))
+    }
+}

--- a/posthog/src/test/java/com/posthog/PostHogPreferencesInternalKeysTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogPreferencesInternalKeysTest.kt
@@ -1,7 +1,7 @@
 package com.posthog
 
 import com.posthog.internal.PostHogMemoryPreferences
-import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_OPENED_MESSAGE_IDS
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -10,11 +10,11 @@ internal class PostHogPreferencesInternalKeysTest {
     @Test
     fun `the push dedupe id is internal storage, not a super property`() {
         val preferences = PostHogMemoryPreferences()
-        preferences.setValue(PUSH_LAST_OPENED_MESSAGE_ID, "0:1700000000%abcdef")
+        preferences.setValue(PUSH_OPENED_MESSAGE_IDS, "0:1700000000%abcdef")
         preferences.setValue("aUserProperty", "kept")
 
         // getAll() feeds PostHog.buildProperties(), so anything not filtered here rides on every event.
-        assertFalse(preferences.getAll().containsKey(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertFalse(preferences.getAll().containsKey(PUSH_OPENED_MESSAGE_IDS))
         assertTrue(preferences.getAll().containsKey("aUserProperty"))
     }
 }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -16,6 +16,7 @@ import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROPERTIES_FOR_FLAGS
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
 import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.internal.PostHogPrintLogger
@@ -2383,6 +2384,24 @@ internal class PostHogTest {
 
         val theEvent = batch.batch.first()
         assertNull(theEvent.properties!!["prop"])
+
+        sut.close()
+    }
+
+    @Test
+    fun `reset preserves the push dedupe id`() {
+        val http = mockHttp()
+        val url = http.url("/")
+        val preferences = PostHogMemoryPreferences()
+        val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
+
+        preferences.setValue(PUSH_LAST_OPENED_MESSAGE_ID, "0:1700000000%abcdef")
+
+        sut.reset()
+
+        // Device state, not user data: clearing it would let a process-death restore be counted as a
+        // second tap of the same notification.
+        assertEquals("0:1700000000%abcdef", preferences.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
 
         sut.close()
     }

--- a/posthog/src/test/java/com/posthog/PostHogTest.kt
+++ b/posthog/src/test/java/com/posthog/PostHogTest.kt
@@ -16,7 +16,7 @@ import com.posthog.internal.PostHogPreferences.Companion.IS_IDENTIFIED
 import com.posthog.internal.PostHogPreferences.Companion.OPT_OUT
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROCESSING
 import com.posthog.internal.PostHogPreferences.Companion.PERSON_PROPERTIES_FOR_FLAGS
-import com.posthog.internal.PostHogPreferences.Companion.PUSH_LAST_OPENED_MESSAGE_ID
+import com.posthog.internal.PostHogPreferences.Companion.PUSH_OPENED_MESSAGE_IDS
 import com.posthog.internal.PostHogPreferences.Companion.SESSION_REPLAY
 import com.posthog.internal.PostHogPreferences.Companion.SURVEYS
 import com.posthog.internal.PostHogPrintLogger
@@ -2395,13 +2395,13 @@ internal class PostHogTest {
         val preferences = PostHogMemoryPreferences()
         val sut = getSut(url.toString(), preloadFeatureFlags = false, reloadFeatureFlags = false, cachePreferences = preferences)
 
-        preferences.setValue(PUSH_LAST_OPENED_MESSAGE_ID, "0:1700000000%abcdef")
+        preferences.setValue(PUSH_OPENED_MESSAGE_IDS, "0:1700000000%abcdef")
 
         sut.reset()
 
         // Device state, not user data: clearing it would let a process-death restore be counted as a
         // second tap of the same notification.
-        assertEquals("0:1700000000%abcdef", preferences.getValue(PUSH_LAST_OPENED_MESSAGE_ID))
+        assertEquals("0:1700000000%abcdef", preferences.getValue(PUSH_OPENED_MESSAGE_IDS))
 
         sut.close()
     }

--- a/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
+++ b/posthog/src/testFixtures/java/com/posthog/PostHogFake.kt
@@ -165,9 +165,13 @@ public class PostHogFake : PostHogInterface {
     }
 
     override fun optIn() {
+        optedOut = false
     }
 
+    public var optedOut: Boolean = false
+
     override fun optOut() {
+        optedOut = true
     }
 
     override fun group(
@@ -188,7 +192,7 @@ public class PostHogFake : PostHogInterface {
     }
 
     override fun isOptOut(): Boolean {
-        return false
+        return optedOut
     }
 
     override fun register(


### PR DESCRIPTION
## :link: Related PRs

One fix, five PRs — three SDKs plus the docs. Each Flutter PR is gated on the native release it depends on.

| PR | What it does |
| --- | --- |
| PostHog/posthog-ios#792 | native iOS — hold a tap delivered before `setup()` |
| **PostHog/posthog-android#753** | **native Android — read a launch intent the SDK installed too late to see** — ← this PR |
| PostHog/posthog-flutter#556 | Flutter iOS cold start · needs posthog-ios 3.72.0 · fixes PostHog/posthog-flutter#555 |
| PostHog/posthog-flutter#557 | Flutter Android cold + warm start · needs posthog-android 3.62.0 · fixes PostHog/posthog-flutter#558 |
| PostHog/posthog.com#19905 | docs for all of the above |

**Order:** PostHog/posthog-ios#792 and PostHog/posthog-android#753 merge and release first → PostHog/posthog-flutter#556 and PostHog/posthog-flutter#557 leave draft and go green on their own once the floors publish → PostHog/posthog.com#19905 last, since posthog.com deploys on merge.

## :bulb: Motivation and Context

The Android half of PostHog/posthog-flutter#558 — `$push_notification_opened` is never captured in a Flutter app.

The tray intent is read in `onActivityCreated`, and `install()` only calls `registerActivityLifecycleCallbacks` — it never seeds from an Activity that already exists. A host that configures the SDK from its own runtime installs too late to see that callback. Measured in the Flutter example app:

```
17:54:27.516  MainActivity.onCreate
17:54:27.939  onCreate END / onStart / onResume   ← all three complete
17:54:28.582  first PostHog event                 ← SDK installs ~640ms later
```

Every lifecycle callback for the launch Activity is missed. Native apps that call `setup()` from `Application.onCreate` are unaffected — this only bites hosts that initialise late, which today means Flutter and React Native.

Unlike iOS, no buffering is needed: the tap is durable state on the Intent, so the fix is to read it late rather than to hold it.

## Changes

- `PostHogAndroid.capturePushNotificationOpened(intent)` — one new public entry point for late-installing hosts. Shares the extraction and `google.message_id` dedupe with the automatic path, so calling both cannot double-count.
- On that path only, recently opened ids are also persisted (`pushOpenedMessageIds`, a bounded history). A caller with no `savedInstanceState` cannot tell a process-kill restore — which hands the Activity back its original intent — from a real second tap. **Read and write are both scoped to the new path**, so a pure-native app's stored state is byte-identical to today.
- `onActivityCreated` keeps `savedInstanceState` as its restore gate and never touches the persisted id: it is the strictly better signal, because it separates a restore from a genuine re-tap.

## :green_heart: How did you test it?

- `./gradlew :posthog-android:testReleaseUnitTest :posthog:test :posthog-android-surveys-compose:test` — 945 core and 364 Android cases, 0 failures. `spotlessCheck`, `:posthog:apiCheck`, `:posthog-android:apiCheck` clean.
- Ten new tests. Three were verified to **fail** with their fix reverted — the ones guarding the silent regressions below: the `ALL_INTERNAL_KEYS` entry, `the automatic path still captures a genuine re-tap in a new process`, and `with after setup must not redirect the manual entry to the secondary project`.
- On device (Pixel 9 emulator, Flutter example app against a local build): cold start with a `google.message_id` extra → 1 capture (was 0); same id in a new process → 0; a new id → 1; no push extra → 0.

## Testing

Beyond the unit tests, verified on a Pixel 9 emulator through two hosts:

**posthog-android's own sample** (`setup()` in `Application.onCreate`, plus the new `onNewIntent` forwarding this PR adds):

| Scenario | Result |
| --- | --- |
| Cold launch from a tap | captured — also on unmodified `origin/main`, confirming no regression |
| Tap while running, forwarded from `onNewIntent` | captured |
| Same message id again | not captured |
| Fresh launch with a previously seen id | captured — a real second tap, not a restore |
| Launch with no push payload | not captured |

**A Flutter host** (PostHog/posthog-flutter#557), where the SDK installs after the launch Activity has already resumed: cold and warm both captured, with the dedupe holding across process death.

Warm delivery needs `android:launchMode="singleTop"` — without it the system resumes the task instead of delivering the intent, which is why the sample now declares it.

**Re-verified 2026-09-08**, after rebasing on `main` (which has moved to 3.61.3, so this `minor` still lands on 3.62.0 and the Flutter floor is unchanged): full unit suites green, and the sample's cold and warm taps re-run on a Pixel 9 emulator.

Method note: the sample points at a local HTTP server standing in for the ingestion host (via the existing `POSTHOG_HOST` hook), so every assertion above is made against the exact `/batch` body the SDK sent, not a dashboard query.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file

The changeset declares `posthog` as well as `posthog-android` — the core `ALL_INTERNAL_KEYS` entry is load-bearing (see below) and would not otherwise be released.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code ([session](https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd)), driven by @turnipdabeets. Root cause measured on an emulator before any code was written; a first attempt that hooked `onActivityStarted`/`onActivityResumed` was implemented, tested, and discarded once the ordering above was measured.

Six review rounds ran over this branch. Three findings are worth a reviewer's attention because each was a silent regression caught only by an executed test:

- The new preferences key was initially missing from `ALL_INTERNAL_KEYS`, so it rode on **every event** as a super property. `getAll()` feeds `buildProperties()`; every other internal key is listed.
- Persisting the dedupe id on the *automatic* path suppressed a genuine second tap of the same notification after a process death — demonstrated 2 → 1 captures. Hence the read/write scoping.
- An earlier "mark after delivery" guard was dead code (`?: return` on a `Unit` function), and the two `synchronized` blocks it required reopened the race the lock existed to close — two callers both delivered for one id.

A warm-start tap arrives through `Activity.onNewIntent`, which `ActivityLifecycleCallbacks` does not expose — so a native host forwards it with one line, which the sample now demonstrates. PostHog/posthog-flutter#557 does it automatically for Flutter apps.

Consumer: PostHog/posthog-flutter#557 (which closes PostHog/posthog-flutter#558) raises its floor to `[3.62.0,4.0.0)` and is held until this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012txiHBCZRkShMdE7V25Jrd







