### PR TITLE
fix(android): initialize replay buffer off the setup thread

### DIFF
--- a/.changeset/quiet-replay-startup.md
+++ b/.changeset/quiet-replay-startup.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": patch
+---
+
+Move replay buffer initialization and leftover-file cleanup off the SDK setup thread onto the replay executor to reduce main-thread startup stalls, including when session replay is disabled.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayBufferQueue.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayBufferQueue.kt
@@ -38,10 +38,6 @@ internal class PostHogReplayBufferQueue(
                 maxOf(newestTs - oldestTs, 0)
             }
 
-    init {
-        setup()
-    }
-
     private fun setup() {
         // Clear any leftover buffer from previous sessions — if they're still here,
         // they didn't meet the minimum duration threshold and should be discarded.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayQueue.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayQueue.kt
@@ -34,6 +34,13 @@ internal class PostHogReplayQueue internal constructor(
             },
         )
 
+    init {
+        // Queue cleanup before any writes, without doing disk IO on the setup caller's thread.
+        executor.executeSafely {
+            bufferQueue.clear()
+        }
+    }
+
     internal var bufferDelegate: PostHogReplayBufferDelegate? = null
 
     /**

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayBufferQueueTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayBufferQueueTest.kt
@@ -113,7 +113,7 @@ internal class PostHogReplayBufferQueueTest {
         config: PostHogConfig = PostHogConfig(API_KEY),
     ): PostHogReplayBufferQueue {
         val dir = bufferDir ?: File(tmpDir.newFolder(), "buffer")
-        return PostHogReplayBufferQueue(config, dir)
+        return PostHogReplayBufferQueue(config, dir).apply { clear() }
     }
 
     private fun createExecutor(): ExecutorService {
@@ -199,7 +199,7 @@ internal class PostHogReplayBufferQueueTest {
     }
 
     @Test
-    fun `init clears leftover buffer from previous session`() {
+    fun `clear initializes directory and removes leftover buffer from previous session`() {
         val bufferDir = File(tmpDir.newFolder(), "buffer")
         bufferDir.mkdirs()
 

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayQueueTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayQueueTest.kt
@@ -3,8 +3,10 @@ package com.posthog.android.replay
 import com.posthog.PostHogConfig
 import com.posthog.PostHogEvent
 import com.posthog.android.API_KEY
+import com.posthog.android.PostHogAndroidConfig
 import com.posthog.internal.EndpointSpec
 import com.posthog.internal.PostHogApi
+import com.posthog.internal.PostHogApiEndpoint
 import com.posthog.internal.PostHogQueue
 import com.posthog.internal.PostHogQueueInterface
 import org.junit.Rule
@@ -20,6 +22,8 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 internal class PostHogReplayQueueTest {
@@ -30,7 +34,14 @@ internal class PostHogReplayQueueTest {
 
     @AfterTest
     fun tearDown() {
-        executors.forEach { it.shutdownNow() }
+        executors.forEach {
+            if (it is PausedExecutorService) {
+                it.shutdownNow()
+            } else {
+                it.shutdown()
+                assertTrue(it.awaitTermination(2, TimeUnit.SECONDS))
+            }
+        }
         executors.clear()
     }
 
@@ -191,6 +202,83 @@ internal class PostHogReplayQueueTest {
     }
 
     @Test
+    fun `queue provider defers buffer cleanup even with replay disabled`() {
+        val config = PostHogAndroidConfig(API_KEY)
+        val storagePrefix = File(tmpDir.root, "replay").absolutePath
+        val bufferDir = File("$storagePrefix-buffer", API_KEY)
+        bufferDir.mkdirs()
+        val leftover = File(bufferDir, "leftover.event").apply { writeText("old data") }
+        val executor = createPausedExecutor()
+        assertFalse(config.sessionReplay)
+
+        val queue =
+            config.queueProvider(config, PostHogApi(config), PostHogApiEndpoint.SNAPSHOT, storagePrefix, executor)
+                as PostHogReplayQueue
+
+        assertTrue(leftover.exists())
+        assertEquals(0, queue.bufferDepth)
+        assertNull(queue.bufferDurationMs)
+        assertEquals(1, executor.queuedTaskCount)
+
+        executor.runNext()
+
+        assertFalse(leftover.exists())
+        assertTrue(bufferDir.isDirectory)
+        assertTrue(bufferDir.listFiles()!!.isEmpty())
+    }
+
+    @Test
+    fun `construction does not create buffer directory`() {
+        val storagePrefix = File(tmpDir.root, "replay").absolutePath
+        val bufferDir = File("$storagePrefix-buffer", API_KEY)
+        val executor = createPausedExecutor()
+        val queue = createReplayQueue(createFakeQueue(), storagePrefix, executor)
+
+        assertEquals(0, queue.bufferDepth)
+        assertNull(queue.bufferDurationMs)
+        assertFalse(bufferDir.exists())
+        assertEquals(1, executor.queuedTaskCount)
+
+        executor.runNext()
+
+        assertTrue(bufferDir.isDirectory)
+    }
+
+    @Test
+    fun `initial cleanup precedes buffered writes and subsequent clears`() {
+        val config = PostHogConfig(API_KEY)
+        val storagePrefix = File(tmpDir.root, "replay").absolutePath
+        val bufferDir = File("$storagePrefix-buffer", API_KEY)
+        bufferDir.mkdirs()
+        val leftover = File(bufferDir, "leftover.event").apply { writeText("old data") }
+        val executor = createPausedExecutor()
+        val queue = createReplayQueue(createFakeQueue(), storagePrefix, executor)
+        queue.bufferDelegate = MockReplayBufferDelegate().apply { isBuffering = true }
+
+        queue.add(createTestEvent("before_clear"))
+        queue.clearBuffer()
+        queue.add(createTestEvent("after_clear"))
+
+        assertTrue(leftover.exists())
+        assertEquals(4, executor.queuedTaskCount)
+        executor.runNext()
+        assertFalse(leftover.exists())
+        assertEquals(0, queue.bufferDepth)
+
+        executor.runNext()
+        assertEquals(listOf("before_clear"), eventNamesInDirectory(config, bufferDir))
+        assertEquals(1, queue.bufferDepth)
+
+        executor.runNext()
+        assertTrue(bufferDir.listFiles()!!.isEmpty())
+        assertEquals(0, queue.bufferDepth)
+
+        executor.runNext()
+        assertEquals(listOf("after_clear"), eventNamesInDirectory(config, bufferDir))
+        assertEquals(1, queue.bufferDepth)
+    }
+
+    @Test
     fun `add routes to buffer when delegate isBuffering is true`() {
         val fakeInnerQueue = createFakeQueue()
         val queue = createReplayQueue(fakeInnerQueue)
@@ -211,6 +299,7 @@ internal class PostHogReplayQueueTest {
         val fakeInnerQueue = createFakeQueue()
         val executor = createPausedExecutor()
         val queue = createReplayQueue(fakeInnerQueue, executor = executor)
+        executor.runNext()
         val delegate = MockReplayBufferDelegate().apply { isBuffering = true }
         queue.bufferDelegate = delegate
 
@@ -233,6 +322,7 @@ internal class PostHogReplayQueueTest {
         val fakeInnerQueue = createFakeQueue()
         val executor = createPausedExecutor()
         val queue = createReplayQueue(fakeInnerQueue, executor = executor)
+        executor.runNext()
         val delegate = MockReplayBufferDelegate().apply { isBuffering = true }
         queue.bufferDelegate = delegate
 
@@ -283,6 +373,7 @@ internal class PostHogReplayQueueTest {
         val fakeInnerQueue = createFakeQueue()
         val executor = createPausedExecutor()
         val queue = createReplayQueue(fakeInnerQueue, executor = executor)
+        executor.runNext()
         val delegate =
             MockReplayBufferDelegate().apply {
                 isBuffering = true


### PR DESCRIPTION
## :bulb: Motivation and Context

SDK setup constructs the replay queue even when session replay is disabled. Its buffer constructor deletes leftover files and recreates the buffer directory on the calling thread. When setup runs from `Application.onCreate()`, this adds disk I/O to main-thread startup.

An ANR report from SDK 3.60.7 points to this exact queue-construction call. The stack does not establish how much of the timeout PostHog consumed, but the synchronous cleanup is an avoidable startup cost.

Move buffer cleanup to the replay executor before any buffered writes. Construction no longer touches the buffer directory, and later writes and clears remain ordered behind initialization. Include a patch changeset.

## :green_heart: How did you test it?

- Three new regression tests failed before the fix and pass afterward. They cover deferred cleanup with replay disabled, deferred directory creation, and cleanup ordering before writes and later clears.
- `make test` passed after merging latest `main`.
- `make testJava` passed with Java 17. The local Java 21 run hit an existing Byte Buddy compatibility error.
- `make checkFormat` passed.
- Autoreview of the final branch against `origin/main` reported no actionable findings.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed. No public API or configuration changes need documentation.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a patch changeset file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Pi using file tools, Git, Gradle, and the isolated autoreview helper. The fix moves cleanup to the existing replay executor instead of making the buffer lazy, which could still put disk I/O on the first caller. The ANR stack guided the investigation, but this PR does not claim to have reproduced the device's ANR. Human review is required.
