### PR TITLE
feat(surveys): target linked feature flag variants

### DIFF
--- a/.changeset/five-humans-ring.md
+++ b/.changeset/five-humans-ring.md
@@ -1,0 +1,6 @@
+---
+"posthog": minor
+"posthog-android": minor
+---
+
+Support survey targeting by a specific linked feature flag variant.

--- a/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/surveys/PostHogSurveysIntegration.kt
@@ -254,29 +254,7 @@ public class PostHogSurveysIntegration(
             if (!hasWaitPeriodPassed(survey, getLastSeenSurveyDate(), config.dateProvider.currentDate())) return@filter false
 
             // 4. Check feature flags (collect all non-empty keys and verify they're enabled)
-            val allKeys = mutableListOf<String>()
-
-            // Linked flag key
-            survey.linkedFlagKey?.takeIf { it.isNotEmpty() }?.let { allKeys.add(it) }
-
-            // Targeting flag key
-            survey.targetingFlagKey?.takeIf { it.isNotEmpty() }?.let { allKeys.add(it) }
-
-            // Internal targeting flag key (only if survey cannot activate repeatedly)
-            if (!canActivateRepeatedly(survey)) {
-                survey.internalTargetingFlagKey?.takeIf { it.isNotEmpty() }?.let { allKeys.add(it) }
-            }
-
-            // Feature flag keys
-            survey.featureFlagKeys?.forEach { keyVal ->
-                val flagValue = keyVal.value
-                if (keyVal.key.isNotEmpty() && !flagValue.isNullOrEmpty()) {
-                    allKeys.add(flagValue)
-                }
-            }
-
-            // All collected flag keys must be enabled
-            val featureFlagsMatch = allKeys.all { postHog.isFeatureEnabled(it) }
+            val featureFlagsMatch = matchesFeatureFlags(survey, postHog)
 
             // 5. For event-based surveys, check if they have been activated by the event
             val eventActivationCheck =
@@ -288,6 +266,45 @@ public class PostHogSurveysIntegration(
 
             featureFlagsMatch && eventActivationCheck
         }
+    }
+
+    private fun matchesFeatureFlags(
+        survey: Survey,
+        postHog: PostHogInterface,
+    ): Boolean {
+        val allKeys = mutableListOf<String>()
+
+        // Linked flag key
+        survey.linkedFlagKey?.takeIf { it.isNotEmpty() }?.let { allKeys.add(it) }
+
+        // Targeting flag key
+        survey.targetingFlagKey?.takeIf { it.isNotEmpty() }?.let { allKeys.add(it) }
+
+        // Internal targeting flag key (only if survey cannot activate repeatedly)
+        if (!canActivateRepeatedly(survey)) {
+            survey.internalTargetingFlagKey?.takeIf { it.isNotEmpty() }?.let { allKeys.add(it) }
+        }
+
+        // Feature flag keys
+        survey.featureFlagKeys?.forEach { keyVal ->
+            val flagValue = keyVal.value
+            if (keyVal.key.isNotEmpty() && !flagValue.isNullOrEmpty()) {
+                allKeys.add(flagValue)
+            }
+        }
+
+        // All collected flag keys must be enabled
+        return allKeys.all { postHog.isFeatureEnabled(it) } && matchesLinkedFlagVariant(survey, postHog)
+    }
+
+    private fun matchesLinkedFlagVariant(
+        survey: Survey,
+        postHog: PostHogInterface,
+    ): Boolean {
+        val variant = survey.conditions?.linkedFlagVariant
+        if (variant.isNullOrEmpty() || variant == "any") return true
+        val key = survey.linkedFlagKey?.takeIf { it.isNotEmpty() } ?: return true
+        return postHog.getFeatureFlag(key, sendFeatureFlagEvent = false) == variant
     }
 
     /**

--- a/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysLinkedFlagVariantTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/surveys/PostHogSurveysLinkedFlagVariantTest.kt
@@ -1,0 +1,87 @@
+package com.posthog.android.surveys
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.posthog.PostHogConfig
+import com.posthog.PostHogInterface
+import com.posthog.surveys.PostHogSurveysDelegate
+import com.posthog.surveys.Survey
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
+import java.io.StringReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(ParameterizedRobolectricTestRunner::class)
+internal class PostHogSurveysLinkedFlagVariantTest(
+    private val linkedKey: String?,
+    private val variant: String?,
+    private val matches: Boolean,
+) {
+    companion object {
+        @JvmStatic
+        @Parameters(name = "key={0}, variant={1}, matches={2}")
+        fun cases(): List<Array<Any?>> =
+            listOf(
+                arrayOf("linked-blue", "blue", true),
+                arrayOf("linked-blue", "red", false),
+                arrayOf("linked-blue", "Blue", false),
+                arrayOf("linked-enabled", "blue", false),
+                arrayOf("linked-disabled", "blue", false),
+                arrayOf("missing-flag", "blue", false),
+                arrayOf("linked-blue", "any", true),
+                arrayOf("linked-enabled", "any", true),
+                arrayOf("linked-disabled", "any", false),
+                arrayOf("missing-flag", "any", false),
+                arrayOf("linked-blue", null, true),
+                arrayOf("linked-blue", "", true),
+                arrayOf(null, "blue", true),
+                arrayOf("", "blue", true),
+            )
+    }
+
+    @Test
+    fun `matches decoded variant without bypassing other targeting`() {
+        val config =
+            PostHogConfig("test-api-key").apply {
+                surveys = true
+                surveysConfig.surveysDelegate = mock<PostHogSurveysDelegate>()
+            }
+        val flagValues = mapOf("linked-blue" to "blue", "linked-enabled" to true, "linked-disabled" to false)
+        val postHog = mock<PostHogInterface>()
+        whenever(postHog.isFeatureEnabled(any(), any(), anyOrNull())).thenAnswer {
+            val value = flagValues[it.getArgument<String>(0)]
+            value == true || value is String
+        }
+        whenever(postHog.getFeatureFlag(any(), anyOrNull(), anyOrNull())).thenAnswer {
+            flagValues[it.getArgument<String>(0)]
+        }
+        val survey =
+            config.serializer.deserialize<Survey>(
+                StringReader(
+                    """
+                    {
+                        "id": "survey", "name": "Survey", "type": "popover", "questions": [],
+                        "start_date": "2024-07-23T09:18:18.376Z",
+                        "linked_flag_key": ${linkedKey?.let { "\"$it\"" } ?: "null"},
+                        "conditions": { "linkedFlagVariant": ${variant?.let { "\"$it\"" } ?: "null"} }
+                    }
+                    """.trimIndent(),
+                ),
+            )
+        assertEquals(variant, survey.conditions?.copy()?.linkedFlagVariant)
+        val integration = PostHogSurveysIntegration(ApplicationProvider.getApplicationContext<Context>(), config)
+        integration.install(postHog)
+        try {
+            integration.onSurveysLoaded(listOf(survey, survey.copy(id = "blocked", targetingFlagKey = "disabled-targeting")))
+            assertEquals(if (matches) listOf("survey") else emptyList(), integration.getActiveMatchingSurveys().map { it.id })
+        } finally {
+            integration.uninstall()
+        }
+    }
+}

--- a/posthog/api/posthog.api
+++ b/posthog/api/posthog.api
@@ -2063,6 +2063,8 @@ public final class com/posthog/surveys/SurveyAppearanceWidgetType$Companion {
 
 public final class com/posthog/surveys/SurveyConditions {
 	public fun <init> (Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;)V
+	public fun <init> (Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/posthog/surveys/SurveyMatchType;
 	public final fun component3 ()Ljava/lang/String;
@@ -2070,12 +2072,16 @@ public final class com/posthog/surveys/SurveyConditions {
 	public final fun component5 ()Lcom/posthog/surveys/SurveyMatchType;
 	public final fun component6 ()Ljava/lang/Integer;
 	public final fun component7 ()Lcom/posthog/surveys/SurveyEventConditions;
+	public final fun component8 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;)Lcom/posthog/surveys/SurveyConditions;
+	public final fun copy (Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;Ljava/lang/String;)Lcom/posthog/surveys/SurveyConditions;
 	public static synthetic fun copy$default (Lcom/posthog/surveys/SurveyConditions;Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;ILjava/lang/Object;)Lcom/posthog/surveys/SurveyConditions;
+	public static synthetic fun copy$default (Lcom/posthog/surveys/SurveyConditions;Ljava/lang/String;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/String;Ljava/util/List;Lcom/posthog/surveys/SurveyMatchType;Ljava/lang/Integer;Lcom/posthog/surveys/SurveyEventConditions;Ljava/lang/String;ILjava/lang/Object;)Lcom/posthog/surveys/SurveyConditions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDeviceTypes ()Ljava/util/List;
 	public final fun getDeviceTypesMatchType ()Lcom/posthog/surveys/SurveyMatchType;
 	public final fun getEvents ()Lcom/posthog/surveys/SurveyEventConditions;
+	public final fun getLinkedFlagVariant ()Ljava/lang/String;
 	public final fun getSeenSurveyWaitPeriodInDays ()Ljava/lang/Integer;
 	public final fun getSelector ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;

--- a/posthog/src/main/java/com/posthog/surveys/SurveyConditions.kt
+++ b/posthog/src/main/java/com/posthog/surveys/SurveyConditions.kt
@@ -1,12 +1,37 @@
 package com.posthog.surveys
 
-public data class SurveyConditions(
-    val url: String?,
-    val urlMatchType: SurveyMatchType?,
-    val selector: String?,
-    val deviceTypes: List<String>?,
-    val deviceTypesMatchType: SurveyMatchType?,
-    val seenSurveyWaitPeriodInDays: Int?,
-    val events: SurveyEventConditions?,
-    // TODO: actions
-)
+public data class SurveyConditions
+    @JvmOverloads
+    public constructor(
+        val url: String?,
+        val urlMatchType: SurveyMatchType?,
+        val selector: String?,
+        val deviceTypes: List<String>?,
+        val deviceTypesMatchType: SurveyMatchType?,
+        val seenSurveyWaitPeriodInDays: Int?,
+        val events: SurveyEventConditions?,
+        /** Required variant of the linked flag; "any" accepts any enabled value. */
+        val linkedFlagVariant: String? = null,
+        // TODO: actions
+    ) {
+        // Preserve the original copy/copy$default signatures for compiled SDK consumers.
+        public fun copy(
+            url: String? = this.url,
+            urlMatchType: SurveyMatchType? = this.urlMatchType,
+            selector: String? = this.selector,
+            deviceTypes: List<String>? = this.deviceTypes,
+            deviceTypesMatchType: SurveyMatchType? = this.deviceTypesMatchType,
+            seenSurveyWaitPeriodInDays: Int? = this.seenSurveyWaitPeriodInDays,
+            events: SurveyEventConditions? = this.events,
+        ): SurveyConditions =
+            copy(
+                url,
+                urlMatchType,
+                selector,
+                deviceTypes,
+                deviceTypesMatchType,
+                seenSurveyWaitPeriodInDays,
+                events,
+                linkedFlagVariant,
+            )
+    }


