### PR TITLE
feat(replay): allow disabling touch capture

### DIFF
--- a/.changeset/quiet-touch-privacy.md
+++ b/.changeset/quiet-touch-privacy.md
@@ -1,0 +1,5 @@
+---
+"posthog-android": minor
+---
+
+Add `PostHogSessionReplayConfig.captureTouches` (default `true`) to disable touch coordinate recording independently of screenshots and view capture. The setting can be changed at runtime, and queued touch capture is skipped while disabled.

--- a/.changeset/quiet-touch-privacy.md
+++ b/.changeset/quiet-touch-privacy.md
@@ -2,4 +2,4 @@
 "posthog-android": minor
 ---
 
-Add `PostHogSessionReplayConfig.captureTouches` (default `true`) to disable touch coordinate recording independently of screenshots and view capture. The setting can be changed at runtime, and queued touch capture is skipped while disabled.
+Add `PostHogSessionReplayConfig.captureTouches` (default `true`) to disable touch coordinate recording during SDK initialization independently of screenshots and view capture. Runtime changes are not supported.

--- a/posthog-android/api/posthog-android.api
+++ b/posthog-android/api/posthog-android.api
@@ -116,6 +116,7 @@ public final class com/posthog/android/replay/PostHogSessionReplayConfig {
 	public fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ZJJLjava/lang/Double;)V
 	public synthetic fun <init> (ZZZLcom/posthog/android/replay/PostHogDrawableConverter;ZJJLjava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCaptureLogcat ()Z
+	public final fun getCaptureTouches ()Z
 	public final fun getDebouncerDelayMs ()J
 	public final fun getDrawableConverter ()Lcom/posthog/android/replay/PostHogDrawableConverter;
 	public final fun getMaskAllImages ()Z
@@ -128,6 +129,7 @@ public final class com/posthog/android/replay/PostHogSessionReplayConfig {
 	public final fun getThrottleDelayMs ()J
 	public final fun getVerifyScreenshotMaskAlignment ()Z
 	public final fun setCaptureLogcat (Z)V
+	public final fun setCaptureTouches (Z)V
 	public final fun setDebouncerDelayMs (J)V
 	public final fun setDrawableConverter (Lcom/posthog/android/replay/PostHogDrawableConverter;)V
 	public final fun setMaskAllImages (Z)V

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -457,7 +457,7 @@ public class PostHogReplayIntegration(
 
                     executor.submit {
                         try {
-                            if (!config.sessionReplayConfig.captureTouches || !isActive()) {
+                            if (!isActive()) {
                                 return@submit
                             }
                             when (safeMotionEvent.action.and(MotionEvent.ACTION_MASK)) {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogReplayIntegration.kt
@@ -447,7 +447,7 @@ public class PostHogReplayIntegration(
             try {
                 val state = dispatch(motionEvent)
                 try {
-                    if (!isActive()) {
+                    if (!config.sessionReplayConfig.captureTouches || !isActive()) {
                         return@TouchEventInterceptor state
                     }
                     val timestamp = config.dateProvider.currentTimeMillis()
@@ -457,7 +457,7 @@ public class PostHogReplayIntegration(
 
                     executor.submit {
                         try {
-                            if (!isActive()) {
+                            if (!config.sessionReplayConfig.captureTouches || !isActive()) {
                                 return@submit
                             }
                             when (safeMotionEvent.action.and(MotionEvent.ACTION_MASK)) {

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
@@ -63,6 +63,14 @@ public class PostHogSessionReplayConfig
         public var sampleRate: Double? = null,
     ) {
         /**
+         * Capture touch coordinates in session replay. Defaults to true.
+         * Can be changed at runtime without stopping screenshots or view capture.
+         * Disable this when touch positions could reveal sensitive input, even if the views are masked.
+         */
+        @Volatile
+        public var captureTouches: Boolean = true
+
+        /**
          * Verifies mask alignment for session replay screenshots.
          * This can preserve screenshots during pixel-only redraws, including continuously animated
          * content, but performs additional view hierarchy walks while a screenshot is captured.

--- a/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
+++ b/posthog-android/src/main/java/com/posthog/android/replay/PostHogSessionReplayConfig.kt
@@ -64,10 +64,10 @@ public class PostHogSessionReplayConfig
     ) {
         /**
          * Capture touch coordinates in session replay. Defaults to true.
-         * Can be changed at runtime without stopping screenshots or view capture.
+         * Set before SDK setup. Runtime changes are not supported.
+         * Screenshot and view capture are unaffected.
          * Disable this when touch positions could reveal sensitive input, even if the views are masked.
          */
-        @Volatile
         public var captureTouches: Boolean = true
 
         /**

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -540,56 +540,6 @@ internal class PostHogReplayIntegrationTest {
     }
 
     @Test
-    fun `captureTouches runtime false then true suppresses only disabled touches`() {
-        val config = configWithSampling(flagActive = true, samplingPasses = true)
-        val executor = QueuedReplayExecutor(createReplayExecutor())
-        val sut = PostHogReplayIntegration(ApplicationProvider.getApplicationContext(), config, MainHandler(), executor)
-        val fake = createPostHogFake()
-        sut.install(fake)
-        try {
-            sut.start(resumeCurrent = true)
-            dispatchTouch(sut)
-            executor.tasks.removeAt(0).run()
-            assertEquals(1, fake.captures)
-
-            config.sessionReplayConfig.captureTouches = false
-            dispatchTouch(sut)
-            executor.tasks.forEach { it.run() }
-            executor.tasks.clear()
-            assertEquals(1, fake.captures, "Disabled touches must not emit coordinates")
-
-            config.sessionReplayConfig.captureTouches = true
-            dispatchTouch(sut)
-            executor.tasks.removeAt(0).run()
-            assertEquals(2, fake.captures)
-            assertTrue(sut.isActive())
-        } finally {
-            sut.uninstall()
-        }
-    }
-
-    @Test
-    fun `captureTouches disabled before queued work runs drops coordinates`() {
-        val config = configWithSampling(flagActive = true, samplingPasses = true)
-        val executor = QueuedReplayExecutor(createReplayExecutor())
-        val sut = PostHogReplayIntegration(ApplicationProvider.getApplicationContext(), config, MainHandler(), executor)
-        val fake = createPostHogFake()
-        sut.install(fake)
-        try {
-            sut.start(resumeCurrent = true)
-            dispatchTouch(sut)
-            dispatchTouch(sut, MotionEvent.ACTION_UP)
-            assertEquals(2, executor.tasks.size)
-            config.sessionReplayConfig.captureTouches = false
-            executor.tasks.forEach { it.run() }
-            assertEquals(0, fake.captures, "Already queued touches must be dropped when disabled")
-            assertTrue(sut.isActive())
-        } finally {
-            sut.uninstall()
-        }
-    }
-
-    @Test
     fun `onSessionIdChanged starts replay when previously inactive and sampling passes`() {
         // The prior session may have been sampled out; rotation must re-evaluate sampling and
         // start replay even though isSessionReplayActive was false.
@@ -2151,13 +2101,17 @@ internal class PostHogReplayIntegrationTest {
             .setInt(attachInfo, View.VISIBLE)
     }
 
-    private fun screenshotFixture(enableMaskAlignmentVerification: Boolean = true): Pair<RealQueueFixture, PostHogFake> {
+    private fun screenshotFixture(
+        enableMaskAlignmentVerification: Boolean = true,
+        captureTouches: Boolean = true,
+    ): Pair<RealQueueFixture, PostHogFake> {
         val fx =
             createIntegrationWithRealQueue(
                 flagActive = true,
                 hasFetched = true,
                 integrationContext = ApplicationProvider.getApplicationContext(),
             )
+        fx.config.sessionReplayConfig.captureTouches = captureTouches
         fx.config.sessionReplayConfig.screenshot = true
         fx.config.sessionReplayConfig.verifyScreenshotMaskAlignment = enableMaskAlignmentVerification
         val fake = PostHogFake()
@@ -2438,10 +2392,9 @@ internal class PostHogReplayIntegrationTest {
     @Test
     @Config(sdk = [26], shadows = [ShadowPixelCopy::class])
     fun `captureTouches disabled leaves screenshot capture active`() {
-        val (fx, fake) = screenshotFixture()
+        val (fx, fake) = screenshotFixture(captureTouches = false)
         val controller = Robolectric.buildActivity(Activity::class.java).setup()
         try {
-            fx.config.sessionReplayConfig.captureTouches = false
             shadowOf(Looper.getMainLooper()).idle()
             val window = controller.get().window
             val view = window.decorView

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogReplayIntegrationTest.kt
@@ -50,7 +50,10 @@ import com.posthog.internal.PostHogSessionManager
 import com.posthog.internal.replay.RREvent
 import com.posthog.internal.replay.RREventType
 import com.posthog.internal.replay.RRFullSnapshotEvent
+import com.posthog.internal.replay.RRIncrementalMouseInteractionData
+import com.posthog.internal.replay.RRIncrementalMouseInteractionEvent
 import com.posthog.internal.replay.RRMetaEvent
+import com.posthog.internal.replay.RRMouseInteraction
 import com.posthog.internal.replay.RRWireframe
 import curtains.Curtains
 import curtains.DispatchState
@@ -458,6 +461,129 @@ internal class PostHogReplayIntegrationTest {
             assertEquals(DispatchState.Consumed, state)
             assertTrue(submits.get() >= 1)
             assertTrue(dateCalls.get() >= 1)
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    private fun dispatchTouch(
+        sut: PostHogReplayIntegration,
+        action: Int = MotionEvent.ACTION_DOWN,
+    ) {
+        val event = MotionEvent.obtain(0L, 0L, action, 42f, 73f, 0)
+        var dispatched = false
+        try {
+            val state =
+                sut.onTouchEventListener.intercept(event) {
+                    assertTrue(it === event)
+                    dispatched = true
+                    DispatchState.Consumed
+                }
+            assertTrue(dispatched, "Replay must dispatch the original touch to the app")
+            assertEquals(DispatchState.Consumed, state)
+        } finally {
+            event.recycle()
+        }
+    }
+
+    @Test
+    fun `captureTouches enabled by default records touch start and end coordinates`() {
+        val config = configWithSampling(flagActive = true, samplingPasses = true)
+        val executor = QueuedReplayExecutor(createReplayExecutor())
+        val sut = PostHogReplayIntegration(ApplicationProvider.getApplicationContext(), config, MainHandler(), executor)
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            sut.start(resumeCurrent = true)
+            assertTrue(sut.isActive())
+            assertTrue(config.sessionReplayConfig.captureTouches)
+            listOf(
+                MotionEvent.ACTION_DOWN to RRMouseInteraction.TouchStart,
+                MotionEvent.ACTION_UP to RRMouseInteraction.TouchEnd,
+            ).forEach { (action, type) ->
+                dispatchTouch(sut, action)
+                executor.tasks.removeAt(0).run()
+                val events = fake.properties!!["\$snapshot_data"] as List<*>
+                val event = events.single() as RRIncrementalMouseInteractionEvent
+                val data = event.data as RRIncrementalMouseInteractionData
+                assertEquals(type, data.type)
+                assertEquals(42, data.x)
+                assertEquals(73, data.y)
+            }
+            assertEquals(2, fake.captures)
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `captureTouches initially false skips collection without stopping dispatch or replay`() {
+        val config = configWithSampling(flagActive = true, samplingPasses = true)
+        config.sessionReplayConfig.captureTouches = false
+        val executor = QueuedReplayExecutor(createReplayExecutor())
+        val dateCalls = AtomicInteger(0)
+        val sut = PostHogReplayIntegration(ApplicationProvider.getApplicationContext(), config, MainHandler(), executor)
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            sut.start(resumeCurrent = true)
+            config.dateProvider = CountingDateProvider(dateCalls)
+            dispatchTouch(sut)
+            dispatchTouch(sut, MotionEvent.ACTION_UP)
+            assertTrue(sut.isActive())
+            assertEquals(0, executor.tasks.size, "Disabled touches must not queue coordinate capture")
+            assertEquals(0, dateCalls.get())
+            assertEquals(0, fake.captures)
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `captureTouches runtime false then true suppresses only disabled touches`() {
+        val config = configWithSampling(flagActive = true, samplingPasses = true)
+        val executor = QueuedReplayExecutor(createReplayExecutor())
+        val sut = PostHogReplayIntegration(ApplicationProvider.getApplicationContext(), config, MainHandler(), executor)
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            sut.start(resumeCurrent = true)
+            dispatchTouch(sut)
+            executor.tasks.removeAt(0).run()
+            assertEquals(1, fake.captures)
+
+            config.sessionReplayConfig.captureTouches = false
+            dispatchTouch(sut)
+            executor.tasks.forEach { it.run() }
+            executor.tasks.clear()
+            assertEquals(1, fake.captures, "Disabled touches must not emit coordinates")
+
+            config.sessionReplayConfig.captureTouches = true
+            dispatchTouch(sut)
+            executor.tasks.removeAt(0).run()
+            assertEquals(2, fake.captures)
+            assertTrue(sut.isActive())
+        } finally {
+            sut.uninstall()
+        }
+    }
+
+    @Test
+    fun `captureTouches disabled before queued work runs drops coordinates`() {
+        val config = configWithSampling(flagActive = true, samplingPasses = true)
+        val executor = QueuedReplayExecutor(createReplayExecutor())
+        val sut = PostHogReplayIntegration(ApplicationProvider.getApplicationContext(), config, MainHandler(), executor)
+        val fake = createPostHogFake()
+        sut.install(fake)
+        try {
+            sut.start(resumeCurrent = true)
+            dispatchTouch(sut)
+            dispatchTouch(sut, MotionEvent.ACTION_UP)
+            assertEquals(2, executor.tasks.size)
+            config.sessionReplayConfig.captureTouches = false
+            executor.tasks.forEach { it.run() }
+            assertEquals(0, fake.captures, "Already queued touches must be dropped when disabled")
+            assertTrue(sut.isActive())
         } finally {
             sut.uninstall()
         }
@@ -2306,6 +2432,31 @@ internal class PostHogReplayIntegrationTest {
             assertEquals("\$snapshot", fake.event)
         } finally {
             fx.sut.uninstall()
+        }
+    }
+
+    @Test
+    @Config(sdk = [26], shadows = [ShadowPixelCopy::class])
+    fun `captureTouches disabled leaves screenshot capture active`() {
+        val (fx, fake) = screenshotFixture()
+        val controller = Robolectric.buildActivity(Activity::class.java).setup()
+        try {
+            fx.config.sessionReplayConfig.captureTouches = false
+            shadowOf(Looper.getMainLooper()).idle()
+            val window = controller.get().window
+            val view = window.decorView
+            makeWindowVisible(view)
+            fx.sut.decorViews[view] = ViewTreeSnapshotStatus(mock<NextDrawListener>())
+
+            assertTrue(fx.sut.isActive())
+            assertTrue(fx.sut.generateSnapshot(WeakReference(view), WeakReference(window)))
+            assertEquals(1, fake.captures)
+            val events = fake.properties!!["\$snapshot_data"] as List<*>
+            assertTrue(events[0] is RRMetaEvent)
+            assertTrue(events[1] is RRFullSnapshotEvent)
+        } finally {
+            fx.sut.uninstall()
+            controller.pause().stop().destroy()
         }
     }
 

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogSessionReplayConfigTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogSessionReplayConfigTest.kt
@@ -8,13 +8,11 @@ import kotlin.test.assertEquals
 
 internal class PostHogSessionReplayConfigTest {
     @Test
-    fun `captureTouches defaults to true and can change at runtime`() {
+    fun `captureTouches defaults to true and can be disabled before setup`() {
         val config = PostHogSessionReplayConfig()
         assertEquals(true, config.captureTouches)
         config.captureTouches = false
         assertEquals(false, config.captureTouches)
-        config.captureTouches = true
-        assertEquals(true, config.captureTouches)
     }
 
     @RunWith(Parameterized::class)

--- a/posthog-android/src/test/java/com/posthog/android/replay/PostHogSessionReplayConfigTest.kt
+++ b/posthog-android/src/test/java/com/posthog/android/replay/PostHogSessionReplayConfigTest.kt
@@ -7,6 +7,16 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class PostHogSessionReplayConfigTest {
+    @Test
+    fun `captureTouches defaults to true and can change at runtime`() {
+        val config = PostHogSessionReplayConfig()
+        assertEquals(true, config.captureTouches)
+        config.captureTouches = false
+        assertEquals(false, config.captureTouches)
+        config.captureTouches = true
+        assertEquals(true, config.captureTouches)
+    }
+
     @RunWith(Parameterized::class)
     class ScreenshotScaleTest(private val input: Float, private val expected: Float) {
         companion object {


### PR DESCRIPTION
## :bulb: Motivation and Context

Masked PIN keypads can still reveal the entered value through replay touch coordinates. Pixel masking does not hide taps on a known layout. Reported in https://github.com/PostHog/posthog-flutter/issues/570.

Flutter integration: https://github.com/PostHog/posthog-flutter/pull/575. iOS counterpart: https://github.com/PostHog/posthog-ios/pull/823.

Add `PostHogSessionReplayConfig.captureTouches`, enabled by default. Set it before SDK setup to disable touch recording without stopping screenshots or view capture. The interceptor still delivers touches to the app but skips replay collection when disabled. Existing constructor signatures are unchanged. Runtime changes are not supported.

## :green_heart: How did you test it?

- All 260 replay/config tests pass. Removing the guard makes the initial opt-out regression fail.
- Coverage includes the enabled default, initial opt-out, application touch dispatch, and screenshots while touches are disabled.
- Tested the Flutter bridge with locally built native artifacts on an Android emulator. Separate enabled and disabled startups each received three keypad taps. Enabled capture sent six touch events, disabled capture sent zero, and both runs sent four masked screenshot frames. Replay stayed active and all taps reached the app.
- API checks, formatting, and committed-branch autoreview pass.

## :pencil: Checklist

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [x] Added a minor changeset file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the change in an isolated worktree using Gradle, Flutter, adb, a local test server, and autoreview for validation and review. The implementation follows the requested initialization-only configuration. The session transcript remains local. Human review is required.
