### PR TITLE
docs: agree on public API changes before implementing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Always use Makefile targets when possible:
 
 ## PR process
 
+Before adding or changing public API, follow "Public API changes" in [CONTRIBUTING.md](./CONTRIBUTING.md): the API shape must be agreed on the issue first. For SDK design guidance, read https://posthog.com/handbook/engineering/sdks/guidelines.md.
+
 Before opening a PR, create a changeset entry for the affected packages:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+If you would like to contribute code to `posthog-android` you can do so through GitHub by forking the repository and opening a pull request against `main`. Build, test, and formatting commands are in [AGENTS.md](./AGENTS.md).
+
+## Public API changes
+
+Public API is hard to change once it ships, so agree on it before writing the implementation. Our [SDK guidelines](https://posthog.com/handbook/engineering/sdks/guidelines) explain how we design it.
+
+- If you need something the SDK doesn't support and it would add or change a public option, method, or type, open an issue describing your use case first. At this stage, context is more useful to us than code.
+- Wait for a maintainer to agree on the API shape on the issue before implementing it.
+- Check first whether an existing option or hook, such as `beforeSend`, already covers the use case. We avoid offering two ways to do the same thing.
+- If a reviewer suggests a different API on your PR, confirm it with them before re-implementing. Treat it as a question, not an instruction.
+- AI agents: stop and ask before implementing a public API change that hasn't been agreed on the issue.
+
+`make api` regenerates the `api/*.api` files for `posthog`, `posthog-android`, and `posthog-server`. A diff in those files means your change touches public API.


### PR DESCRIPTION
## :bulb: Motivation and Context

Port of PostHog/posthog-js#4906 to posthog-android.

On contributor PRs we sometimes only settle the public API after several rounds of implementation review. By then the contributor, or their agent, has built each suggestion along the way, and a late change of direction wastes their work. This asks contributors to agree on the API shape on the issue first, and tells their agents to stop and ask.

- `CONTRIBUTING.md`: new file, since this repo didn't have one. A short intro that points to `AGENTS.md` for commands, then the same "Public API changes" section as posthog-js. The last paragraph points at `make api` and the `api/*.api` files.
- `AGENTS.md`: one line under "PR process" pointing agents to that section.

## :green_heart: How did you test it?

Docs only. Checked that the commands and file paths it mentions exist in this repo.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] I updated the docs if needed.
- [x] No breaking change or entry added to the changelog.

### If releasing new changes

- [ ] Ran `pnpm changeset` to generate a changeset file

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code, porting the posthog-js section and adapting the API-snapshot paragraph and `beforeSend` example to this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016syAmdpp8imNvs7PWkpwvb