### PR DESCRIPTION
## :bulb: Motivation and Context

A survey linked to the `blue` feature flag variant currently also matches users in `red`. Decode `conditions.linkedFlagVariant` and require an exact, case-sensitive match, moving surveys toward feature parity across SDKs.

`any` still requires an enabled linked flag. Missing/empty variant conditions preserve existing behavior, and other targeting conditions still apply. This PR is independent of partial-response/resume work.

The optional model field preserves existing constructor and `copy` signatures; the API snapshot contains only additions.

Closes #388.

## :green_heart: How did you test it?

- 14 parameterized Robolectric cases exercise JSON decoding and the real SDK matcher; mismatching variants failed before the change.
- All 44 survey integration tests pass. Full core, Android debug/release, server, and plugin test suites also pass (six skipped tests across debug/release). Formatting and API checks pass.
- `make compile` reaches the sample release mapping upload, then fails because `posthog-cli` is unavailable. The same build passes with only `:posthog-samples:posthog-android-sample:uploadPostHogProguardMappingsRelease` excluded.
- CodeScene: matcher complexity improves. Explicit exception: the seven-argument compatibility `copy` overload exceeds its argument threshold; reducing it would break existing compiled callers.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] I updated the docs if needed. Update the support matrix after release.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Ran `pnpm changeset` to generate a changeset file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex used the GitHub CLI and CodeScene. Matching follows web/RN semantics; no UI changes or manual device testing.
